### PR TITLE
fix(#1841): do not refresh on buffer events when not a file buffer

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -362,8 +362,12 @@ local function setup_autocommands(opts)
   end
 
   create_nvim_tree_autocmd("BufReadPost", {
-    callback = function()
-      if filters.config.filter_no_buffer or renderer.config.highlight_opened_files ~= "none" then
+    callback = function(data)
+      -- update opened file buffers
+      if
+        (filters.config.filter_no_buffer or renderer.config.highlight_opened_files ~= "none")
+        and vim.bo[data.buf].buftype == ""
+      then
         reloaders.reload_explorer()
       end
     end,
@@ -371,7 +375,11 @@ local function setup_autocommands(opts)
 
   create_nvim_tree_autocmd("BufUnload", {
     callback = function(data)
-      if filters.config.filter_no_buffer or renderer.config.highlight_opened_files ~= "none" then
+      -- update opened file buffers
+      if
+        (filters.config.filter_no_buffer or renderer.config.highlight_opened_files ~= "none")
+        and vim.bo[data.buf].buftype == ""
+      then
         reloaders.reload_explorer(nil, data.buf)
       end
     end,


### PR DESCRIPTION
fixes #1841

`vim.fn.filereadable` is expensive. Empty `buftype` should be good enough to detect whether it's a buffer that we can show/highlight.

Follows hotfix 4fc74ca32157ecb275e62647fbe9cff0b8e9b9c8

Follows on from #1830