### PR TITLE
[WIP] allow using the winbar instead of statusbar as a window picker

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -621,6 +621,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       resize_window = true,
       window_picker = {
         enable = true,
+        use_winbar = false,
         chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
         exclude = {
           filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame" },


### PR DESCRIPTION
WIP

Hi. I'm using [vimpostor/vim-tpipeline](https://github.com/vimpostor/vim-tpipeline) with `laststatus=0`. There is some kind of problem when nvim-tree.lua populates the different statusbars in each window, vim-tpipeline doesn't like it. I also use [s1n7ax/nvim-window-picker](https://github.com/s1n7ax/nvim-window-picker) to pick a window when opening a file from telescope.nvim. They added an option to use the winbar instead of the statusbar to select the window. Could we also do something similar in nvim-tree.lua? This PR is some hack I did to test the idea, by adapting (stealing) their code.

PS. Ideally, we could abstract the `window_picker` interface to hook into an arbitrary window picker implementation and reuse the nvim-window-picker function (or another, like [t9md/vim-choosewin](https://github.com/t9md/vim-choosewin))

PS2. nvim-window-picker is inspired by nvim-tree.lua, so it comes full circle =)

Thanks!