### PR TITLE
fix: documentation error

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1273,7 +1273,7 @@ api.tree.close_in_all_tabs()           *nvim-tree.api.tree.close_in_all_tabs()*
 api.tree.focus()                                   *nvim-tree.api.tree.focus()*
     Focus the tree, opening it if necessary.
 
-api.tree.reload()                                  *nvim-tree.api.tree.focus()*
+api.tree.reload()                                  *nvim-tree.api.tree.reload()*
     Refresh the tree. Does nothing if closed.
 
 api.tree.change_root({path})                 *nvim-tree.api.tree.change_root()*


### PR DESCRIPTION
Tag `*nvim-tree.api.tree.foucs()*` wrongly set in `api.tree.reload()` in neovim documentation.

https://github.com/nvim-tree/nvim-tree.lua/blob/f1c2d6d3723947d822930e66cd4d3351a3c0370a/doc/nvim-tree-lua.txt#L1273-L1277