### PR TITLE
fix(#1916): suppress EPERM watcher failures on windows

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1706,5 +1706,6 @@ Windows WSL and PowerShell
 - Trash is unavailable
 - Executable file detection is disabled as this is non-performant and can
   freeze nvim
+- Some filesystem watcher error related to permissions will not be reported
 
  vim:tw=78:ts=4:sw=4:et:ft=help:norl:


### PR DESCRIPTION
fixes #1916 