### PR TITLE
Changing window local options does not trigger OptionSet event

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -126,9 +126,12 @@ end
 
 local function set_window_options_and_buffer()
   pcall(vim.cmd, "buffer " .. M.get_bufnr())
+  local eventignore = vim.opt.eventignore:get()
+  vim.opt.eventignore = "all"
   for k, v in pairs(M.View.winopts) do
     vim.opt_local[k] = v
   end
+  vim.opt.eventignore = eventignore
 end
 
 local function open_win_config()


### PR DESCRIPTION
As mentioned here https://github.com/nvim-tree/nvim-tree.lua/issues/1942#issuecomment-1404397677, the `eventignore` solves the bug, that the `OptionSet` event is triggered when `nvim-tree` updates local window options.

This PR solves https://github.com/nvim-tree/nvim-tree.lua/issues/1942#issue-1554840995

