### PR TITLE
Implement turning off y/n prompt for file deletion

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -374,7 +374,6 @@ Subsequent calls to setup will replace the previous configuration.
       },
       trash = {
         cmd = "gio trash",
-        require_confirm = true,
       },
       live_filter = {
         prefix = "[FILTER]: ",
@@ -389,6 +388,12 @@ Subsequent calls to setup will replace the previous configuration.
       },
       notify = {
         threshold = vim.log.levels.INFO,
+      },
+      ui = {
+        confirm = {
+          remove = true,
+          trash = true,
+        },
       },
       log = {
         enable = false,
@@ -993,10 +998,6 @@ Configuration options for trashing.
     The default is shipped with glib2 which is a common linux package.
       Type: `string`, Default: `"gio trash"`
 
-    *nvim-tree.trash.require_confirm*
-    Show a prompt before trashing takes place.
-      Type: `boolean`, Default: `true`
-
 *nvim-tree.actions*
 Configuration for various actions.
 
@@ -1145,6 +1146,20 @@ Configuration for notification.
     `WARNING`: non-fatal errors e.g. unable to system open a file.
     `INFO:`    information only e.g. file copy path confirmation.
     `DEBUG:`   not used.
+
+*nvim-tree.ui*
+General UI configuration.
+
+    *nvim-tree.ui.confirm*
+    Confirmation prompts.
+
+        *nvim-tree.ui.confirm.remove*
+        Prompt before removing.
+          Type: `boolean`, Default: `true`
+
+        *nvim-tree.ui.confirm.trash*  (previously `trash.require_confirm`)
+        Prompt before trashing.
+          Type: `boolean`, Default: `true`
 
 *nvim-tree.log*
 Configuration for diagnostic logging.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -495,12 +495,6 @@ local function setup_autocommands(opts)
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
-	ui = {
-		confirm = {
-		 node_deletion = true,
-		 trash = true,
-		},
-	},
   auto_reload_on_write = true,
   disable_netrw = false,
   hijack_cursor = false,
@@ -718,6 +712,12 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   notify = {
     threshold = vim.log.levels.INFO,
+  },
+  ui = {
+    confirm = {
+      remove = true,
+      trash = true,
+    },
   },
   log = {
     enable = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -501,7 +501,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
 		 trash = true,
 		},
 	},
-  file_deletion_confirmation = true,
   auto_reload_on_write = true,
   disable_netrw = false,
   hijack_cursor = false,
@@ -705,7 +704,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   trash = {
     cmd = "gio trash",
-    require_confirm = true,
   },
   live_filter = {
     prefix = "[FILTER]: ",

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -495,6 +495,7 @@ local function setup_autocommands(opts)
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
+  file_deletion_confirmation = true,
   auto_reload_on_write = true,
   disable_netrw = false,
   hijack_cursor = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -495,6 +495,12 @@ local function setup_autocommands(opts)
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
+	ui = {
+		confirm = {
+		 node_deletion = true,
+		 trash = true,
+		},
+	},
   file_deletion_confirmation = true,
   auto_reload_on_write = true,
   disable_netrw = false,

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -73,36 +73,47 @@ function M.fn(node)
   if node.name == ".." then
     return
   end
-  local prompt_select = "Remove " .. node.name .. " ?"
-  local prompt_input = prompt_select .. " y/n: "
-  lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
-    utils.clear_prompt()
-    if item_short == "y" then
-      if node.nodes ~= nil and not node.link_to then
-        local success = remove_dir(node.absolute_path)
-        if not success then
-          return notify.error("Could not remove " .. node.name)
-        end
-        events._dispatch_folder_removed(node.absolute_path)
-      else
-        local success = vim.loop.fs_unlink(node.absolute_path)
-        if not success then
-          return notify.error("Could not remove " .. node.name)
-        end
-        events._dispatch_file_removed(node.absolute_path)
-        clear_buffer(node.absolute_path)
+
+  local function do_remove()
+    if node.nodes ~= nil and not node.link_to then
+      local success = remove_dir(node.absolute_path)
+      if not success then
+        return notify.error("Could not remove " .. node.name)
       end
-      notify.info(node.absolute_path .. " was properly removed.")
-      if M.enable_reload then
-        require("nvim-tree.actions.reloaders.reloaders").reload_explorer()
+      events._dispatch_folder_removed(node.absolute_path)
+    else
+      local success = vim.loop.fs_unlink(node.absolute_path)
+      if not success then
+        return notify.error("Could not remove " .. node.name)
       end
+      events._dispatch_file_removed(node.absolute_path)
+      clear_buffer(node.absolute_path)
     end
-  end)
+    notify.info(node.absolute_path .. " was properly removed.")
+    if M.enable_reload then
+      require("nvim-tree.actions.reloaders.reloaders").reload_explorer()
+    end
+  end
+
+
+  if M.file_deletion_confirmation then
+    local prompt_select = "Remove " .. node.name .. " ?"
+    local prompt_input = prompt_select .. " y/n: "
+    lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
+      utils.clear_prompt()
+      if item_short == "y" then
+        do_remove()
+      end
+    end)
+  else
+    do_remove()
+  end
 end
 
 function M.setup(opts)
   M.enable_reload = not opts.filesystem_watchers.enable
   M.close_window = opts.actions.remove_file.close_window
+  M.file_deletion_confirmation = opts.file_deletion_confirmation
 end
 
 return M

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -95,8 +95,7 @@ function M.fn(node)
     end
   end
 
-
-  if M.config.ui.confirm.node_deletion then
+  if M.config.ui.confirm.remove then
     local prompt_select = "Remove " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/n: "
     lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
@@ -111,8 +110,8 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-	M.config = {}
-	M.config.ui = opts.ui or {}
+  M.config = {}
+  M.config.ui = opts.ui or {}
   M.enable_reload = not opts.filesystem_watchers.enable
   M.close_window = opts.actions.remove_file.close_window
 end

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -96,7 +96,7 @@ function M.fn(node)
   end
 
 
-  if M.file_deletion_confirmation then
+  if M.config.ui.confirm.node_deletion then
     local prompt_select = "Remove " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/n: "
     lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
@@ -111,9 +111,10 @@ function M.fn(node)
 end
 
 function M.setup(opts)
+	M.config = {}
+	M.config.ui = opts.ui or {}
   M.enable_reload = not opts.filesystem_watchers.enable
   M.close_window = opts.actions.remove_file.close_window
-  M.file_deletion_confirmation = opts.file_deletion_confirmation
 end
 
 return M

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -32,8 +32,8 @@ function M.fn(node)
     if M.config.trash.cmd == nil then
       M.config.trash.cmd = "trash"
     end
-    if M.config.trash.require_confirm == nil then
-      M.config.trash.require_confirm = true
+    if M.config.ui.confirm.trash == nil then
+      M.config.ui.confirm.trash = true
     end
   else
     notify.warn "Trash is currently a UNIX only feature!"
@@ -104,6 +104,7 @@ end
 function M.setup(opts)
   M.config = {}
   M.config.ui = opts.ui or {}
+  M.config.trash = opts.trash or {}
   M.enable_reload = not opts.filesystem_watchers.enable
 end
 

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -87,7 +87,7 @@ function M.fn(node)
     end
   end
 
-  if M.config.trash.require_confirm then
+  if M.config.ui.confirm.trash then
     local prompt_select = "Trash " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/n: "
     lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
@@ -103,7 +103,7 @@ end
 
 function M.setup(opts)
   M.config = {}
-  M.config.trash = opts.trash or {}
+  M.config.ui = opts.ui or {}
   M.enable_reload = not opts.filesystem_watchers.enable
 end
 

--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -27,6 +27,9 @@ local function refactored(opts)
 
   -- 2023/01/01
   utils.move_missing_val(opts, "update_focused_file", "debounce_delay", opts, "view", "debounce_delay", true)
+
+  -- 2023/01/08
+  utils.move_missing_val(opts, "trash", "require_confirm", opts, "ui.confirm", "trash", true)
 end
 
 local function removed(opts)


### PR DESCRIPTION
I have a suggestion to give users the option to disable the prompt when deleting a file. For example, when working in small folders, there is no particular need to double-check the file you are deleting