### PR TITLE
proper session restoration

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -336,12 +336,13 @@ local function setup_autocommands(opts)
 
   create_nvim_tree_autocmd("SessionLoadPost", {
     callback = function()
-      if M.setup_called and view.is_visible() then
-        view.abandon_current_window()
-        view.open { focus_tree = false }
-        if _config.update_focused_file.enable then
-          vim.schedule(M.find_file)
-        end
+      if view.is_visible() and view.wipe_rogue_buffer() then
+        vim.schedule(function()
+          view.open { focus_tree = false }
+          if _config.update_focused_file.enable then
+            vim.schedule(M.find_file)
+          end
+        end)
       end
     end,
   })

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -334,6 +334,17 @@ local function setup_autocommands(opts)
     vim.api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
   end
 
+  create_nvim_tree_autocmd("SessionLoadPost", {
+    callback = function()
+      if view.wipe_rogue_buffer() then
+        view.open({focus_tree = false })
+        if _config.update_focused_file.enable then
+          vim.schedule(M.find_file)
+        end
+      end
+    end
+  })
+
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -336,13 +336,14 @@ local function setup_autocommands(opts)
 
   create_nvim_tree_autocmd("SessionLoadPost", {
     callback = function()
-      if view.wipe_rogue_buffer() then
-        view.open({focus_tree = false })
+      if M.setup_called and view.is_visible() then
+        view.abandon_current_window()
+        view.open { focus_tree = false }
         if _config.update_focused_file.enable then
           vim.schedule(M.find_file)
         end
       end
-    end
+    end,
   })
 
   -- reset highlights when colorscheme is changed

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -78,6 +78,11 @@ function M.wipe_rogue_buffer()
   local was_wiped = false
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if not matches_bufnr(bufnr) and utils.is_nvim_tree_buf(bufnr) then
+
+      -- if restored from session, values might be incorrect
+      for option, value in pairs(BUFFER_OPTIONS) do
+        vim.bo[bufnr][option] = value
+      end
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
       was_wiped = true
     end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -74,16 +74,19 @@ local function matches_bufnr(bufnr)
   return false
 end
 
-local function wipe_rogue_buffer()
+function M.wipe_rogue_buffer()
+  local was_wiped = false
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if not matches_bufnr(bufnr) and utils.is_nvim_tree_buf(bufnr) then
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      was_wiped = true
     end
   end
+  return was_wiped
 end
 
 local function create_buffer(bufnr)
-  wipe_rogue_buffer()
+  M.wipe_rogue_buffer()
 
   local tab = vim.api.nvim_get_current_tabpage()
   BUFNR_PER_TAB[tab] = bufnr or vim.api.nvim_create_buf(false, false)


### PR DESCRIPTION
Currently, if you open a session after vim is already opened (not with `vim -S ./path/to/session.vim`), the old `nvim-tree` buffers are not restored. This ensures that `nvim-tree` is reloaded whenever a session is loaded.