### PR TITLE
feat: Add highlight group for opened folder icon

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1406,7 +1406,7 @@ NvimTreeSymlink
 NvimTreeFolderName          (Directory)
 NvimTreeRootFolder
 NvimTreeFolderIcon
-NvimTreeOpenedFolderIcon
+NvimTreeOpenedFolderIcon    (NvimTreeFolderIcon)
 NvimTreeFileIcon
 NvimTreeEmptyFolderName     (Directory)
 NvimTreeOpenedFolderName    (Directory)

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1406,6 +1406,7 @@ NvimTreeSymlink
 NvimTreeFolderName          (Directory)
 NvimTreeRootFolder
 NvimTreeFolderIcon
+NvimTreeOpenedFolderIcon
 NvimTreeFileIcon
 NvimTreeEmptyFolderName     (Directory)
 NvimTreeOpenedFolderName    (Directory)

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1407,6 +1407,7 @@ NvimTreeFolderName          (Directory)
 NvimTreeRootFolder
 NvimTreeFolderIcon
 NvimTreeOpenedFolderIcon    (NvimTreeFolderIcon)
+NvimTreeClosedFolderIcon    (NvimTreeFolderIcon)
 NvimTreeFileIcon
 NvimTreeEmptyFolderName     (Directory)
 NvimTreeOpenedFolderName    (Directory)

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -61,6 +61,7 @@ local function get_links()
     FolderName = "Directory",
     EmptyFolderName = "Directory",
     OpenedFolderName = "Directory",
+    OpenedFolderIcon = "NvimTreeFolderIcon",
     Normal = "Normal",
     NormalNC = "NvimTreeNormal",
     EndOfBuffer = "EndOfBuffer",

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -62,6 +62,7 @@ local function get_links()
     EmptyFolderName = "Directory",
     OpenedFolderName = "Directory",
     OpenedFolderIcon = "NvimTreeFolderIcon",
+    ClosedFolderIcon = "NvimTreeFolderIcon",
     Normal = "Normal",
     NormalNC = "NvimTreeNormal",
     EndOfBuffer = "EndOfBuffer",

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -126,9 +126,9 @@ function Builder:_build_folder(node, padding, git_hl, git_icons_tbl)
 
   if #icon > 0 then
     if node.open then
-      self:_insert_highlight("NvimTreeFolderOpenIcon", offset, offset + #icon)
+      self:_insert_highlight("NvimTreeOpenedFolderIcon", offset, offset + #icon)
     else
-      self:_insert_highlight("NvimTreeFolderClosedIcon", offset, offset + #icon)
+      self:_insert_highlight("NvimTreeClosedFolderIcon", offset, offset + #icon)
     end
   end
 

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -125,7 +125,11 @@ function Builder:_build_folder(node, padding, git_hl, git_icons_tbl)
   self:_insert_line(line)
 
   if #icon > 0 then
-    self:_insert_highlight("NvimTreeFolderIcon", offset, offset + #icon)
+    if node.open then
+      self:_insert_highlight("NvimTreeFolderOpenIcon", offset, offset + #icon)
+    else
+      self:_insert_highlight("NvimTreeFolderClosedIcon", offset, offset + #icon)
+    end
   end
 
   local foldername_hl = "NvimTreeFolderName"


### PR DESCRIPTION
closes #1674

The issue proposed `NvimTreeFolderIconOpen`  as the name for this hl-group, but I went with `NvimTreeOpenedFolderIcon` to stay consistent with `NvimTreeOpenedFolderName`.

This defaults to just `NvimTreeFolderIcon`, so nothing changes if you don't set `NvimTreeOpenedFolderIcon`.