### PR TITLE
Add dynamic sizing padding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ require("nvim-tree").setup()
 require("nvim-tree").setup({
   sort_by = "case_sensitive",
   view = {
-    width = 30
+    width = 30,
     mappings = {
       list = {
         { key = "u", action = "dir_up" },

--- a/README.md
+++ b/README.md
@@ -74,14 +74,7 @@ require("nvim-tree").setup()
 require("nvim-tree").setup({
   sort_by = "case_sensitive",
   view = {
-    -- adaptive width (use width = number instead for static width)
-    width = {
-      min = 30
-      -- -1 means no limit
-      max = -1,
-      -- set total padding space when resizing (handy for custom status columns)
-      padding = 3
-    }
+    width = 30
     mappings = {
       list = {
         { key = "u", action = "dir_up" },

--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ require("nvim-tree").setup()
 require("nvim-tree").setup({
   sort_by = "case_sensitive",
   view = {
-    adaptive_size = true,
+    -- adaptive width (use width = number instead for static width)
+    width = {
+      min = 30
+      -- -1 means no limit
+      max = -1,
+      -- set total padding space when resizing (handy for custom status columns)
+      padding = 3
+    }
     mappings = {
       list = {
         { key = "u", action = "dir_up" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -734,16 +734,16 @@ Window / buffer setup.
       Type: `string | number | function | table`, Default: `30`
 
         *nvim-tree.view.width.min*
-          Minimum dynamic width.
-            Type: `string | number | function`, Default: `30`
+        Minimum dynamic width.
+          Type: `string | number | function`, Default: `30`
 
         *nvim-tree.view.width.max*
-          Maximum dynamic width, -1 for unbounded.
-            Type: `string | number | function`, Default: `-1`
+        Maximum dynamic width, -1 for unbounded.
+          Type: `string | number | function`, Default: `-1`
 
         *nvim-tree.view.width.padding*
-          extra padding to the right.
-            Type: `string | number | function`, Default: `1`
+        Extra padding to the right.
+          Type: `string | number | function`, Default: `1`
 
     *nvim-tree.view.side*
     Side of the tree, can be `"left"`, `"right"`.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -734,11 +734,16 @@ Window / buffer setup.
 
         *nvim-tree.view.width.min*
           Minimum dynamic width.
-          Type: `string | number | function`, Default: `30`
+            Type: `string | number | function`, Default: `30`
 
         *nvim-tree.view.width.max*
           Maximum dynamic width, -1 for unbounded.
-          Type: `string | number | function`, Default: `-1`
+            Type: `string | number | function`, Default: `-1`
+
+        *nvim-tree.view.width.padding*
+          dynamic padding when resizing. Useful for custom status-column
+          styles.
+            Type: `number`, Default: `3`
 
     *nvim-tree.view.side*
     Side of the tree, can be `"left"`, `"right"`.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1273,7 +1273,7 @@ api.tree.close_in_all_tabs()           *nvim-tree.api.tree.close_in_all_tabs()*
 api.tree.focus()                                   *nvim-tree.api.tree.focus()*
     Focus the tree, opening it if necessary.
 
-api.tree.reload()                                  *nvim-tree.api.tree.focus()*
+api.tree.reload()                                  *nvim-tree.api.tree.reload()*
     Refresh the tree. Does nothing if closed.
 
 api.tree.change_root({path})                 *nvim-tree.api.tree.change_root()*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -81,8 +81,8 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
     require("nvim-tree").setup({
       sort_by = "case_sensitive",
       view = {
+        width = 30,
         mappings = {
-          width = 30,
           list = {
             { key = "u", action = "dir_up" },
           },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -82,6 +82,7 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
       sort_by = "case_sensitive",
       view = {
         mappings = {
+          width = 30,
           list = {
             { key = "u", action = "dir_up" },
           },
@@ -741,9 +742,8 @@ Window / buffer setup.
             Type: `string | number | function`, Default: `-1`
 
         *nvim-tree.view.width.padding*
-          dynamic padding when resizing. Useful for custom status-column
-          styles.
-            Type: `number`, Default: `3`
+          extra padding to the right.
+            Type: `string | number | function`, Default: `1`
 
     *nvim-tree.view.side*
     Side of the tree, can be `"left"`, `"right"`.

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -6,6 +6,7 @@ local log = require "nvim-tree.log"
 
 local DEFAULT_MIN_WIDTH = 30
 local DEFAULT_MAX_WIDTH = -1
+local DEFAULT_PADDING = 3
 
 M.View = {
   adaptive_size = false,
@@ -250,7 +251,7 @@ local function grow()
   local starts_at = M.is_root_folder_visible(require("nvim-tree.core").get_cwd()) and 1 or 0
   local lines = vim.api.nvim_buf_get_lines(M.get_bufnr(), starts_at, -1, false)
   -- 1 column of right-padding to indicate end of path
-  local padding = 3
+  local padding = M.View.padding
   local resizing_width = M.View.initial_width - padding
   local max_width
 
@@ -517,6 +518,7 @@ function M.setup(opts)
     M.View.adaptive_size = true
     M.View.width = options.width.min or DEFAULT_MIN_WIDTH
     M.View.max_width = options.width.max or DEFAULT_MAX_WIDTH
+    M.View.padding = options.width.padding or DEFAULT_PADDING
   else
     M.View.adaptive_size = false
     M.View.width = options.width

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -6,7 +6,7 @@ local log = require "nvim-tree.log"
 
 local DEFAULT_MIN_WIDTH = 30
 local DEFAULT_MAX_WIDTH = -1
-local DEFAULT_PADDING = 3
+local DEFAULT_PADDING = 1
 
 M.View = {
   adaptive_size = false,
@@ -103,7 +103,6 @@ local function create_buffer(bufnr)
 end
 
 local function get_size(size)
-  size = size or M.View.width
   if type(size) == "number" then
     return size
   elseif type(size) == "function" then
@@ -112,6 +111,11 @@ local function get_size(size)
   local size_as_number = tonumber(size:sub(0, -2))
   local percent_as_decimal = size_as_number / 100
   return math.floor(vim.o.columns * percent_as_decimal)
+end
+
+local function get_width(size)
+  size = size or M.View.width
+  return get_size(size)
 end
 
 local move_tbl = {
@@ -250,8 +254,10 @@ end
 local function grow()
   local starts_at = M.is_root_folder_visible(require("nvim-tree.core").get_cwd()) and 1 or 0
   local lines = vim.api.nvim_buf_get_lines(M.get_bufnr(), starts_at, -1, false)
-  -- 1 column of right-padding to indicate end of path
-  local padding = M.View.padding
+  -- number of columns of right-padding to indicate end of path
+  local padding = get_size(M.View.padding)
+  print(padding)
+
   local resizing_width = M.View.initial_width - padding
   local max_width
 
@@ -259,7 +265,7 @@ local function grow()
   if M.View.max_width == -1 then
     max_width = -1
   else
-    max_width = get_size(M.View.max_width) - padding
+    max_width = get_width(M.View.max_width) - padding
   end
 
   for _, l in pairs(lines) do
@@ -311,7 +317,7 @@ function M.resize(size)
     return
   end
 
-  local new_size = get_size()
+  local new_size = get_width()
   vim.api.nvim_win_set_width(M.get_winnr(), new_size)
 
   events._dispatch_on_tree_resize(new_size)
@@ -524,7 +530,7 @@ function M.setup(opts)
     M.View.width = options.width
   end
 
-  M.View.initial_width = get_size()
+  M.View.initial_width = get_width()
 end
 
 return M


### PR DESCRIPTION
with https://github.com/neovim/neovim/pull/20621 merged in it is now possible to fully customize the status-column in nvim (the column on the left containing line-numbers, fold info, signs and borders).

A fair few cool implementations have popped up like:
- https://github.com/CKolkey/config/blob/master/nvim/after/plugin/statuscolumn.lua
- https://github.com/luukvbaal/statuscol.nvim
- and my own personal one (based on CKolkey's fantastic work) https://git.hendrikpeter.net/hendrikpeter/pico-vim/-/blob/main/lua/peva/status_column.lua

The problem with nvim-tree however is that dynamic sizing doesn't take the custom size of a status column into account and the end of file names get clipped off. This little patch should fix that (and give some examples to help other status_column modders get started).

Thanks for looking at this and thanks for making this amazing plugin, I've been using it for a while and I really like it!

## Some screenshots:

Before:
![Screenshot 2023-01-24 at 10 13 45](https://user-images.githubusercontent.com/3583395/214253182-56e5f8b4-5cdf-47c1-9e33-3969ffa8b9ab.png)

After:
![Screenshot 2023-01-24 at 10 13 18](https://user-images.githubusercontent.com/3583395/214253216-f011de04-3e94-4272-bc39-aa3d08a346a9.png)

