### PR TITLE
Fix nvim tree frozen with no name buffer

### DIFF
--- a/lua/nvim-tree/modified.lua
+++ b/lua/nvim-tree/modified.lua
@@ -9,10 +9,16 @@ function M.reload()
   local bufs = vim.fn.getbufinfo { bufmodified = true, buflisted = true }
   for _, buf in pairs(bufs) do
     local path = buf.name
-    M._record[path] = true
-    while path ~= vim.fn.getcwd() and path ~= "/" do
-      path = vim.fn.fnamemodify(path, ":h")
-      M._record[path] = true
+    if path ~= "" then -- not a [No Name] buffer
+      -- mark all the parent as modified as well
+      while
+        M._record[path] ~= true
+        -- no need to keep going if already recorded
+        -- This also prevents an infinite loop
+      do
+        M._record[path] = true
+        path = vim.fn.fnamemodify(path, ":h")
+      end
     end
   end
 end


### PR DESCRIPTION
closes #1878.

Thanks for raising this one @alex-courtis.

The issue turned out to be path never becoming `cwd` or `"/"` no matter how many `fnamemodify(path, ":h")`. This bug would've also appeared if a file out side of the cwd is modified on windows as path would've stopped at `"C:\\"` instead of `"/"`.

I've made it so that:
- ignore buffer for modified if `buf.name` is `""`
- Don't keep looking for parents if the path is already recorded as modified, or if `fnamemodify` didn't change the path.