### PR TITLE
feat: change parent directory to open

### DIFF
--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -54,6 +54,7 @@ function M.create(node)
     node = {
       absolute_path = lib.Tree.cwd,
       entries = lib.Tree.entries,
+      open = true,
     }
   end
 


### PR DESCRIPTION
Now pressing <kbd>a</kbd> on the parent directory (e.g. `~/nvim-tree.lua/..`) has a slash at the end of the path (`/home/figsoda/nvim-tree.lua/` instead of `/home/figsoda/nvim-tree.lua`)