### PR TITLE
fix(#1720): .git watch only FETCH_HEAD, HEAD, HEAD.lock, config, index

### DIFF
--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -77,7 +77,7 @@ function M.create_watcher(absolute_path)
   end
 
   M.uid = M.uid + 1
-  return Watcher:new(absolute_path, callback, {
+  return Watcher:new(absolute_path, nil, callback, {
     context = "explorer:watch:" .. absolute_path .. ":" .. M.uid,
   })
 end

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -11,6 +11,12 @@ local M = {
   cwd_to_project_root = {},
 }
 
+local WATCHED_FILES = {
+  "HEAD",
+  "config",
+  "index",
+}
+
 function M.reload()
   if not M.config.git.enable then
     return {}
@@ -149,7 +155,7 @@ function M.load_project_status(cwd)
       end)
     end
 
-    watcher = Watcher:new(utils.path_join { project_root, ".git" }, callback, {
+    watcher = Watcher:new(utils.path_join { project_root, ".git" }, WATCHED_FILES, callback, {
       project_root = project_root,
     })
   end

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -11,10 +11,14 @@ local M = {
   cwd_to_project_root = {},
 }
 
+-- Files under .git that should result in a reload when changed.
+-- Utilities (like watchman) can also write to this directory (often) and aren't useful for us.
 local WATCHED_FILES = {
-  "HEAD",
-  "config",
-  "index",
+  "FETCH_HEAD", -- remote ref
+  "HEAD", -- local ref
+  "HEAD.lock", -- HEAD will not always be updated e.g. revert
+  "config", -- user config
+  "index", -- staging area
 }
 
 function M.reload()


### PR DESCRIPTION
fixes #1720

supersede #1725 

`.git` watches only for useful files.

Use case: git operations that don't affect files, such as stage, commit etc.

Tested:
* add
* restore --staged
* commit
* revert
* init - not functional but not a regression