### PR TITLE
feat(view): add filters.git_clean, filters.no_buffer

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -309,6 +309,7 @@ Subsequent calls to setup will replace the previous configuration.
         dotfiles = false,
         git_clean = false,
         no_buffer = false,
+        diagnostics_ok = false,
         custom = {},
         exclude = {},
       },
@@ -914,6 +915,13 @@ Filtering options.
     *nvim-tree.filters.no_buffer*
     Do not show files that have no listed buffer.
     Toggle via the `toggle_no_buffer` action, default mapping `B`.
+    For performance reasons this may not immediately update on buffer
+    delete/wipe. A reload or filesystem event will result in an update.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.filters.diagnostics_ok*
+    Do not show files that have no diagnostic issues.
+    Toggle via the `toggle_diagnostics_ok` action, default mapping `A`.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.filters.custom*
@@ -1317,57 +1325,58 @@ Single right / middle mouse mappings will requre changes to |mousemodel| or |mou
 
 DEFAULT MAPPINGS                                     *nvim-tree-default-mappings*
 
-`<CR>`            edit                open a file or folder; root will cd to the above directory
+`<CR>`            edit                   open a file or folder; root will cd to the above directory
 `o`
 `<2-LeftMouse>`
-`<C-e>`           edit_in_place       edit the file in place, effectively replacing the tree explorer
-`O`               edit_no_picker      same as (edit) with no window picker
-`<C-]>`           cd                  cd in the directory under the cursor
+`<C-e>`           edit_in_place          edit the file in place, effectively replacing the tree explorer
+`O`               edit_no_picker         same as (edit) with no window picker
+`<C-]>`           cd                     cd in the directory under the cursor
 `<2-RightMouse>`
-`<C-v>`           vsplit              open the file in a vertical split
-`<C-x>`           split               open the file in a horizontal split
-`<C-t>`           tabnew              open the file in a new tab
-`<`               prev_sibling        navigate to the previous sibling of current file/directory
-`>`               next_sibling        navigate to the next sibling of current file/directory
-`P`               parent_node         move cursor to the parent directory
-`<BS>`            close_node          close current opened directory or parent
-`<Tab>`           preview             open the file as a preview (keeps the cursor in the tree)
-`K`               first_sibling       navigate to the first sibling of current file/directory
-`J`               last_sibling        navigate to the last sibling of current file/directory
-`C`               toggle_git_clean    toggle visibility of git clean via |filters.git_clean| option
-`I`               toggle_git_ignored  toggle visibility of files/folders hidden via |git.ignore| option
-`H`               toggle_dotfiles     toggle visibility of dotfiles via |filters.dotfiles| option
-`B`               toggle_no_buffer    toggle visibility of files/folders hidden via |filters.no_buffer| option
-`U`               toggle_custom       toggle visibility of files/folders hidden via |filters.custom| option
-`R`               refresh             refresh the tree
-`a`               create              add a file; leaving a trailing `/` will add a directory
-`d`               remove              delete a file (will prompt for confirmation)
-`D`               trash               trash a file via |trash| option
-`r`               rename              rename a file
-`<C-r>`           full_rename         rename a file and omit the filename on input
-`x`               cut                 add/remove file/directory to cut clipboard
-`c`               copy                add/remove file/directory to copy clipboard
-`p`               paste               paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation
-`y`               copy_name           copy name to system clipboard
-`Y`               copy_path           copy relative path to system clipboard
-`gy`              copy_absolute_path  copy absolute path to system clipboard
-`[e`              prev_diag_item      go to next diagnostic item
-`[c`              prev_git_item       go to next git item
-`]e`              next_diag_item      go to prev diagnostic item
-`]c`              next_git_item       go to prev git item
-`-`               dir_up              navigate up to the parent directory of the current file/directory
-`s`               system_open         open a file with default system application or a folder with default file manager, using |system_open| option
-`f`               live_filter         live filter nodes dynamically based on regex matching.
-`F`               clear_live_filter   clear live filter
-`q`               close               close tree window
-`W`               collapse_all        collapse the whole tree
-`E`               expand_all          expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder
-`S`               search_node         prompt the user to enter a path and then expands the tree to match the path
-`.`               run_file_command    enter vim command mode with the file the cursor is on
-`<C-k>`           toggle_file_info    toggle a popup with file infos about the file under the cursor
-`g?`              toggle_help         toggle help
-`m`               toggle_mark         Toggle node in bookmarks
-`bmv`             bulk_move           Move all bookmarked nodes into specified location
+`<C-v>`           vsplit                 open the file in a vertical split
+`<C-x>`           split                  open the file in a horizontal split
+`<C-t>`           tabnew                 open the file in a new tab
+`<`               prev_sibling           navigate to the previous sibling of current file/directory
+`>`               next_sibling           navigate to the next sibling of current file/directory
+`P`               parent_node            move cursor to the parent directory
+`<BS>`            close_node             close current opened directory or parent
+`<Tab>`           preview                open the file as a preview (keeps the cursor in the tree)
+`K`               first_sibling          navigate to the first sibling of current file/directory
+`J`               last_sibling           navigate to the last sibling of current file/directory
+`C`               toggle_git_clean       toggle visibility of git clean via |filters.git_clean| option
+`I`               toggle_git_ignored     toggle visibility of files/folders hidden via |git.ignore| option
+`H`               toggle_dotfiles        toggle visibility of dotfiles via |filters.dotfiles| option
+`B`               toggle_no_buffer       toggle visibility of files/folders hidden via |filters.no_buffer| option
+`A`               toggle_diagnostics_ok  toggle visibility of files/folders hidden via |filters.diagnostics_ok| option
+`U`               toggle_custom          toggle visibility of files/folders hidden via |filters.custom| option
+`R`               refresh                refresh the tree
+`a`               create                 add a file; leaving a trailing `/` will add a directory
+`d`               remove                 delete a file (will prompt for confirmation)
+`D`               trash                  trash a file via |trash| option
+`r`               rename                 rename a file
+`<C-r>`           full_rename            rename a file and omit the filename on input
+`x`               cut                    add/remove file/directory to cut clipboard
+`c`               copy                   add/remove file/directory to copy clipboard
+`p`               paste                  paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation
+`y`               copy_name              copy name to system clipboard
+`Y`               copy_path              copy relative path to system clipboard
+`gy`              copy_absolute_path     copy absolute path to system clipboard
+`[e`              prev_diag_item         go to next diagnostic item
+`[c`              prev_git_item          go to next git item
+`]e`              next_diag_item         go to prev diagnostic item
+`]c`              next_git_item          go to prev git item
+`-`               dir_up                 navigate up to the parent directory of the current file/directory
+`s`               system_open            open a file with default system application or a folder with default file manager, using |system_open| option
+`f`               live_filter            live filter nodes dynamically based on regex matching.
+`F`               clear_live_filter      clear live filter
+`q`               close                  close tree window
+`W`               collapse_all           collapse the whole tree
+`E`               expand_all             expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder
+`S`               search_node            prompt the user to enter a path and then expands the tree to match the path
+`.`               run_file_command       enter vim command mode with the file the cursor is on
+`<C-k>`           toggle_file_info       toggle a popup with file infos about the file under the cursor
+`g?`              toggle_help            toggle help
+`m`               toggle_mark            Toggle node in bookmarks
+`bmv`             bulk_move              Move all bookmarked nodes into specified location
 
 >
   view.mappings.list = { -- BEGIN_DEFAULT_MAPPINGS
@@ -1389,6 +1398,7 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
     { key = "I",                              action = "toggle_git_ignored" },
     { key = "H",                              action = "toggle_dotfiles" },
     { key = "B",                              action = "toggle_no_buffer" },
+    { key = "A",                              action = "toggle_diagnostics_ok" },
     { key = "U",                              action = "toggle_custom" },
     { key = "R",                              action = "refresh" },
     { key = "a",                              action = "create" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -309,7 +309,6 @@ Subsequent calls to setup will replace the previous configuration.
         dotfiles = false,
         git_clean = false,
         no_buffer = false,
-        diagnostics_ok = false,
         custom = {},
         exclude = {},
       },
@@ -919,11 +918,6 @@ Filtering options.
     delete/wipe. A reload or filesystem event will result in an update.
       Type: `boolean`, Default: `false`
 
-    *nvim-tree.filters.diagnostics_ok*
-    Do not show files that have no diagnostic issues.
-    Toggle via the `toggle_diagnostics_ok` action, default mapping `A`.
-      Type: `boolean`, Default: `false`
-
     *nvim-tree.filters.custom*
     Custom list of vim regex for file/directory names that will not be shown.
     Backslashes must be escaped e.g. "^\\.git". See |string-match|.
@@ -1346,7 +1340,6 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
 `I`               toggle_git_ignored     toggle visibility of files/folders hidden via |git.ignore| option
 `H`               toggle_dotfiles        toggle visibility of dotfiles via |filters.dotfiles| option
 `B`               toggle_no_buffer       toggle visibility of files/folders hidden via |filters.no_buffer| option
-`A`               toggle_diagnostics_ok  toggle visibility of files/folders hidden via |filters.diagnostics_ok| option
 `U`               toggle_custom          toggle visibility of files/folders hidden via |filters.custom| option
 `R`               refresh                refresh the tree
 `a`               create                 add a file; leaving a trailing `/` will add a directory
@@ -1398,7 +1391,6 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
     { key = "I",                              action = "toggle_git_ignored" },
     { key = "H",                              action = "toggle_dotfiles" },
     { key = "B",                              action = "toggle_no_buffer" },
-    { key = "A",                              action = "toggle_diagnostics_ok" },
     { key = "U",                              action = "toggle_custom" },
     { key = "R",                              action = "refresh" },
     { key = "a",                              action = "create" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -304,9 +304,10 @@ Subsequent calls to setup will replace the previous configuration.
       },
       filters = {
         dotfiles = false,
+        git_clean = false,
+        no_buffer = false,
         custom = {},
         exclude = {},
-        git_clean = false,
       },
       filesystem_watchers = {
         enable = true,
@@ -893,6 +894,12 @@ Filtering options.
     *nvim-tree.filters.git_clean*
     Do not show files with no git status. This will show ignored files when
     |nvim-tree.git.ignore| is set, as they are effectively dirty.
+    Toggle via the `toggle_git_clean` action, default mapping `C`.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.filters.no_buffer*
+    Do not show files that have no open buffer.
+    Toggle via the `toggle_no_buffer` action, default mapping `B`.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.filters.custom*
@@ -1181,6 +1188,7 @@ exists.
     - expand_all
     - toggle_gitignore_filter
     - toggle_git_clean_filter
+    - toggle_no_buffer_filter
     - toggle_custom_filter
     - toggle_hidden_filter
     - toggle_help
@@ -1315,6 +1323,7 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
 `C`               toggle_git_clean    toggle visibility of git clean via |filters.git_clean| option
 `I`               toggle_git_ignored  toggle visibility of files/folders hidden via |git.ignore| option
 `H`               toggle_dotfiles     toggle visibility of dotfiles via |filters.dotfiles| option
+`B`               toggle_no_buffer    toggle visibility of files/folders hidden via |filters.no_buffer| option
 `U`               toggle_custom       toggle visibility of files/folders hidden via |filters.custom| option
 `R`               refresh             refresh the tree
 `a`               create              add a file; leaving a trailing `/` will add a directory
@@ -1365,6 +1374,7 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
     { key = "C",                              action = "toggle_git_clean" },
     { key = "I",                              action = "toggle_git_ignored" },
     { key = "H",                              action = "toggle_dotfiles" },
+    { key = "B",                              action = "toggle_no_buffer" },
     { key = "U",                              action = "toggle_custom" },
     { key = "R",                              action = "refresh" },
     { key = "a",                              action = "create" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1180,6 +1180,7 @@ exists.
     - collapse_all `(keep_buffers?: bool)`
     - expand_all
     - toggle_gitignore_filter
+    - toggle_git_clean_filter
     - toggle_custom_filter
     - toggle_hidden_filter
     - toggle_help

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -293,7 +293,7 @@ Subsequent calls to setup will replace the previous configuration.
         debounce_delay = 50,
         severity = {
           min = vim.diagnostic.severity.HINT,
-          max = vim.diagnostic.severity.ERROR
+          max = vim.diagnostic.severity.ERROR,
         },
         icons = {
           hint = "",
@@ -306,6 +306,7 @@ Subsequent calls to setup will replace the previous configuration.
         dotfiles = false,
         custom = {},
         exclude = {},
+        git_clean = false,
       },
       filesystem_watchers = {
         enable = true,
@@ -889,6 +890,11 @@ Filtering options.
     Toggle via the `toggle_dotfiles` action, default mapping `H`.
       Type: `boolean`, Default: `false`
 
+    *nvim-tree.filters.git_clean*
+    Do not show files with no git status. This will show ignored files when
+    |nvim-tree.git.ignore| is set, as they are effectively dirty.
+      Type: `boolean`, Default: `false`
+
     *nvim-tree.filters.custom*
     Custom list of vim regex for file/directory names that will not be shown.
     Backslashes must be escaped e.g. "^\\.git". See |string-match|.
@@ -1305,6 +1311,7 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
 `<Tab>`           preview             open the file as a preview (keeps the cursor in the tree)
 `K`               first_sibling       navigate to the first sibling of current file/directory
 `J`               last_sibling        navigate to the last sibling of current file/directory
+`C`               toggle_git_clean    toggle visibility of git clean via |filters.git_clean| option
 `I`               toggle_git_ignored  toggle visibility of files/folders hidden via |git.ignore| option
 `H`               toggle_dotfiles     toggle visibility of dotfiles via |filters.dotfiles| option
 `U`               toggle_custom       toggle visibility of files/folders hidden via |filters.custom| option
@@ -1354,6 +1361,7 @@ DEFAULT MAPPINGS                                     *nvim-tree-default-mappings
     { key = "<Tab>",                          action = "preview" },
     { key = "K",                              action = "first_sibling" },
     { key = "J",                              action = "last_sibling" },
+    { key = "C",                              action = "toggle_git_clean" },
     { key = "I",                              action = "toggle_git_ignored" },
     { key = "H",                              action = "toggle_dotfiles" },
     { key = "U",                              action = "toggle_custom" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -898,7 +898,7 @@ Filtering options.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.filters.no_buffer*
-    Do not show files that have no open buffer.
+    Do not show files that have no listed buffer.
     Toggle via the `toggle_no_buffer` action, default mapping `B`.
       Type: `boolean`, Default: `false`
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -584,6 +584,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     dotfiles = false,
     custom = {},
     exclude = {},
+    git_clean = false,
   },
   filesystem_watchers = {
     enable = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -602,7 +602,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     dotfiles = false,
     git_clean = false,
     no_buffer = false,
-    diagnostics_ok = false,
     custom = {},
     exclude = {},
   },

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -602,6 +602,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     dotfiles = false,
     git_clean = false,
     no_buffer = false,
+    diagnostics_ok = false,
     custom = {},
     exclude = {},
   },

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -11,6 +11,7 @@ local reloaders = require "nvim-tree.actions.reloaders.reloaders"
 local copy_paste = require "nvim-tree.actions.fs.copy-paste"
 local collapse_all = require "nvim-tree.actions.tree-modifiers.collapse-all"
 local git = require "nvim-tree.git"
+local filters = require "nvim-tree.explorer.filters"
 
 local _config = {}
 
@@ -352,6 +353,22 @@ local function setup_autocommands(opts)
   if opts.auto_reload_on_write and not has_watchers then
     create_nvim_tree_autocmd("BufWritePost", { callback = reloaders.reload_explorer })
   end
+
+  create_nvim_tree_autocmd("BufReadPost", {
+    callback = function()
+      if filters.config.filter_no_buffer then
+        reloaders.reload_explorer()
+      end
+    end,
+  })
+
+  create_nvim_tree_autocmd("BufUnload", {
+    callback = function(data)
+      if filters.config.filter_no_buffer then
+        reloaders.reload_explorer(nil, data.buf)
+      end
+    end,
+  })
 
   if not has_watchers and opts.git.enable then
     create_nvim_tree_autocmd("User", {

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -582,9 +582,10 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   filters = {
     dotfiles = false,
+    git_clean = false,
+    no_buffer = false,
     custom = {},
     exclude = {},
-    git_clean = false,
   },
   filesystem_watchers = {
     enable = true,

--- a/lua/nvim-tree/actions/dispatch.lua
+++ b/lua/nvim-tree/actions/dispatch.lua
@@ -12,6 +12,7 @@ local Actions = {
   toggle_dotfiles = require("nvim-tree.actions.tree-modifiers.toggles").dotfiles,
   toggle_custom = require("nvim-tree.actions.tree-modifiers.toggles").custom,
   toggle_git_ignored = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored,
+  toggle_git_clean = require("nvim-tree.actions.tree-modifiers.toggles").git_clean,
 
   -- Filesystem operations
   copy_absolute_path = require("nvim-tree.actions.fs.copy-paste").copy_absolute_path,

--- a/lua/nvim-tree/actions/dispatch.lua
+++ b/lua/nvim-tree/actions/dispatch.lua
@@ -14,7 +14,6 @@ local Actions = {
   toggle_git_ignored = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored,
   toggle_git_clean = require("nvim-tree.actions.tree-modifiers.toggles").git_clean,
   toggle_no_buffer = require("nvim-tree.actions.tree-modifiers.toggles").no_buffer,
-  toggle_diagnostics_ok = require("nvim-tree.actions.tree-modifiers.toggles").diagnostics_ok,
 
   -- Filesystem operations
   copy_absolute_path = require("nvim-tree.actions.fs.copy-paste").copy_absolute_path,

--- a/lua/nvim-tree/actions/dispatch.lua
+++ b/lua/nvim-tree/actions/dispatch.lua
@@ -13,6 +13,7 @@ local Actions = {
   toggle_custom = require("nvim-tree.actions.tree-modifiers.toggles").custom,
   toggle_git_ignored = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored,
   toggle_git_clean = require("nvim-tree.actions.tree-modifiers.toggles").git_clean,
+  toggle_no_buffer = require("nvim-tree.actions.tree-modifiers.toggles").no_buffer,
 
   -- Filesystem operations
   copy_absolute_path = require("nvim-tree.actions.fs.copy-paste").copy_absolute_path,

--- a/lua/nvim-tree/actions/dispatch.lua
+++ b/lua/nvim-tree/actions/dispatch.lua
@@ -14,6 +14,7 @@ local Actions = {
   toggle_git_ignored = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored,
   toggle_git_clean = require("nvim-tree.actions.tree-modifiers.toggles").git_clean,
   toggle_no_buffer = require("nvim-tree.actions.tree-modifiers.toggles").no_buffer,
+  toggle_diagnostics_ok = require("nvim-tree.actions.tree-modifiers.toggles").diagnostics_ok,
 
   -- Filesystem operations
   copy_absolute_path = require("nvim-tree.actions.fs.copy-paste").copy_absolute_path,

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -14,7 +14,7 @@ local function search(search_dir, input_path)
   local function iter(dir)
     local realpath, path, name, stat, handle, _
 
-    local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+    local bufinfo = vim.fn.getbufinfo { buflisted = 1 }
 
     handle, _ = vim.loop.fs_scandir(dir)
     if not handle then

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -14,7 +14,7 @@ local function search(search_dir, input_path)
   local function iter(dir)
     local realpath, path, name, stat, handle, _
 
-    local bufinfo = vim.fn.getbufinfo { buflisted = 1 }
+    local filter_status = filters.prepare()
 
     handle, _ = vim.loop.fs_scandir(dir)
     if not handle then
@@ -36,7 +36,7 @@ local function search(search_dir, input_path)
         break
       end
 
-      if not filters.should_ignore(path, bufinfo) then
+      if not filters.should_filter(path, filter_status) then
         if string.find(path, "/" .. input_path .. "$") then
           return path
         end

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -14,6 +14,8 @@ local function search(search_dir, input_path)
   local function iter(dir)
     local realpath, path, name, stat, handle, _
 
+    local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+
     handle, _ = vim.loop.fs_scandir(dir)
     if not handle then
       return
@@ -34,7 +36,7 @@ local function search(search_dir, input_path)
         break
       end
 
-      if not filters.should_ignore(path) then
+      if not filters.should_ignore(path, bufinfo) then
         if string.find(path, "/" .. input_path .. "$") then
           return path
         end

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -97,11 +97,6 @@ local DEFAULT_MAPPINGS = {
     desc = "toggle visibility of files/folders hidden via |filters.no_buffer| option",
   },
   {
-    key = "A",
-    action = "toggle_diagnostics_ok",
-    desc = "toggle visibility of files/folders hidden via |filters.diagnostics_ok| option",
-  },
-  {
     key = "U",
     action = "toggle_custom",
     desc = "toggle visibility of files/folders hidden via |filters.custom| option",

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -97,6 +97,11 @@ local DEFAULT_MAPPINGS = {
     desc = "toggle visibility of files/folders hidden via |filters.no_buffer| option",
   },
   {
+    key = "A",
+    action = "toggle_diagnostics_ok",
+    desc = "toggle visibility of files/folders hidden via |filters.diagnostics_ok| option",
+  },
+  {
     key = "U",
     action = "toggle_custom",
     desc = "toggle visibility of files/folders hidden via |filters.custom| option",

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -77,6 +77,11 @@ local DEFAULT_MAPPINGS = {
     desc = "navigate to the last sibling of current file/directory",
   },
   {
+    key = "C",
+    action = "toggle_git_clean",
+    desc = "toggle visibility of git clean via |filters.git_clean| option",
+  },
+  {
     key = "I",
     action = "toggle_git_ignored",
     desc = "toggle visibility of files/folders hidden via |git.ignore| option",

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -92,6 +92,11 @@ local DEFAULT_MAPPINGS = {
     desc = "toggle visibility of dotfiles via |filters.dotfiles| option",
   },
   {
+    key = "B",
+    action = "toggle_no_buffer",
+    desc = "toggle visibility of files/folders hidden via |filters.no_buffer| option",
+  },
+  {
     key = "U",
     action = "toggle_custom",
     desc = "toggle visibility of files/folders hidden via |filters.custom| option",

--- a/lua/nvim-tree/actions/tree-modifiers/toggles.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/toggles.lua
@@ -20,6 +20,11 @@ function M.git_clean()
   return reloaders.reload_explorer()
 end
 
+function M.no_buffer()
+  filters.config.filter_no_buffer = not filters.config.filter_no_buffer
+  return reloaders.reload_explorer()
+end
+
 function M.dotfiles()
   filters.config.filter_dotfiles = not filters.config.filter_dotfiles
   return reloaders.reload_explorer()

--- a/lua/nvim-tree/actions/tree-modifiers/toggles.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/toggles.lua
@@ -15,6 +15,11 @@ function M.git_ignored()
   return reloaders.reload_explorer()
 end
 
+function M.git_clean()
+  filters.config.filter_git_clean = not filters.config.filter_git_clean
+  return reloaders.reload_explorer()
+end
+
 function M.dotfiles()
   filters.config.filter_dotfiles = not filters.config.filter_dotfiles
   return reloaders.reload_explorer()

--- a/lua/nvim-tree/actions/tree-modifiers/toggles.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/toggles.lua
@@ -25,11 +25,6 @@ function M.no_buffer()
   return reloaders.reload_explorer()
 end
 
-function M.diagnostics_ok()
-  filters.config.filter_diagnostics_ok = not filters.config.filter_diagnostics_ok
-  return reloaders.reload_explorer()
-end
-
 function M.dotfiles()
   filters.config.filter_dotfiles = not filters.config.filter_dotfiles
   return reloaders.reload_explorer()

--- a/lua/nvim-tree/actions/tree-modifiers/toggles.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/toggles.lua
@@ -25,6 +25,11 @@ function M.no_buffer()
   return reloaders.reload_explorer()
 end
 
+function M.diagnostics_ok()
+  filters.config.filter_diagnostics_ok = not filters.config.filter_diagnostics_ok
+  return reloaders.reload_explorer()
+end
+
 function M.dotfiles()
   filters.config.filter_dotfiles = not filters.config.filter_dotfiles
   return reloaders.reload_explorer()

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -39,6 +39,7 @@ Api.tree.collapse_all = require("nvim-tree.actions.tree-modifiers.collapse-all")
 Api.tree.expand_all = inject_node(require("nvim-tree.actions.tree-modifiers.expand-all").fn)
 Api.tree.toggle_gitignore_filter = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored
 Api.tree.toggle_git_clean_filter = require("nvim-tree.actions.tree-modifiers.toggles").git_clean
+Api.tree.toggle_no_buffer_filter = require("nvim-tree.actions.tree-modifiers.toggles").no_buffer
 Api.tree.toggle_custom_filter = require("nvim-tree.actions.tree-modifiers.toggles").custom
 Api.tree.toggle_hidden_filter = require("nvim-tree.actions.tree-modifiers.toggles").dotfiles
 Api.tree.toggle_help = require("nvim-tree.actions.tree-modifiers.toggles").help

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -38,6 +38,7 @@ Api.tree.search_node = require("nvim-tree.actions.finders.search-node").fn
 Api.tree.collapse_all = require("nvim-tree.actions.tree-modifiers.collapse-all").fn
 Api.tree.expand_all = inject_node(require("nvim-tree.actions.tree-modifiers.expand-all").fn)
 Api.tree.toggle_gitignore_filter = require("nvim-tree.actions.tree-modifiers.toggles").git_ignored
+Api.tree.toggle_git_clean_filter = require("nvim-tree.actions.tree-modifiers.toggles").git_clean
 Api.tree.toggle_custom_filter = require("nvim-tree.actions.tree-modifiers.toggles").custom
 Api.tree.toggle_hidden_filter = require("nvim-tree.actions.tree-modifiers.toggles").dotfiles
 Api.tree.toggle_help = require("nvim-tree.actions.tree-modifiers.toggles").help

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -12,10 +12,10 @@ local function get_type_from(type_, cwd)
   return type_ or (vim.loop.fs_stat(cwd) or {}).type
 end
 
-local function populate_children(handle, cwd, node, status)
+local function populate_children(handle, cwd, node, git_status)
   local node_ignored = node.git_status == "!!"
   local nodes_by_path = utils.bool_record(node.nodes, "absolute_path")
-  local bufinfo = vim.fn.getbufinfo { buflisted = 1 }
+  local filter_status = filters.prepare(git_status)
   while true do
     local name, t = vim.loop.fs_scandir_next(handle)
     if not name then
@@ -24,11 +24,7 @@ local function populate_children(handle, cwd, node, status)
 
     local abs = utils.path_join { cwd, name }
     t = get_type_from(t, abs)
-    if
-      not filters.should_ignore(abs, bufinfo)
-      and not filters.should_ignore_git(abs, status)
-      and not nodes_by_path[abs]
-    then
+    if not filters.should_filter(abs, filter_status) and not nodes_by_path[abs] then
       local child = nil
       if t == "directory" and vim.loop.fs_access(abs, "R") then
         child = builders.folder(node, abs, name)
@@ -43,7 +39,7 @@ local function populate_children(handle, cwd, node, status)
       if child then
         table.insert(node.nodes, child)
         nodes_by_path[child.absolute_path] = true
-        common.update_git_status(child, node_ignored, status)
+        common.update_git_status(child, node_ignored, git_status)
       end
     end
   end

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -23,11 +23,7 @@ local function populate_children(handle, cwd, node, status)
 
     local abs = utils.path_join { cwd, name }
     t = get_type_from(t, abs)
-    if
-      not filters.should_ignore(abs)
-      and not filters.should_ignore_git(abs, status.files)
-      and not nodes_by_path[abs]
-    then
+    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status) and not nodes_by_path[abs] then
       local child = nil
       if t == "directory" and vim.loop.fs_access(abs, "R") then
         child = builders.folder(node, abs, name)

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -15,7 +15,7 @@ end
 local function populate_children(handle, cwd, node, status)
   local node_ignored = node.git_status == "!!"
   local nodes_by_path = utils.bool_record(node.nodes, "absolute_path")
-  local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+  local bufinfo = vim.fn.getbufinfo { buflisted = 1 }
   while true do
     local name, t = vim.loop.fs_scandir_next(handle)
     if not name then

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -15,6 +15,7 @@ end
 local function populate_children(handle, cwd, node, status)
   local node_ignored = node.git_status == "!!"
   local nodes_by_path = utils.bool_record(node.nodes, "absolute_path")
+  local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
   while true do
     local name, t = vim.loop.fs_scandir_next(handle)
     if not name then
@@ -23,7 +24,11 @@ local function populate_children(handle, cwd, node, status)
 
     local abs = utils.path_join { cwd, name }
     t = get_type_from(t, abs)
-    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status) and not nodes_by_path[abs] then
+    if
+      not filters.should_ignore(abs, bufinfo)
+      and not filters.should_ignore_git(abs, status)
+      and not nodes_by_path[abs]
+    then
       local child = nil
       if t == "directory" and vim.loop.fs_access(abs, "R") then
         child = builders.folder(node, abs, name)

--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -27,12 +27,10 @@ function M.should_ignore(path, bufinfo, unloaded_bufnr)
     return false
   end
 
-  -- TODO exact match for files, ../ for dirs
-
   -- filter files with no open buffer and directories containing no open buffers
   if M.config.filter_no_buffer and type(bufinfo) == "table" then
     for _, buf in ipairs(bufinfo) do
-      if buf.name:find(path, 1, true) and buf.bufnr ~= unloaded_bufnr then
+      if buf.name == path or buf.name:find(path .. "/", 1, true) and buf.bufnr ~= unloaded_bufnr then
         return false
       end
     end

--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -16,9 +16,10 @@ end
 
 ---Check if the given path should be ignored.
 ---@param path string Absolute path
----@param bufinfo table vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+---@param bufinfo table vim.fn.getbufinfo { buflisted = 1 }
+---@param unloaded_bufnr number optional bufnr recently unloaded via BufUnload event
 ---@return boolean
-function M.should_ignore(path, bufinfo)
+function M.should_ignore(path, bufinfo, unloaded_bufnr)
   local basename = utils.path_basename(path)
 
   -- exclusions override all filters
@@ -26,10 +27,12 @@ function M.should_ignore(path, bufinfo)
     return false
   end
 
+  -- TODO exact match for files, ../ for dirs
+
   -- filter files with no open buffer and directories containing no open buffers
   if M.config.filter_no_buffer and type(bufinfo) == "table" then
     for _, buf in ipairs(bufinfo) do
-      if buf.name:find(path, 1, true) then
+      if buf.name:find(path, 1, true) and buf.bufnr ~= unloaded_bufnr then
         return false
       end
     end

--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -95,13 +95,11 @@ end
 --- git_status: reference
 --- unloaded_bufnr: copy
 --- bufinfo: empty unless no_buffer set: vim.fn.getbufinfo { buflisted = 1 }
---- buffer_severity: TODO
 function M.prepare(git_status, unloaded_bufnr)
   local status = {
     git_status = git_status or {},
     unloaded_bufnr = unloaded_bufnr,
     bufinfo = {},
-    buffer_severity = {},
   }
 
   if M.config.filter_no_buffer then
@@ -134,7 +132,6 @@ function M.setup(opts)
     filter_git_ignored = opts.git.ignore,
     filter_git_clean = opts.filters.git_clean,
     filter_no_buffer = opts.filters.no_buffer,
-    filter_diagnostics_ok = opts.filters.diagnostics_ok,
   }
 
   M.ignore_list = {}

--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -16,14 +16,27 @@ end
 
 ---Check if the given path should be ignored.
 ---@param path string Absolute path
+---@param bufinfo table vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
 ---@return boolean
-function M.should_ignore(path)
+function M.should_ignore(path, bufinfo)
   local basename = utils.path_basename(path)
 
+  -- exclusions override all filters
   if is_excluded(path) then
     return false
   end
 
+  -- filter files with no open buffer and directories containing no open buffers
+  if M.config.filter_no_buffer and type(bufinfo) == "table" then
+    for _, buf in ipairs(bufinfo) do
+      if buf.name:find(path, 1, true) then
+        return false
+      end
+    end
+    return true
+  end
+
+  -- filter dotfiles
   if M.config.filter_dotfiles then
     if basename:sub(1, 1) == "." then
       return true
@@ -34,6 +47,7 @@ function M.should_ignore(path)
     return false
   end
 
+  -- filter custom regexes
   local relpath = utils.path_relative(path, vim.loop.cwd())
   for pat, _ in pairs(M.ignore_list) do
     if vim.fn.match(relpath, pat) ~= -1 or vim.fn.match(basename, pat) ~= -1 then
@@ -56,20 +70,20 @@ function M.should_ignore_git(path, status)
     return false
   end
 
-  -- exclusions override all
+  -- exclusions override all filters
   if is_excluded(path) then
     return false
   end
 
-  -- default to clean
+  -- default status to clean
   local st = status.files[path] or status.dirs[path] or "  "
 
-  -- ignored overrides clean as they are effectively dirty
+  -- filter ignored; overrides clean as they are effectively dirty
   if M.config.filter_git_ignored and st == "!!" then
     return true
   end
 
-  -- clean last
+  -- filter clean
   if M.config.filter_git_clean and st == "  " then
     return true
   end
@@ -83,6 +97,7 @@ function M.setup(opts)
     filter_dotfiles = opts.filters.dotfiles,
     filter_git_ignored = opts.git.ignore,
     filter_git_clean = opts.filters.git_clean,
+    filter_no_buffer = opts.filters.no_buffer,
   }
 
   M.ignore_list = {}

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -44,6 +44,8 @@ function M.reload(node, status)
 
   local ps = log.profile_start("reload %s", node.absolute_path)
 
+  local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+
   if node.group_next then
     node.nodes = { node.group_next }
     node.group_next = nil
@@ -71,7 +73,7 @@ function M.reload(node, status)
 
     local abs = utils.path_join { cwd, name }
     t = t or (fs_stat_cached(abs) or {}).type
-    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status) then
+    if not filters.should_ignore(abs, bufinfo) and not filters.should_ignore_git(abs, status) then
       child_names[abs] = true
 
       -- Recreate node if type changes.

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -71,7 +71,7 @@ function M.reload(node, status)
 
     local abs = utils.path_join { cwd, name }
     t = t or (fs_stat_cached(abs) or {}).type
-    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status.files) then
+    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status) then
       child_names[abs] = true
 
       -- Recreate node if type changes.

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -34,7 +34,7 @@ local function update_parent_statuses(node, project, root)
   end
 end
 
-function M.reload(node, status)
+function M.reload(node, status, unloaded_bufnr)
   local cwd = node.link_to or node.absolute_path
   local handle = vim.loop.fs_scandir(cwd)
   if type(handle) == "string" then
@@ -44,7 +44,7 @@ function M.reload(node, status)
 
   local ps = log.profile_start("reload %s", node.absolute_path)
 
-  local bufinfo = vim.fn.getbufinfo { bufloaded = 1, buflisted = 1 }
+  local bufinfo = vim.fn.getbufinfo { buflisted = 1 }
 
   if node.group_next then
     node.nodes = { node.group_next }
@@ -73,7 +73,7 @@ function M.reload(node, status)
 
     local abs = utils.path_join { cwd, name }
     t = t or (fs_stat_cached(abs) or {}).type
-    if not filters.should_ignore(abs, bufinfo) and not filters.should_ignore_git(abs, status) then
+    if not filters.should_ignore(abs, bufinfo, unloaded_bufnr) and not filters.should_ignore_git(abs, status) then
       child_names[abs] = true
 
       -- Recreate node if type changes.

--- a/lua/nvim-tree/renderer/components/icons.lua
+++ b/lua/nvim-tree/renderer/components/icons.lua
@@ -85,7 +85,7 @@ end
 function M.setup(opts)
   M.config = opts.renderer.icons
 
-  M.devicons = pcall(require, "nvim-web-devicons") and require "nvim-web-devicons"
+  M.devicons = pcall(require, "nvim-web-devicons") and require "nvim-web-devicons" or nil
 end
 
 return M


### PR DESCRIPTION
fixes #1692

```help
    *nvim-tree.filters.git_clean*
    Do not show files with no git status. This will show ignored files when
    |nvim-tree.git.ignore| is set, as they are effectively dirty.
    Toggle via the `toggle_git_clean` action, default mapping `C`.
      Type: `boolean`, Default: `false`

    *nvim-tree.filters.no_buffer*
    Do not show files that have no listed buffer.
    Toggle via the `toggle_no_buffer` action, default mapping `B`.
      Type: `boolean`, Default: `false`
```

no_buffer's matching is a bit fuzzy and may miss some updates on buffer delete/wipe however it is not worth the performance cost of making it perfectly accurate.

- [ ] ~~`filters.diagnostics_ok`~~

Raised #1785 which may be completed separately.