### PR TITLE
fix(#1716): focus file/directory when created in a sub-directory, don't dispatch FolderCreated on file creation

### DIFF
--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -106,6 +106,8 @@ function M.fn(node)
     if not is_error then
       notify.info(new_file_path .. " was properly created")
     end
+
+    -- implicitly refreshes contents
     require("nvim-tree.actions.finders.find-file").fn(new_file_path)
   end)
 end

--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -106,7 +106,6 @@ function M.fn(node)
     if not is_error then
       notify.info(new_file_path .. " was properly created")
     end
-    require("nvim-tree.actions.reloaders.reloaders").reload_explorer()
     require("nvim-tree.actions.finders.find-file").fn(new_file_path)
   end)
 end

--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -4,7 +4,6 @@ local utils = require "nvim-tree.utils"
 local events = require "nvim-tree.events"
 local lib = require "nvim-tree.lib"
 local core = require "nvim-tree.core"
-local watch = require "nvim-tree.explorer.watch"
 local notify = require "nvim-tree.notify"
 
 local M = {}
@@ -101,22 +100,14 @@ function M.fn(node)
           is_error = true
           break
         end
+        events._dispatch_folder_created(path_to_create)
       end
     end
     if not is_error then
       notify.info(new_file_path .. " was properly created")
     end
-    events._dispatch_folder_created(new_file_path)
-    if M.enable_reload then
-      require("nvim-tree.actions.reloaders.reloaders").reload_explorer()
-    else
-      -- synchronous call required so that we may focus the file now
-      node = node.nodes ~= nil and node or node.parent
-      if node then
-        watch.refresh_path(node.absolute_path)
-      end
-    end
-    utils.focus_file(utils.path_remove_trailing(new_file_path))
+    require("nvim-tree.actions.reloaders.reloaders").reload_explorer()
+    require("nvim-tree.actions.finders.find-file").fn(new_file_path)
   end)
 end
 

--- a/lua/nvim-tree/actions/reloaders/reloaders.lua
+++ b/lua/nvim-tree/actions/reloaders/reloaders.lua
@@ -3,6 +3,7 @@ local view = require "nvim-tree.view"
 local renderer = require "nvim-tree.renderer"
 local explorer_module = require "nvim-tree.explorer"
 local core = require "nvim-tree.core"
+local log = require "nvim-tree.log"
 
 local M = {}
 
@@ -39,11 +40,16 @@ function M.reload_explorer()
   end
   event_running = true
 
+  local ps = log.profile_start "reload_explorer"
+
   local projects = git.reload()
   refresh_nodes(core.get_explorer(), projects)
   if view.is_visible() then
     renderer.draw()
   end
+
+  log.profile_end(ps, "reload_explorer")
+
   event_running = false
 end
 
@@ -53,9 +59,14 @@ function M.reload_git()
   end
   event_running = true
 
+  local ps = log.profile_start "reload_git"
+
   local projects = git.reload()
   M.reload_node_status(core.get_explorer(), projects)
   renderer.draw()
+
+  log.profile_end(ps, "reload_git")
+
   event_running = false
 end
 


### PR DESCRIPTION
fixes #1716 

Synchronous refresh is always performed on creation. Node is found following create/refresh.