### PR TITLE
utils may not have a notify field

### DIFF
--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -89,7 +89,7 @@ function Event:destroy(message)
 
   if self._fs_event then
     if message then
-      utils.notify.warn(message)
+      notify.warn(message)
     end
 
     local rc, _, name = self._fs_event:stop()


### PR DESCRIPTION
Hi. `utils` may not have a field `notify` and this PR removes it.