### PR TITLE
fix: Implicit current buf on centralize selection

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -407,9 +407,8 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd("BufEnter", {
       pattern = "NvimTree_*",
       callback = function()
-        local bufnr = vim.api.nvim_get_current_buf()
         vim.schedule(function()
-          vim.api.nvim_buf_call(bufnr, function()
+          vim.api.nvim_buf_call(0, function()
             vim.cmd [[norm! zz]]
           end)
         end)


### PR DESCRIPTION
The recent implementation change to center the selected file produces a very odd error on my setup.
If I have `nvim-tree` open (for example, when opening an empty project) and then open a file using any other mean (e.g. Telescope)  a `Invalid buffer id: 1` error pops into my neovim.
Tweaking the code I've discovered the cause: the `centralize_selection` autocmd that runs when closing the tree tries to reads the `bufnr` of Telescope and then schedules the `zz` call, running after some milliseconds when the Telescope buffer is already killed.
By implicitly using the current buffer (by using `0` as a param) instead of explicitly retrieving it solves this problem. It'd probably also work if the retrieving is moved inside the `schedule` function, but haven't tried as I don't think it's better to do so.