### PR TITLE
feat(diagnostics): only show diagnostic and git icon on closed folder

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -290,6 +290,7 @@ Subsequent calls to setup will replace the previous configuration.
       diagnostics = {
         enable = false,
         show_on_dirs = false,
+        show_on_open_dirs = true,
         debounce_delay = 50,
         severity = {
           min = vim.diagnostic.severity.HINT,
@@ -554,6 +555,11 @@ Show LSP and COC diagnostics in the signcolumn
     *nvim-tree.diagnostics.show_on_dirs*
     Show diagnostic icons on parent directories.
       Type: `boolean`, Default: `false`
+
+    *nvim-tree.diagnostics.show_on_open_dirs*
+    Show diagnostics icons on directories that are open.
+    Only relevant when `diagnostics.show_on_dirs` is `true`.
+      Type: `boolean`, Default: `true`
 
     *nvim-tree.diagnostics.icons*
     Icons for diagnostic severity.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -317,6 +317,7 @@ Subsequent calls to setup will replace the previous configuration.
         enable = true,
         ignore = true,
         show_on_dirs = true,
+        show_on_open_dirs = true,
         timeout = 400,
       },
       actions = {
@@ -590,6 +591,11 @@ Git integration with icons and colors.
 
     *nvim-tree.git.show_on_dirs*
     Show status icons of children when directory itself has no status icon.
+      Type: `boolean`, Default: `true`
+
+    *nvim-tree.git.show_on_open_dirs*
+    Show status icons on directories that are open.
+    Only relevant when `git.show_on_dirs` is `true`.
       Type: `boolean`, Default: `true`
 
     *nvim-tree.git.timeout*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -568,6 +568,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   diagnostics = {
     enable = false,
     show_on_dirs = false,
+    show_on_open_dirs = true,
     debounce_delay = 50,
     severity = {
       min = vim.diagnostic.severity.HINT,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -595,6 +595,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     enable = true,
     ignore = true,
     show_on_dirs = true,
+    show_on_open_dirs = true,
     timeout = 400,
   },
   actions = {

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -114,7 +114,7 @@ function M.update()
         for line, node in pairs(nodes_by_line) do
           local nodepath = utils.canonical_path(node.absolute_path)
           log.line("diagnostics", "  %d checking nodepath '%s'", line, nodepath)
-          if M.show_on_dirs and vim.startswith(bufpath, nodepath) then
+          if M.show_on_dirs and vim.startswith(bufpath, nodepath) and (not node.open or M.show_on_open_dirs) then
             log.line("diagnostics", " matched fold node '%s'", node.absolute_path)
             node.diag_status = severity
             add_sign(line, severity)
@@ -147,6 +147,7 @@ function M.setup(opts)
   end
 
   M.show_on_dirs = opts.diagnostics.show_on_dirs
+  M.show_on_open_dirs = opts.diagnostics.show_on_open_dirs
   vim.fn.sign_define(sign_names[1][1], { text = opts.diagnostics.icons.error, texthl = sign_names[1][2] })
   vim.fn.sign_define(sign_names[2][1], { text = opts.diagnostics.icons.warning, texthl = sign_names[2][2] })
   vim.fn.sign_define(sign_names[3][1], { text = opts.diagnostics.icons.info, texthl = sign_names[3][2] })

--- a/lua/nvim-tree/renderer/components/git.lua
+++ b/lua/nvim-tree/renderer/components/git.lua
@@ -75,9 +75,13 @@ local function warn_status(git_status)
   )
 end
 
+local function show_git(node)
+  return node.git_status and (not node.open or M.git_show_on_open_dirs)
+end
+
 local function get_icons_(node)
   local git_status = node.git_status
-  if not git_status then
+  if not show_git(node) then
     return nil
   end
 
@@ -137,7 +141,7 @@ end
 
 local function get_highlight_(node)
   local git_status = node.git_status
-  if not git_status then
+  if not show_git(node) then
     return
   end
 
@@ -162,6 +166,8 @@ function M.setup(opts)
   else
     M.get_highlight = nil_
   end
+
+  M.git_show_on_open_dirs = opts.git.show_on_open_dirs
 end
 
 return M


### PR DESCRIPTION
fixes #1781 

On certain projects there might be deeply nested folders (e.g. java projects). Showing diagnostics on all the parent folders feels very cluttered. It also makes it harder to get a idea of how many files have diagnostics at a glance.

This PR adds the `show_on_open_dirs` which when set to false will only show diagnostics on closed directory.