### PR TITLE
fix(#1728): escape cwd changes to prevent environment variable expansion

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -226,9 +226,9 @@ function M.on_enter(netrw_disabled)
   local is_file = stats and stats.type == "file"
   local cwd
   if is_dir then
-    cwd = vim.fn.expand(bufname)
+    cwd = vim.fn.expand(vim.fn.fnameescape(bufname))
     -- INFO: could potentially conflict with rooter plugins
-    vim.cmd("noautocmd cd " .. cwd)
+    vim.cmd("noautocmd cd " .. vim.fn.fnameescape(cwd))
   end
 
   local lines = not is_dir and vim.api.nvim_buf_get_lines(bufnr, 0, -1, false) or {}

--- a/lua/nvim-tree/actions/root/change-dir.lua
+++ b/lua/nvim-tree/actions/root/change-dir.lua
@@ -7,6 +7,7 @@ local M = {
 }
 
 local function clean_input_cwd(name)
+  name = vim.fn.fnameescape(name)
   local root_parent_cwd = vim.fn.fnamemodify(utils.path_remove_trailing(core.get_cwd()), ":h")
   if name == ".." and root_parent_cwd then
     return vim.fn.expand(root_parent_cwd)


### PR DESCRIPTION
resolves #1728

fnameescape before expanding to prevent expand from substituting environment variables