### PR TITLE
Fix tree refreshing logic

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -197,9 +197,7 @@ function M.refresh_tree(disable_clock)
     M.Tree.loaded = false
   end
 
-  if not disable_clock then
-    vim.defer_fn(function() refreshing = false end, vim.g.nvim_tree_refresh_wait or 1000)
-  end
+  vim.defer_fn(function() refreshing = false end, vim.g.nvim_tree_refresh_wait or 1000)
 end
 
 function M.set_index_and_redraw(fname)


### PR DESCRIPTION
This PR contains one commit to fix an issue in the logic that is used to prevent too many refreshes during a short period of time.

Before this commit, when `lib.refresh_tree()` is called with `disable_clock = true` (for example by typing `R` in the tree's window), `refreshing` gets set to `true`. However, nothing sets `refreshing` to `false` afterwards because the `if` statement evaluates to `false`. This results in subsequent calls to `lib.refresh_tree()` with `disable_clock = false` (for example through `:NvimTreeRefresh`) to exit the function early and therefore not actually update the tree.

The proposed fix in this commit is to simply set `refreshing` to `false` unconditionally (i.e., regardless of the `disable_clock` value).

P.S.: Thank you for you for creating and maintaining this great plugin!