### PR TITLE
feat(watcher): add filesystem_watchers.ignore_dirs

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -308,6 +308,7 @@ Subsequent calls to setup will replace the previous configuration.
       filesystem_watchers = {
         enable = true,
         debounce_delay = 50,
+        ignore_dirs = {},
       },
       git = {
         enable = true,
@@ -600,6 +601,12 @@ performance.
     *nvim-tree.filesystem_watchers.debounce_delay*
     Idle milliseconds between filesystem change and action.
       Type: `number`, Default: `50` (ms)
+
+    *nvim-tree.filesystem_watchers.ignore_dirs*
+    List of vim regex for absolute directory paths that will not be watched.
+    Backslashes must be escaped e.g. `"my-project/\\.build$"`. See |string-match|.
+    Useful when path is not in `.gitignore` or git integration is disabled.
+      Type: {string}, Default: `{}`
 
 *nvim-tree.on_attach*
 Function ran when creating the nvim-tree buffer.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -589,6 +589,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   filesystem_watchers = {
     enable = true,
     debounce_delay = 50,
+    ignore_dirs = {},
   },
   git = {
     enable = true,

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -36,6 +36,13 @@ local function is_folder_ignored(path)
       return true
     end
   end
+
+  for _, ignore_dir in ipairs(M.ignore_dirs) do
+    if vim.fn.match(path, ignore_dir) ~= -1 then
+      return true
+    end
+  end
+
   return false
 end
 
@@ -78,6 +85,7 @@ end
 function M.setup(opts)
   M.enabled = opts.filesystem_watchers.enable
   M.debounce_delay = opts.filesystem_watchers.debounce_delay
+  M.ignore_dirs = opts.filesystem_watchers.ignore_dirs
   M.uid = 0
 end
 


### PR DESCRIPTION
#1606

Add `filesystem_watchers.ignore_dirs`.

Tested:
* exact path
* trailing directory
* project directory
* escaped specials like `\\.`