### PR TITLE
feat(#1814): added cursorline config to DEFAULT_OPTS

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -681,6 +681,10 @@ Window / buffer setup.
     initially centralized, see |zz|.
       Type: `boolean`, Default: `false`
 
+    *nvim-tree.view.cursorline*
+    Enable |cursorline| in the tree window.
+      Type: `boolean`, Default: `true`
+
     *nvim-tree.view.hide_root_folder*
     Hide the path of the current working directory on top of the tree.
       Type: `boolean`, Default: `false`

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -190,6 +190,7 @@ Subsequent calls to setup will replace the previous configuration.
       view = {
         adaptive_size = false,
         centralize_selection = false,
+        cursorline = true,
         width = 30,
         hide_root_folder = false,
         side = "left",

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -499,6 +499,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   view = {
     adaptive_size = false,
     centralize_selection = false,
+    cursorline = true,
     width = 30,
     hide_root_folder = false,
     side = "left",

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -490,6 +490,7 @@ function M.setup(opts)
   M.View.hide_root_folder = options.hide_root_folder
   M.View.tab = opts.tab
   M.View.preserve_window_proportions = options.preserve_window_proportions
+  M.View.winopts.cursorline = options.cursorline
   M.View.winopts.number = options.number
   M.View.winopts.relativenumber = options.relativenumber
   M.View.winopts.signcolumn = options.signcolumn


### PR DESCRIPTION
Extends #1814

Currently, the config cursorline is set to `true` by default.

This behaviour can only be changed by a hacky way of listening to an event, as @alex-courtis mentioned that: "The user can change this default if they want via event".

This PR generalizes the configuration to be easier to config via the function `setup()`.