### PR TITLE
feat: async rename and create file

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -408,6 +408,12 @@ Subsequent calls to setup will replace the previous configuration.
           watcher = false,
         },
       },
+      experimental = {
+        async = {
+          create_file = false,
+          rename_file = false,
+        }
+      }
     } -- END_DEFAULT_OPTS
 <
 
@@ -1204,6 +1210,20 @@ Configuration for diagnostic logging.
 
         *nvim-tree.log.types.watcher*
         |nvim-tree.filesystem_watchers| processing, verbose.
+          Type: `boolean`, Default: `false`
+
+*nvim-tree.experimental*
+Configuration for experimental features.
+
+    *nvim-tree.experimental.async*
+    Control experimental async behavior.
+
+        *nvim-tree.experimental.async.create_file*
+        Toggle async behavior of create file operation.
+          Type: `boolean`, Default: `false`
+
+        *nvim-tree.experimental.async.rename_file*
+        Toggle async behavior of rename file operation.
           Type: `boolean`, Default: `false`
 
 ==============================================================================

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -733,6 +733,12 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       watcher = false,
     },
   },
+  experimental = {
+    async = {
+      create_file = false,
+      rename_file = false,
+    },
+  },
 } -- END_DEFAULT_OPTS
 
 local function merge_options(conf)

--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -97,6 +97,11 @@ local function create_file(new_file_path)
   if not is_error then
     notify.info(new_file_path .. " was properly created")
   end
+  if M.enable_async then
+    async.schedule()
+  end
+  -- synchronously refreshes as we can't wait for the watchers
+  find_file(utils.path_remove_trailing(new_file_path))
 end
 
 local function get_containing_folder(node)
@@ -135,15 +140,12 @@ function M.fn(node, cb)
 
     if M.enable_async then
       async.exec(create_file, new_file_path, function(err)
-        find_file(utils.path_remove_trailing(new_file_path))
         if cb then
           cb(err)
         end
       end)
     else
       create_file(new_file_path)
-      -- synchronously refreshes as we can't wait for the watchers
-      find_file(utils.path_remove_trailing(new_file_path))
     end
   end)
 end

--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -5,32 +5,28 @@ local core = require "nvim-tree.core"
 local notify = require "nvim-tree.notify"
 
 local find_file = require("nvim-tree.actions.finders.find-file").fn
+local async = require "nvim-tree.async"
 
 local M = {}
 
+---@async
 local function create_and_notify(file)
-  local ok, fd = pcall(vim.loop.fs_open, file, "w", 420)
-  if not ok then
+  local fd, err
+  if M.enable_async then
+    err, fd = async.call(vim.loop.fs_open, file, "w", 420)
+  else
+    fd, err = vim.loop.fs_open(file, "w", 420)
+  end
+  if err then
     notify.error("Couldn't create file " .. file)
     return
   end
-  vim.loop.fs_close(fd)
-  events._dispatch_file_created(file)
-end
-
-local function create_file(file)
-  if utils.file_exists(file) then
-    local prompt_select = "Overwrite " .. file .. " ?"
-    local prompt_input = prompt_select .. " y/n: "
-    lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
-      utils.clear_prompt()
-      if item_short == "y" then
-        create_and_notify(file)
-      end
-    end)
+  if M.enable_async then
+    async.call(vim.loop.fs_close, fd)
   else
-    create_and_notify(file)
+    vim.loop.fs_close(fd)
   end
+  events._dispatch_file_created(file)
 end
 
 local function get_num_nodes(iter)
@@ -41,6 +37,68 @@ local function get_num_nodes(iter)
   return i
 end
 
+local function create_file(new_file_path)
+  -- create a folder for each path element if the folder does not exist
+  -- if the answer ends with a /, create a file for the last path element
+  local is_last_path_file = not new_file_path:match(utils.path_separator .. "$")
+  local path_to_create = ""
+  local idx = 0
+
+  local num_nodes = get_num_nodes(utils.path_split(utils.path_remove_trailing(new_file_path)))
+  local is_error = false
+  for path in utils.path_split(new_file_path) do
+    idx = idx + 1
+    local p = utils.path_remove_trailing(path)
+    if #path_to_create == 0 and utils.is_windows then
+      path_to_create = utils.path_join { p, path_to_create }
+    else
+      path_to_create = utils.path_join { path_to_create, p }
+    end
+    if is_last_path_file and idx == num_nodes then
+      if M.enable_async then
+        async.schedule()
+      end
+      if utils.file_exists(new_file_path) then
+        local prompt_select = "Overwrite " .. new_file_path .. " ?"
+        local prompt_input = prompt_select .. " y/n: "
+        if M.enable_async then
+          local item_short = async.call(lib.prompt, prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" })
+          utils.clear_prompt()
+          if item_short == "y" then
+            create_and_notify(new_file_path)
+          end
+        else
+          lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
+            utils.clear_prompt()
+            if item_short == "y" then
+              create_and_notify(new_file_path)
+            end
+          end)
+        end
+      else
+        create_and_notify(new_file_path)
+      end
+    elseif not utils.file_exists(path_to_create) then
+      local err
+      if M.enable_async then
+        err = async.call(vim.loop.fs_mkdir, path_to_create, 493)
+      else
+        local _
+        _, err = vim.loop.fs_mkdir(path_to_create, 493)
+      end
+      if err then
+        notify.error("Could not create folder " .. path_to_create .. ": " .. err)
+        is_error = true
+        break
+      end
+      events._dispatch_folder_created(new_file_path)
+    end
+  end
+  if not is_error then
+    notify.info(new_file_path .. " was properly created")
+  end
+end
+
 local function get_containing_folder(node)
   if node.nodes ~= nil then
     return utils.path_add_trailing(node.absolute_path)
@@ -49,7 +107,8 @@ local function get_containing_folder(node)
   return node.absolute_path:sub(0, -node_name_size - 1)
 end
 
-function M.fn(node)
+--TODO: once async feature is finalized, use `async.wrap` instead of cb param
+function M.fn(node, cb)
   node = node and lib.get_last_group_node(node)
   if not node or node.name == ".." then
     node = {
@@ -74,45 +133,24 @@ function M.fn(node)
       return
     end
 
-    -- create a folder for each path element if the folder does not exist
-    -- if the answer ends with a /, create a file for the last path element
-    local is_last_path_file = not new_file_path:match(utils.path_separator .. "$")
-    local path_to_create = ""
-    local idx = 0
-
-    local num_nodes = get_num_nodes(utils.path_split(utils.path_remove_trailing(new_file_path)))
-    local is_error = false
-    for path in utils.path_split(new_file_path) do
-      idx = idx + 1
-      local p = utils.path_remove_trailing(path)
-      if #path_to_create == 0 and vim.fn.has "win32" == 1 then
-        path_to_create = utils.path_join { p, path_to_create }
-      else
-        path_to_create = utils.path_join { path_to_create, p }
-      end
-      if is_last_path_file and idx == num_nodes then
-        create_file(path_to_create)
-      elseif not utils.file_exists(path_to_create) then
-        local success = vim.loop.fs_mkdir(path_to_create, 493)
-        if not success then
-          notify.error("Could not create folder " .. path_to_create)
-          is_error = true
-          break
+    if M.enable_async then
+      async.exec(create_file, new_file_path, function(err)
+        find_file(utils.path_remove_trailing(new_file_path))
+        if cb then
+          cb(err)
         end
-        events._dispatch_folder_created(new_file_path)
-      end
+      end)
+    else
+      create_file(new_file_path)
+      -- synchronously refreshes as we can't wait for the watchers
+      find_file(utils.path_remove_trailing(new_file_path))
     end
-    if not is_error then
-      notify.info(new_file_path .. " was properly created")
-    end
-
-    -- synchronously refreshes as we can't wait for the watchers
-    find_file(utils.path_remove_trailing(new_file_path))
   end)
 end
 
 function M.setup(opts)
   M.enable_reload = not opts.filesystem_watchers.enable
+  M.enable_async = opts.experimental.async.create_file
 end
 
 return M

--- a/lua/nvim-tree/async.lua
+++ b/lua/nvim-tree/async.lua
@@ -1,0 +1,180 @@
+---Idea taken from: https://github.com/ms-jpq/lua-async-await
+local co = coroutine
+
+local M = {}
+
+---@type table<thread, boolean>
+local async_threads = {}
+
+---Execuate an asynchronous function
+---@param func function
+---@param ... any The arguments passed to `func`, plus a callback receives (err, ...result)
+function M.exec(func, ...)
+  local nargs = select("#", ...)
+  local args = { ... }
+  ---@type function
+  local cb = function() end
+  if nargs > 0 then
+    cb = args[nargs]
+    args[nargs] = nil
+  end
+
+  local thread = co.create(func)
+  async_threads[thread] = true
+
+  local function step(...)
+    local res = { co.resume(thread, ...) }
+    local ok = table.remove(res, 1)
+    local err_or_next = res[1]
+    if co.status(thread) ~= "dead" then
+      local _, err = xpcall(err_or_next, debug.traceback, step)
+      if err then
+        cb(err)
+      end
+    else
+      async_threads[thread] = nil
+      if ok then
+        cb(nil, unpack(res))
+      else
+        cb(debug.traceback(thread, err_or_next))
+      end
+    end
+  end
+
+  step(unpack(args))
+end
+
+---Test whether we are in async context
+---@return boolean
+function M.in_async()
+  local thread = co.running()
+  return async_threads[thread] ~= nil
+end
+
+---Wrap an asynchronous function to be directly called in synchronous context
+---@param func function
+---@param argc number The number of arguments the wrapped function accepts. Pass it if you want the returned function to receive an additional callback as final argument, and the signature of callback is the same as that of `async.exec`.
+---@return function
+function M.wrap(func, argc)
+  return function(...)
+    local args = { ... }
+    if argc == nil or #args == argc then
+      table.insert(args, function() end)
+    end
+    M.exec(func, unpack(args))
+  end
+end
+
+---Asynchronously call a function, which has callback as the last parameter (like luv apis)
+---@param func function
+---@param ... any
+---@return any
+function M.call(func, ...)
+  local args = { ... }
+  return co.yield(function(cb)
+    table.insert(args, cb)
+    func(unpack(args))
+  end)
+end
+
+---Execuate multiple asynchronous function simultaneously
+---@param ... fun()
+---@return table[] (err, ...result) tuples from every function
+function M.all(...)
+  local tasks = { ... }
+  if #tasks == 0 then
+    return {}
+  end
+
+  local results = {}
+  local finished = 0
+  return co.yield(function(cb)
+    for i, task in ipairs(tasks) do
+      M.exec(task, function(...)
+        finished = finished + 1
+        results[i] = { ... }
+        if finished == #tasks then
+          cb(results)
+        end
+      end)
+    end
+  end)
+end
+
+---Asynchronous `vim.schedule`
+function M.schedule()
+  return co.yield(function(cb)
+    vim.schedule(cb)
+  end)
+end
+
+---@class Interrupter
+---@field yield fun()
+---@field interval number
+---@field last number
+local Interrupter = {}
+
+---@return Interrupter
+function Interrupter.new(ms, yield)
+  local obj = {
+    interval = ms or 12,
+    last = vim.loop.hrtime(),
+    yield = yield or M.schedule,
+  }
+  setmetatable(obj, { __index = Interrupter })
+  return obj
+end
+
+function Interrupter:check()
+  local cur = vim.loop.hrtime()
+  if cur - self.last >= self.interval * 1000000 then
+    self:yield()
+    self.last = cur
+  end
+end
+
+M.Interrupter = Interrupter
+
+---This is useful for cancelling execution async function
+---@class AbortSignal
+---@field aborted boolean
+---@field reason any
+---@field private abort_cbs function[]
+local AbortSignal = {}
+
+---@return AbortSignal
+function AbortSignal.new()
+  local obj = {
+    aborted = false,
+    reason = nil,
+    abort_cbs = {},
+  }
+
+  setmetatable(obj, { __index = AbortSignal })
+  return obj
+end
+
+function AbortSignal:abort(reason)
+  if not self.aborted then
+    self.aborted = true
+    self.reason = reason
+    for _, cb in pairs(self.abort_cbs) do
+      cb(reason)
+    end
+  end
+end
+
+---@param cb function
+function AbortSignal:on_abort(cb)
+  table.insert(self.abort_cbs, cb)
+end
+
+function AbortSignal:throw_if_aborted()
+  if self.aborted then
+    error(self.reason)
+  end
+end
+
+M.AbortSignal = AbortSignal
+
+return M

--- a/lua/nvim-tree/marks/bulk-move.lua
+++ b/lua/nvim-tree/marks/bulk-move.lua
@@ -26,7 +26,7 @@ function M.bulk_move()
     for _, node in pairs(marks) do
       local head = vim.fn.fnamemodify(node.absolute_path, ":t")
       local to = utils.path_join { location, head }
-      FsRename.rename(node, to)
+      FsRename.rename(node, to, false)
     end
 
     if M.enable_reload then


### PR DESCRIPTION
Split of #1863.

New experimental options: 
```lua
  experimental = {
    async = {
      create_file = false,
      rename_file = false,
    },
  },
```

I select these two operations because their async version is nearly 1to1 copy of the original implementation, and the risk of breaking is bit lower. Also, I think we could turn on `rename_file` by default, and let users choose to enable `create_file` either if they feel well about the new async behavior. 