### PR TITLE
fix: set highlight in an invalid window.

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -438,8 +438,9 @@ end
 
 -- used on ColorScheme event
 function M.reset_winhl()
-  if M.get_winnr() then
-    vim.wo[M.get_winnr()].winhl = M.View.winopts.winhl
+  local winnr = M.get_winnr()
+  if winnr and vim.api.nvim_win_is_valid(winnr) then
+    vim.wo[winnr].winhl = M.View.winopts.winhl
   end
 end
 


### PR DESCRIPTION
Avoid setting highlight in an invalid window. Fix on this [commit](https://github.com/nvim-tree/nvim-tree.lua/commit/65c2ba895213c3641fc58dd33bc7a44423a6cdbe).