### PR TITLE
chore(#1649): remove workaround for https://github.com/neovim/neovim/issues/17395 which was fixed in nvim 0.7.0

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -328,8 +328,6 @@ end
 function M.set_cursor(opts)
   if M.is_visible() then
     pcall(a.nvim_win_set_cursor, M.get_winnr(), opts)
-    -- patch until https://github.com/neovim/neovim/issues/17395 is fixed
-    require("nvim-tree.renderer").draw()
   end
 end
 


### PR DESCRIPTION
fixes #1649