### PR TITLE
fix: use pcall to prevent live-filter regex errors

### DIFF
--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -76,8 +76,8 @@ function M.apply_filter(node_)
     end
 
     local has_nodes = nodes and (M.always_show_folders or #nodes > filtered_nodes)
-    local found, is_match  = pcall(matches, node)
-    node.hidden = not (has_nodes or (found and is_match))
+    local ok, is_match  = pcall(matches, node)
+    node.hidden = not (has_nodes or (ok and is_match))
   end
 
   iterate(node_ or TreeExplorer)

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -76,7 +76,8 @@ function M.apply_filter(node_)
     end
 
     local has_nodes = nodes and (M.always_show_folders or #nodes > filtered_nodes)
-    node.hidden = not (has_nodes or matches(node))
+    local found, is_match  = pcall(matches, node)
+    node.hidden = not (has_nodes or (found and is_match))
   end
 
   iterate(node_ or TreeExplorer)

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -76,7 +76,7 @@ function M.apply_filter(node_)
     end
 
     local has_nodes = nodes and (M.always_show_folders or #nodes > filtered_nodes)
-    local ok, is_match  = pcall(matches, node)
+    local ok, is_match = pcall(matches, node)
     node.hidden = not (has_nodes or (ok and is_match))
   end
 


### PR DESCRIPTION
Currently, if you attempt to type regex during live filter, such as "filename_[1-5]", nvim-tree will  throw errors after the opening bracket due to invalid regex.

```
Error executing vim.schedule lua callback: ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:54: couldn't parse regex: Vim:E769: Missing ] after %s[
stack traceback:
        [C]: in function 'regex'
        ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:54: in function 'matches'
        ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:79: in function 'iterate'
        ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:71: in function 'iterate'
        ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:82: in function 'apply_filter'
        ...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:88: in function <...packer/start/nvim-tree.lua/lua/nvim-tree/live-filter.lua:86>
```

This PR wraps live-filter's `matches` function in pcall so that it shows no matches instead of throwing errors and disrupting the user while typing.