### PR TITLE
Remove what appears to have been a debug message.

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -265,7 +265,6 @@ local function grow()
   if type(wininfo) == "table" and type(wininfo[1]) == "table" then
     padding = padding + wininfo[1].textoff
   end
-  print(padding)
 
   local resizing_width = M.View.initial_width - padding
   local max_width


### PR DESCRIPTION
Looks like a debug message was left in to test for padding which causes a message to be displayed prior to the NvimTree view opening. 