### PR TITLE
fix(#1740): set open state only on folders

### DIFF
--- a/lua/nvim-tree/actions/tree-modifiers/collapse-all.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/collapse-all.lua
@@ -31,7 +31,9 @@ function M.fn(keep_buffers)
   Iterator.builder(core.get_explorer().nodes)
     :hidden()
     :applier(function(node)
-      node.open = keep_buffers == true and matches(node.absolute_path)
+      if node.nodes ~= nil then
+        node.open = keep_buffers == true and matches(node.absolute_path)
+      end
     end)
     :recursor(function(n)
       return n.nodes


### PR DESCRIPTION
Fixes [issue 1740](https://github.com/nvim-tree/nvim-tree.lua/issues/1740)

If we set `node.open` indiscriminately (e.g. for files) then we fail later on this line when we try to draw the tree.

First we will recurse here on a file:
https://github.com/nvim-tree/nvim-tree.lua/blob/master/lua/nvim-tree/renderer/builder.lua#L263-L267

And then `tree.node` will be `nil` here:
https://github.com/nvim-tree/nvim-tree.lua/blob/master/lua/nvim-tree/renderer/builder.lua#L285