### PR TITLE
fix: remove printing padding message on startup

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -265,7 +265,6 @@ local function grow()
   if type(wininfo) == "table" and type(wininfo[1]) == "table" then
     padding = padding + wininfo[1].textoff
   end
-  print(padding)
 
   local resizing_width = M.View.initial_width - padding
   local max_width


### PR DESCRIPTION
when starting up, there is verbosing echo message for padding.
remove that message.

![image](https://user-images.githubusercontent.com/3125503/215261529-c6230945-c0ad-49c1-bc9f-ea694e6bf26d.png)

(the printing integer '3')