### PR TITLE
fix(#1664): respect hijack_directories.enable on startup when not open_on_setup

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -491,7 +491,8 @@ Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.hijack_directories*  (previously `update_to_buf_dir`)
-hijacks new directory buffers when they are opened (`:e dir`).
+hijacks new directory buffers when they are opened (`:e dir`) or if a
+directory is opened on startup e.g. `nvim .`
 
     *nvim-tree.hijack_directories.enable*
     Enable the feature.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -257,13 +257,18 @@ function M.on_enter(netrw_disabled)
     end
   end
 
+  local should_hijack = _config.hijack_directories.enable
+    and _config.hijack_directories.auto_open
+    and is_dir
+    and not should_be_preserved
+
   -- Session that left a NvimTree Buffer opened, reopen with it
   local existing_tree_wins = find_existing_windows()
   if existing_tree_wins[1] then
     api.nvim_set_current_win(existing_tree_wins[1])
   end
 
-  if should_open or existing_tree_wins[1] ~= nil then
+  if should_open or should_hijack or existing_tree_wins[1] ~= nil then
     lib.open(cwd)
 
     if should_focus_other_window then


### PR DESCRIPTION
resolves #1664 

#1618 removed this functionality; this PR restores it.

Behaviour is unreliable when netrw is enabled, usually opening netrw. See #1607