### PR TITLE
Make create/paste add files to closed folders

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -171,7 +171,7 @@ Subsequent calls to setup will replace the previous configuration.
 >
     require("nvim-tree").setup { -- BEGIN_DEFAULT_OPTS
       auto_reload_on_write = true,
-      create_in_closed_folder = false,
+      create_in_closed_folder = true,
       disable_netrw = false,
       hijack_cursor = false,
       hijack_netrw = true,
@@ -437,7 +437,7 @@ Reloads the explorer every time a buffer is written to.
 *nvim-tree.create_in_closed_folder*
 Creating a file when the cursor is on a closed folder will set the
 path to be inside the closed folder, otherwise the parent folder.
-  Type: `boolean`, Default: `false`
+  Type: `boolean`, Default: `true`
 
 *nvim-tree.sort_by*
 Changes how files within the same directory are sorted.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -435,7 +435,7 @@ Reloads the explorer every time a buffer is written to.
   Type: `boolean`, Default: `true`
 
 *nvim-tree.create_in_closed_folder*
-Creating a file when the cursor is on a closed folder will set the
+Creating or pasting a file when the cursor is on a closed folder will set the
 path to be inside the closed folder, otherwise the parent folder.
   Type: `boolean`, Default: `true`
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -171,7 +171,6 @@ Subsequent calls to setup will replace the previous configuration.
 >
     require("nvim-tree").setup { -- BEGIN_DEFAULT_OPTS
       auto_reload_on_write = true,
-      create_in_closed_folder = true,
       disable_netrw = false,
       hijack_cursor = false,
       hijack_netrw = true,
@@ -432,11 +431,6 @@ in some scenarios (eg using vim startify).
 
 *nvim-tree.auto_reload_on_write*
 Reloads the explorer every time a buffer is written to.
-  Type: `boolean`, Default: `true`
-
-*nvim-tree.create_in_closed_folder*
-Creating or pasting a file when the cursor is on a closed folder will set the
-path to be inside the closed folder, otherwise the parent folder.
   Type: `boolean`, Default: `true`
 
 *nvim-tree.sort_by*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -447,7 +447,6 @@ end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
-  create_in_closed_folder = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -447,7 +447,7 @@ end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
-  create_in_closed_folder = false,
+  create_in_closed_folder = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -162,8 +162,6 @@ local function do_paste(node, action_type, action_fn)
   local is_dir = stats and stats.type == "directory"
   if not is_dir then
     destination = vim.fn.fnamemodify(destination, ":p:h")
-  elseif not (M.create_in_closed_folder or node.open) then
-    destination = vim.fn.fnamemodify(destination, ":p:h:h")
   end
 
   for _, _node in ipairs(clip) do
@@ -252,7 +250,6 @@ end
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
   M.enable_reload = not opts.filesystem_watchers.enable
-  M.create_in_closed_folder = opts.create_in_closed_folder
 end
 
 return M

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -160,10 +160,9 @@ local function do_paste(node, action_type, action_fn)
     return
   end
   local is_dir = stats and stats.type == "directory"
-
   if not is_dir then
     destination = vim.fn.fnamemodify(destination, ":p:h")
-  elseif not node.open then
+  elseif not (M.create_in_closed_folder or node.open) then
     destination = vim.fn.fnamemodify(destination, ":p:h:h")
   end
 
@@ -253,6 +252,7 @@ end
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
   M.enable_reload = not opts.filesystem_watchers.enable
+  M.create_in_closed_folder = opts.create_in_closed_folder
 end
 
 return M

--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -42,8 +42,7 @@ local function get_num_nodes(iter)
 end
 
 local function get_containing_folder(node)
-  local is_open = M.create_in_closed_folder or node.open
-  if node.nodes ~= nil and is_open then
+  if node.nodes ~= nil then
     return utils.path_add_trailing(node.absolute_path)
   end
   local node_name_size = #(node.name or "")
@@ -113,7 +112,6 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.create_in_closed_folder = opts.create_in_closed_folder
   M.enable_reload = not opts.filesystem_watchers.enable
 end
 

--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -305,7 +305,7 @@ local function removed(opts)
   end
 
   if opts.create_in_closed_folder then
-    notify.warn "create_in_closed_folder has been removed. Please use api.fs.create to add a file under your desired node."
+    notify.warn "create_in_closed_folder has been removed and is now the default behaviour. You may use api.fs.create to add a file under your desired node."
   end
   opts.create_in_closed_folder = nil
 end

--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -268,12 +268,6 @@ local g_migrations = {
       o.respect_buf_cwd = vim.g.nvim_tree_respect_buf_cwd == 1
     end
   end,
-
-  nvim_tree_create_in_closed_folder = function(o)
-    if o.create_in_closed_folder == nil then
-      o.create_in_closed_folder = vim.g.nvim_tree_create_in_closed_folder == 1
-    end
-  end,
 }
 
 local function refactored(opts)
@@ -309,6 +303,11 @@ local function removed(opts)
     notify.warn "focus_empty_on_setup has been removed and will be replaced by a new startup configuration. Please remove this option. See https://bit.ly/3yJch2T"
     opts.focus_empty_on_setup = nil
   end
+
+  if opts.create_in_closed_folder then
+    notify.warn "create_in_closed_folder has been removed. Please use api.fs.create to add a file under your desired node."
+  end
+  opts.create_in_closed_folder = nil
 end
 
 function M.migrate_legacy_options(opts)


### PR DESCRIPTION
Fixes #1800 
By default, creating or pasting a file with a closed directory selected in the tree should add the file inside of the directory. Alternately, to have them be created in the parent directory, the option `create_in_close_folder` can be set to `false`.