### PR TITLE
fix: escape directory name before cd-ing

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -466,7 +466,7 @@ function M.change_dir(name)
     return
   end
 
-  vim.cmd('lcd '..foldername)
+  vim.cmd('lcd '..vim.fn.fnameescape(foldername))
   M.Tree.cwd = foldername
   M.init(false, true)
 end


### PR DESCRIPTION
When opening a directory with special characters in the name I get the following error. This commit tries to fix the issue.

`Error detected while processing BufEnter Autocommands for "*":
E5108: Error executing lua ....config/nvim/plugged/nvim-tree.lua/lua/nvim-tree/lib.lua:469: Vim(lcd):E194: No alternate file name to substitute for '#': lcd /projects/prototype #6`