### PR TITLE
fix: clear clipboard error

### DIFF
--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -132,7 +132,7 @@ end
 function M.clear_clipboard()
   clipboard.move = {}
   clipboard.copy = {}
-  utils.notify.info "Clipboard has been emptied."
+  notify.info "Clipboard has been emptied."
 end
 
 function M.copy(node)


### PR DESCRIPTION
Calling `api.fs.clear_clipboard()` produces the following error:

```
E5108: Error executing lua: ...ed/nvim-tree.lua/lua/nvim-tree/actions/fs/copy-paste.lua:135: attempt to index field 'notify' (a nil value)
stack traceback:
        ...ed/nvim-tree.lua/lua/nvim-tree/actions/fs/copy-paste.lua:135: in function 'clear_clipboard'
        /Users/rosswilson/Home/nvim/plugin/tree.lua:34: in function </Users/rosswilson/Home/nvim/plugin/tree.lua:33>
```

Occurs when the clipboard is cleared and attempts to notify. Updated to remove `utils` and instead use `notify` directly 