### PR TITLE
fix(#1629): nvim start with file named *NvimTree* opens tree instead of buffer

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -204,6 +204,7 @@ Subsequent calls to setup will replace the previous configuration.
         },
         float = {
           enable = false,
+          quit_on_focus_loss = true,
           open_win_config = {
             relative = "editor",
             border = "rounded",

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -135,8 +135,7 @@ end
 
 local function find_existing_windows()
   return vim.tbl_filter(function(win)
-    local buf = api.nvim_win_get_buf(win)
-    return api.nvim_buf_get_name(buf):match "NvimTree" ~= nil
+    return utils.is_nvim_tree_buf(api.nvim_win_get_buf(win))
   end, api.nvim_list_wins())
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -133,13 +133,6 @@ function M.tab_change()
   end
 end
 
-local function find_existing_windows()
-  return vim.tbl_filter(function(win)
-    local buf = api.nvim_win_get_buf(win)
-    return api.nvim_buf_get_name(buf):match "NvimTree" ~= nil
-  end, api.nvim_list_wins())
-end
-
 local function is_file_readable(fname)
   local stat = luv.fs_stat(fname)
   return stat and stat.type == "file" and luv.fs_access(fname, "R")
@@ -258,13 +251,7 @@ function M.on_enter(netrw_disabled)
     end
   end
 
-  -- Session that left a NvimTree Buffer opened, reopen with it
-  local existing_tree_wins = find_existing_windows()
-  if existing_tree_wins[1] then
-    api.nvim_set_current_win(existing_tree_wins[1])
-  end
-
-  if should_open or existing_tree_wins[1] ~= nil then
+  if should_open then
     lib.open(cwd)
 
     if should_focus_other_window then

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -462,7 +462,7 @@ function M.inject_node(f)
   end
 end
 
----Is the buffer a tree?
+---Is the buffer a tree? Like /path/to/NvimTree_2 and not a readable file.
 ---@param bufnr number
 ---@return boolean
 function M.is_nvim_tree_buf(bufnr)

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -462,4 +462,15 @@ function M.inject_node(f)
   end
 end
 
+---Is the buffer a tree?
+---@param bufnr number
+---@return boolean
+function M.is_nvim_tree_buf(bufnr)
+  if vim.fn.bufexists(bufnr) then
+    local bufname = a.nvim_buf_get_name(bufnr)
+    return vim.fn.fnamemodify(bufname, ":t"):match "^NvimTree_[0-9]+$" and vim.fn.filereadable(bufname) == 0
+  end
+  return false
+end
+
 return M

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -3,6 +3,7 @@ local a = vim.api
 local M = {}
 
 local events = require "nvim-tree.events"
+local utils = require "nvim-tree.utils"
 
 local function get_win_sep_hl()
   -- #1221 WinSeparator not present in nvim 0.6.1 and some builds of 0.7.0
@@ -76,7 +77,7 @@ end
 
 local function wipe_rogue_buffer()
   for _, bufnr in ipairs(a.nvim_list_bufs()) do
-    if not matches_bufnr(bufnr) and a.nvim_buf_get_name(bufnr):match "NvimTree" ~= nil then
+    if not matches_bufnr(bufnr) and utils.is_nvim_tree_buf(bufnr) then
       pcall(a.nvim_buf_delete, bufnr, { force = true })
     end
   end


### PR DESCRIPTION
fixes #1629

[find_existing_windows](https://github.com/nvim-tree/nvim-tree.lua/blob/54afa503a978164204716a98fb67fb21cbd10017/lua/nvim-tree.lua#L136) misidentifies a buffer named `*NvimTree*` as the tree's buffer.

* `setup` -> `on_enter` -> `find_existing_windows` is the only codepath
* view is always closed in `setup`

∴ this may be removed