### PR TITLE
fix(#2004): remove unintentional captures in path_to_matching_str

### DIFF
--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -11,10 +11,6 @@ M.is_wsl = vim.fn.has "wsl" == 1
 -- false for WSL
 M.is_windows = vim.fn.has "win32" == 1 or vim.fn.has "win32unix" == 1
 
-function M.path_to_matching_str(path)
-  return path:gsub("(%-)", "(%%-)"):gsub("(%.)", "(%%.)"):gsub("(%_)", "(%%_)")
-end
-
 function M.str_find(haystack, needle)
   return vim.fn.stridx(haystack, needle) ~= -1
 end
@@ -59,7 +55,14 @@ end
 ---@param relative_to string
 ---@return string
 function M.path_relative(path, relative_to)
-  local p, _ = path:gsub("^" .. M.path_to_matching_str(M.path_add_trailing(relative_to)), "")
+  local _, r = path:find(M.path_add_trailing(relative_to), 1, true)
+  local p = path
+  if r then
+    -- take the relative path starting after '/'
+    -- if somehow given a completely matching path, 
+    -- returns ""
+    p = path:sub(r+1)
+  end
   return p
 end
 

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -59,9 +59,9 @@ function M.path_relative(path, relative_to)
   local p = path
   if r then
     -- take the relative path starting after '/'
-    -- if somehow given a completely matching path, 
+    -- if somehow given a completely matching path,
     -- returns ""
-    p = path:sub(r+1)
+    p = path:sub(r + 1)
   end
   return p
 end


### PR DESCRIPTION
fixes #2004

The captures creates a limit where input path cannot have more than 32 special charactors ( `.`  , `_` or `-`)