### PR TITLE
feat: command to clear the clipboard

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1125,6 +1125,7 @@ exists.
     - rename_sub
     - cut
     - paste
+    - clear_clipboard
     - print_clipboard
     - copy.node
     - copy.absolute_path

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -129,6 +129,12 @@ local function add_to_clipboard(node, clip)
   utils.notify.info(node.absolute_path .. " added to clipboard.")
 end
 
+function M.clear_clipboard()
+  clipboard.move = {}
+  clipboard.copy = {}
+  utils.notify.info("Clipboard has been emptied.")
+end
+
 function M.copy(node)
   add_to_clipboard(node, clipboard.copy)
 end

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -132,7 +132,7 @@ end
 function M.clear_clipboard()
   clipboard.move = {}
   clipboard.copy = {}
-  utils.notify.info("Clipboard has been emptied.")
+  utils.notify.info "Clipboard has been emptied."
 end
 
 function M.copy(node)

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -46,6 +46,7 @@ Api.fs.rename = inject_node(require("nvim-tree.actions.fs.rename-file").fn(false
 Api.fs.rename_sub = inject_node(require("nvim-tree.actions.fs.rename-file").fn(true))
 Api.fs.cut = inject_node(require("nvim-tree.actions.fs.copy-paste").cut)
 Api.fs.paste = inject_node(require("nvim-tree.actions.fs.copy-paste").paste)
+Api.fs.clear_clipboard = require("nvim-tree.actions.fs.copy-paste").clear_clipboard
 Api.fs.print_clipboard = require("nvim-tree.actions.fs.copy-paste").print_clipboard
 Api.fs.copy.node = inject_node(require("nvim-tree.actions.fs.copy-paste").copy)
 Api.fs.copy.absolute_path = inject_node(require("nvim-tree.actions.fs.copy-paste").copy_absolute_path)


### PR DESCRIPTION
There does not appear to be any way to empty the clipboard other than going back to each file and removing it. This will add the command to empty it all at once (currently left unbound by default).