### PR TITLE
fixed: git rename not showing up for the renamed file

### DIFF
--- a/lua/nvim-tree/git/runner.lua
+++ b/lua/nvim-tree/git/runner.lua
@@ -4,29 +4,7 @@ local utils = require "nvim-tree.utils"
 local Runner = {}
 Runner.__index = Runner
 
-function Runner:_parse_status_output(line)
-  local status = line:sub(1, 2)
-  local path = line:sub(4, -2)
-  if utils.str_find(status, "R") then
-    -- rename have format of "from -> to"
-    -- we just what the "to" part
-    if path:sub(1, 1) == '"' then
-      -- incase " -> " is a part of the file name
-      local _, j = path:find('" -> "', nil, true)
-      path = path:sub(j, -1)
-    else
-      local _, j = path:find(" -> ", nil, true)
-      path = path:sub(j + 1, -1)
-    end
-  end
-
-  -- removing `"` when git is returning special file status containing spaces
-  if path:sub(1, 1) == '"' then
-    path = path:sub(2, -2)
-    path = path:gsub('\\"', '"')
-    path = path:gsub("\\\\", "\\")
-  end
-
+function Runner:_parse_status_output(status, path)
   -- replacing slashes if on windows
   if vim.fn.has "win32" == 1 then
     path = path:gsub("/", "\\")
@@ -34,15 +12,26 @@ function Runner:_parse_status_output(line)
   if #status > 0 and #path > 0 then
     self.output[utils.path_remove_trailing(utils.path_join { self.project_root, path })] = status
   end
-  return #line
 end
 
 function Runner:_handle_incoming_data(prev_output, incoming)
   if incoming and utils.str_find(incoming, "\n") then
     local prev = prev_output .. incoming
     local i = 1
+    local skip_next_line = false
     for line in prev:gmatch "[^\n]*\n" do
-      i = i + self:_parse_status_output(line)
+      if skip_next_line then
+        skip_next_line = false
+      else
+        local status = line:sub(1, 2)
+        local path = line:sub(4, -2)
+        if utils.str_find(status, "R") then
+          -- skip next line if it is a rename entry
+          skip_next_line = true
+        end
+        self:_parse_status_output(status, path)
+      end
+      i = i + #line
     end
 
     return prev:sub(i, -1)
@@ -63,7 +52,7 @@ function Runner:_getopts(stdout_handle, stderr_handle)
   local untracked = self.list_untracked and "-u" or nil
   local ignored = (self.list_untracked and self.list_ignored) and "--ignored=matching" or "--ignored=no"
   return {
-    args = { "--no-optional-locks", "status", "--porcelain=v1", ignored, untracked, self.path },
+    args = { "--no-optional-locks", "status", "--porcelain=v1", "-z", ignored, untracked, self.path },
     cwd = self.project_root,
     stdio = { nil, stdout_handle, stderr_handle },
   }
@@ -124,6 +113,9 @@ function Runner:_run_git_job()
   local function manage_stdout(err, data)
     if err then
       return
+    end
+    if data then
+      data = data:gsub("%z", "\n")
     end
     self:_log_raw_output(data)
     output_leftover = self:_handle_incoming_data(output_leftover, data)

--- a/lua/nvim-tree/git/runner.lua
+++ b/lua/nvim-tree/git/runner.lua
@@ -12,10 +12,10 @@ function Runner:_parse_status_output(line)
     -- we just what the "to" part
     if path:sub(1, 1) == '"' then
       -- incase " -> " is a part of the file name
-      local _, j = path:find '" %-> "'
+      local _, j = path:find('" -> "', nil, true)
       path = path:sub(j, -1)
     else
-      local _, j = path:find " %-> "
+      local _, j = path:find(" -> ", nil, true)
       path = path:sub(j + 1, -1)
     end
   end

--- a/lua/nvim-tree/git/runner.lua
+++ b/lua/nvim-tree/git/runner.lua
@@ -6,8 +6,17 @@ Runner.__index = Runner
 
 function Runner:_parse_status_output(line)
   local status = line:sub(1, 2)
+  local path = line:sub(4, -2)
+  if utils.str_find(status, "R") then
+    -- rename have format of "from -> to"
+    -- we just what the "to" part
+    local _, j = path:find " -> "
+    -- Note: The edge case where " -> " is a part of a file name is not addressed
+    path = path:sub(j + 1, -1)
+  end
+
   -- removing `"` when git is returning special file status containing spaces
-  local path = line:sub(4, -2):gsub('^"', ""):gsub('"$', "")
+  path = path:gsub('^"', ""):gsub('"$', "")
   -- replacing slashes if on windows
   if vim.fn.has "win32" == 1 then
     path = path:gsub("/", "\\")


### PR DESCRIPTION
After renaming a file, rename icon only shows up on parent directory. No icon shows up on the file itself. This PR fixes that.

Edit: It now also deal with escape characters in quoted filenames (e.g. "a \\"quoted\\" file name") correctly