### PR TITLE
proper session restoration

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -334,6 +334,17 @@ local function setup_autocommands(opts)
     vim.api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
   end
 
+  create_nvim_tree_autocmd("SessionLoadPost", {
+    callback = function()
+      if view.wipe_rogue_buffer() then
+        view.open({focus_tree = false })
+        if _config.update_focused_file.enable then
+          vim.schedule(M.find_file)
+        end
+      end
+    end
+  })
+
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -357,7 +357,7 @@ local function setup_autocommands(opts)
   end
 
   create_nvim_tree_autocmd("SessionLoadPost", {
-    callback = reattach_session
+    callback = reattach_session,
   })
 
   -- reset highlights when colorscheme is changed

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -343,11 +343,18 @@ local function setup_autocommands(opts)
         return
       end
 
+      -- The only existing window is an nvim tree, so we need to wait for
+      -- nvim tree to get rendered, then delete the blank buffer
       if #find_existing_windows() == #get_normal_windows() then
         vim.schedule(function()
           M.toggle(false, false)
           if _config.update_focused_file.enable then
             vim.schedule(M.find_file)
+          end
+          for _, bufnr in pairs(vim.api.nvim_list_bufs()) do
+            if vim.api.nvim_buf_get_name(bufnr):match "NvimTree" == nil then
+              pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
           end
         end)
         return

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -339,27 +339,23 @@ local function setup_autocommands(opts)
     callback = function()
       view.reset_all_tabs()
       local existing = find_existing_windows()
+      local normal = get_normal_windows()
+      -- nvim tree wasn't open in last session
       if #existing == 0 then
         return
       end
 
-      -- The only existing window is an nvim tree, so we need to wait for
-      -- nvim tree to get rendered, then delete the blank buffer
-      if #find_existing_windows() == #get_normal_windows() then
+      -- only nvim tree was open in last session
+      if #existing == #normal then
+        vim.cmd("vsp")
         vim.schedule(function()
-          M.toggle(false, false)
-          if _config.update_focused_file.enable then
-            vim.schedule(M.find_file)
-          end
-          for _, bufnr in pairs(vim.api.nvim_list_bufs()) do
-            if vim.api.nvim_buf_get_name(bufnr):match "NvimTree" == nil then
-              pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-            end
-          end
+          view.open_in_current_win()
+          require('nvim-tree.renderer').draw()
         end)
         return
       end
 
+      -- nvim tree and other files were open in last session
       M.toggle(false, false)
       if _config.update_focused_file.enable then
         vim.schedule(M.find_file)

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -113,17 +113,12 @@ end
 
 function M.open(cwd)
   M.set_target_win()
-  print("open x")
   if not core.get_explorer() or cwd then
-  print("no explorer")
     core.init(cwd or vim.loop.cwd())
   end
   if should_hijack_current_buf() then
-    print("should hijack")
     view.close()
-    print("closed")
     view.open_in_current_win()
-    print("opening in current")
     renderer.draw()
   else
     open_view_and_draw()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -113,12 +113,17 @@ end
 
 function M.open(cwd)
   M.set_target_win()
+  print("open x")
   if not core.get_explorer() or cwd then
+  print("no explorer")
     core.init(cwd or vim.loop.cwd())
   end
   if should_hijack_current_buf() then
+    print("should hijack")
     view.close()
+    print("closed")
     view.open_in_current_win()
+    print("opening in current")
     renderer.draw()
   else
     open_view_and_draw()

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -38,6 +38,10 @@ function M.path_split(path)
   return path:gmatch("[^" .. path_separator .. "]+" .. path_separator .. "?")
 end
 
+function M.get_tabnr(name)
+  return tonumber(string.sub(name, string.find(name, "%d+")))
+end
+
 ---Get the basename of the given path.
 ---@param path string
 ---@return string

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -459,4 +459,3 @@ function M.setup(opts)
 end
 
 return M
-

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -74,19 +74,16 @@ local function matches_bufnr(bufnr)
   return false
 end
 
-function M.wipe_rogue_buffer()
-  local was_wiped = false
+local function wipe_rogue_buffer()
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if not matches_bufnr(bufnr) and utils.is_nvim_tree_buf(bufnr) then
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-      was_wiped = true
     end
   end
-  return was_wiped
 end
 
 local function create_buffer(bufnr)
-  M.wipe_rogue_buffer()
+  wipe_rogue_buffer()
 
   local tab = vim.api.nvim_get_current_tabpage()
   BUFNR_PER_TAB[tab] = bufnr or vim.api.nvim_create_buf(false, false)
@@ -314,6 +311,15 @@ function M.abandon_current_window()
   M.View.tabpages[tab].winnr = nil
 end
 
+function M.reset_all_tabs()
+  for _, tab in pairs(vim.api.nvim_list_tabpages()) do
+    BUFNR_PER_TAB[tab] = nil
+    if M.View.tabpages[tab] then
+      M.View.tabpages[tab].winnr = nil
+    end
+  end
+end
+
 function M.is_visible(opts)
   if opts and opts.any_tabpage then
     for _, v in pairs(M.View.tabpages) do
@@ -462,3 +468,4 @@ function M.setup(opts)
 end
 
 return M
+

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -168,6 +168,7 @@ local function get_alt_or_next_buf()
 end
 
 local function switch_buf_if_last_buf()
+  print("switching buf if last buf")
   if #vim.api.nvim_list_wins() == 1 then
     local buf = get_alt_or_next_buf()
     if buf then
@@ -188,6 +189,7 @@ function M.close()
   if not M.is_visible() then
     return
   end
+  print("saving tab state")
   save_tab_state()
   switch_buf_if_last_buf()
   local tree_win = M.get_winnr()

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -168,7 +168,6 @@ local function get_alt_or_next_buf()
 end
 
 local function switch_buf_if_last_buf()
-  print("switching buf if last buf")
   if #vim.api.nvim_list_wins() == 1 then
     local buf = get_alt_or_next_buf()
     if buf then
@@ -189,7 +188,6 @@ function M.close()
   if not M.is_visible() then
     return
   end
-  print("saving tab state")
   save_tab_state()
   switch_buf_if_last_buf()
   local tree_win = M.get_winnr()
@@ -313,15 +311,6 @@ function M.abandon_current_window()
   M.View.tabpages[tab].winnr = nil
 end
 
-function M.reset_all_tabs()
-  for _, tab in pairs(vim.api.nvim_list_tabpages()) do
-    BUFNR_PER_TAB[tab] = nil
-    if M.View.tabpages[tab] then
-      M.View.tabpages[tab].winnr = nil
-    end
-  end
-end
-
 function M.is_visible(opts)
   if opts and opts.any_tabpage then
     for _, v in pairs(M.View.tabpages) do
@@ -374,8 +363,8 @@ end
 
 --- Returns the current nvim tree bufnr
 ---@return number
-function M.get_bufnr()
-  return BUFNR_PER_TAB[vim.api.nvim_get_current_tabpage()]
+function M.get_bufnr(tabnr)
+  return BUFNR_PER_TAB[tabnr or vim.api.nvim_get_current_tabpage()]
 end
 
 --- Checks if nvim-tree is displaying the help ui within the tabpage specified

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -74,16 +74,19 @@ local function matches_bufnr(bufnr)
   return false
 end
 
-local function wipe_rogue_buffer()
+function M.wipe_rogue_buffer()
+  local was_wiped = false
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if not matches_bufnr(bufnr) and utils.is_nvim_tree_buf(bufnr) then
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      was_wiped = true
     end
   end
+  return was_wiped
 end
 
 local function create_buffer(bufnr)
-  wipe_rogue_buffer()
+  M.wipe_rogue_buffer()
 
   local tab = vim.api.nvim_get_current_tabpage()
   BUFNR_PER_TAB[tab] = bufnr or vim.api.nvim_create_buf(false, false)


### PR DESCRIPTION
Continuation of #1734.

>Currently, if you open a session after vim is already opened (not with `vim -S ./path/to/session.vim`), the old `nvim-tree` buffers are not restored. This ensures that `nvim-tree` is reloaded whenever a session is loaded.

I have tested this pretty thoroughly and made sure that it functions properly when opening from a previous session with or without an `NvimTree` buffer. It also remembers which buffer you were on correctly and focuses the correct file.

It also functions properly if you delete all buffers (e.g. with `%bd!`) in your current session and load a new session.

I personally use [`auto-session`](https://github.com/nvim-tree/nvim-tree.lua/pull/1734), which creates a new session, listening to global directory changes, also saving your previous session. So, by setting

```
  sync_root_with_cwd = true,
  actions = {
    change_dir = {
      global = true
    }
  },
```

You can switch around in `nvim-tree`, and it automatically restores your sessions as you go, which is, frankly, pretty cool.

I only mention that (other than the fact that it's cool) to note that there may be other session managers with corner cases I haven't noticed, but it's working really well with my set up.

The only limitation is that if you have multiple tabs with NvimTree buffers, it does not restore the tabs that were not in focus at the time you made the session.

Still, it's a lot of progress.

cc @kyazdani42 @alex-courtis (because you were pinged before on the previous PR)
