### PR TITLE
fix: preview on floating window

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -209,7 +209,7 @@ local function open_in_new_window(filename, mode, win_ids)
     cmd = string.format("edit %s", fname)
   end
 
-  if mode == "preview" then
+  if mode == "preview" and view.View.float.enable then
     -- ignore "WinLeave" autocmd on preview
     -- because the registered "WinLeave"
     -- will kill the floating window immediately

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -212,7 +212,7 @@ local function open_in_new_window(filename, mode, win_ids)
 
   if mode == "preview" then
     -- ignore "WinLeave" autocmd on preview
-    -- because the requested "WinLeave"
+    -- because the registered "WinLeave"
     -- will kill the floating window immediately
     set_current_win_no_autocmd(api.nvim_get_current_win(), "WinLeave")
   end

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -167,9 +167,10 @@ end
 
 -- This is only to avoid the BufEnter for nvim-tree to trigger
 -- which would cause find-file to run on an invalid file.
-local function set_current_win_no_autocmd(winid)
+local function set_current_win_no_autocmd(winid, autocmd)
+  autocmd = autocmd or "BufEnter"
   local eventignore = vim.opt.eventignore:get()
-  vim.opt.eventignore:append "BufEnter"
+  vim.opt.eventignore:append(autocmd)
   api.nvim_set_current_win(winid)
   vim.opt.eventignore = eventignore
 end
@@ -207,6 +208,13 @@ local function open_in_new_window(filename, mode, win_ids)
     cmd = string.format("%s %s %s", split_side, split_cmd, fname)
   else
     cmd = string.format("edit %s", fname)
+  end
+
+  if mode == "preview" then
+    -- ignore "WinLeave" autocmd on preview
+    -- because the requested "WinLeave"
+    -- will kill the floating window immediately
+    set_current_win_no_autocmd(api.nvim_get_current_win(), "WinLeave")
   end
 
   set_current_win_no_autocmd(target_winid)

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -168,7 +168,6 @@ end
 -- This is only to avoid the BufEnter for nvim-tree to trigger
 -- which would cause find-file to run on an invalid file.
 local function set_current_win_no_autocmd(winid, autocmd)
-  autocmd = autocmd or "BufEnter"
   local eventignore = vim.opt.eventignore:get()
   vim.opt.eventignore:append(autocmd)
   api.nvim_set_current_win(winid)
@@ -214,10 +213,11 @@ local function open_in_new_window(filename, mode, win_ids)
     -- ignore "WinLeave" autocmd on preview
     -- because the registered "WinLeave"
     -- will kill the floating window immediately
-    set_current_win_no_autocmd(api.nvim_get_current_win(), "WinLeave")
+    set_current_win_no_autocmd(target_winid, { "WinLeave", "BufEnter" })
+  else
+    set_current_win_no_autocmd(target_winid, { "BufEnter" })
   end
 
-  set_current_win_no_autocmd(target_winid)
   pcall(vim.cmd, cmd)
   lib.set_target_win()
 end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -347,7 +347,11 @@ function M.focus(winnr, open_if_closed)
   end
 
   a.nvim_set_current_win(wnr)
-  require("nvim-tree.renderer").draw()
+
+  -- Redraw the tree if the window has been changed
+  if wnr == M.get_bufnr then
+    require("nvim-tree.renderer").draw()
+  end
 end
 
 --- Restores the state of a NvimTree window if it was initialized before.

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -335,10 +335,8 @@ end
 
 function M.focus(winnr, open_if_closed)
   local wnr = winnr or M.get_winnr()
-  if not a.nvim_win_is_valid(wnr) then
-    M.open()
-    wnr = M.get_winnr()
-  elseif a.nvim_win_get_tabpage(wnr or 0) ~= a.nvim_win_get_tabpage(0) then
+
+  if a.nvim_win_get_tabpage(wnr or 0) ~= a.nvim_win_get_tabpage(0) then
     M.close()
     M.open()
     wnr = M.get_winnr()
@@ -347,11 +345,6 @@ function M.focus(winnr, open_if_closed)
   end
 
   a.nvim_set_current_win(wnr)
-
-  -- Redraw the tree if the window has been changed
-  if wnr == M.get_bufnr then
-    require("nvim-tree.renderer").draw()
-  end
 end
 
 --- Restores the state of a NvimTree window if it was initialized before.

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -347,6 +347,7 @@ function M.focus(winnr, open_if_closed)
   end
 
   a.nvim_set_current_win(wnr)
+  require("nvim-tree.renderer").draw()
 end
 
 --- Restores the state of a NvimTree window if it was initialized before.

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -335,8 +335,10 @@ end
 
 function M.focus(winnr, open_if_closed)
   local wnr = winnr or M.get_winnr()
-
-  if a.nvim_win_get_tabpage(wnr or 0) ~= a.nvim_win_get_tabpage(0) then
+  if not a.nvim_win_is_valid(wnr) then
+    M.open()
+    wnr = M.get_winnr()
+  elseif a.nvim_win_get_tabpage(wnr or 0) ~= a.nvim_win_get_tabpage(0) then
     M.close()
     M.open()
     wnr = M.get_winnr()


### PR DESCRIPTION
fixes #1643

My changes prevent nvim-tree from using already closed window, usually when using floating window mode.

More details in the issue #1643 