### PR TITLE
feat(event): add will rename node event.

### DIFF
--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -187,6 +187,7 @@ local function do_cut(source, destination)
     return true
   end
 
+  events._dispatch_will_rename_node(source, destination)
   local success, errmsg = vim.loop.fs_rename(source, destination)
   if not success then
     log.line("copy_paste", "do_cut fs_rename failed '%s'", errmsg)

--- a/lua/nvim-tree/actions/fs/rename-file.lua
+++ b/lua/nvim-tree/actions/fs/rename-file.lua
@@ -15,6 +15,7 @@ function M.rename(node, to)
     return
   end
 
+  events._dispatch_will_rename_node(node.absolute_path, to)
   local success, err = vim.loop.fs_rename(node.absolute_path, to)
   if not success then
     return notify.warn(err_fmt(node.absolute_path, to, err))

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -6,6 +6,7 @@ local global_handlers = {}
 
 M.Event = {
   Ready = "Ready",
+  WillRenameNode = "WillRenameNode",
   NodeRenamed = "NodeRenamed",
   TreeOpen = "TreeOpen",
   TreeClose = "TreeClose",
@@ -38,6 +39,11 @@ end
 --@private
 function M._dispatch_ready()
   dispatch(M.Event.Ready)
+end
+
+--@private
+function M._dispatch_will_rename_node(old_name, new_name)
+  dispatch(M.Event.WillRenameNode, { old_name = old_name, new_name = new_name })
 end
 
 --@private


### PR DESCRIPTION
Hey!
Some language servers support [workspace/willRenameFiles](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) request. It is used in order to automatically fix imports. 
Currently neovim does not support it. So plugins must be used if one wants to use this feature. [Here](https://github.com/neovim/neovim/issues/20784?ysclid=lbgzrup04p974657325) is an open issue in neovim repo.

Since I use `nvim-tree.lua` for all file manipulations I thought it would be cool to add `WillRenameNode` event and do [workspace/willRenameFiles](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) request in the handler.  