### PR TITLE
docs: include `NvimTreeWindowPicker` in hl-groups

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -562,8 +562,9 @@ HIGHLIGHT GROUPS				        *nvim-tree-highlight*
 
 |nvim_tree_highlight|				        *nvim_tree_highlight*
 
-All the following highlight groups can be configured by hand. It is not
-advised to colorize the background of these groups.
+All the following highlight groups can be configured by hand. Aside from
+`NvimTreeWindowPicker`, it is not advised to colorize the background of these
+groups.
 
 Example (in your `init.vim`):
 >
@@ -613,6 +614,8 @@ NvimTreeGitMerge
 NvimTreeGitRenamed
 NvimTreeGitNew
 NvimTreeGitDeleted
+
+NvimTreeWindowPicker
 
 There are also links to normal bindings to style the tree itself.
 


### PR DESCRIPTION
This will make users aware of the option to customize the window picker statuslines via the `NvimTreeWindowPicker` highlight group.