### PR TITLE
fix: autocenter: avoid use of feedkeys

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -388,9 +388,11 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd("BufEnter", {
       pattern = "NvimTree_*",
       callback = function()
+        local bufnr = api.nvim_get_current_buf()
         vim.schedule(function()
-          local keys = api.nvim_replace_termcodes("zz", true, false, true)
-          api.nvim_feedkeys(keys, "n", true)
+          api.nvim_buf_call(bufnr, function()
+            vim.cmd [[norm! zz]]
+          end)
         end)
       end,
     })


### PR DESCRIPTION
I'm using the center feature, I was tracking down why I was unexpectedly getting some 'z' somewhere, then I realized that this feedkeys on focus was causing it. Calling through norm should achieve the same outcome but in a more controlled manner.