### PR TITLE
fix: Don't modify jumplist when `edit_in_place`.

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -265,7 +265,7 @@ end
 
 local function edit_in_current_buf(filename)
   require("nvim-tree.view").abandon_current_window()
-  vim.cmd("edit " .. vim.fn.fnameescape(filename))
+  vim.cmd("keepjumps edit " .. vim.fn.fnameescape(filename))
 end
 
 function M.fn(mode, filename)


### PR DESCRIPTION
closes https://github.com/nvim-tree/nvim-tree.lua/issues/1824