### PR TITLE
fix(#1961): cycle detection on find file refresh, fix regex pattern matching on paths, do not refresh if the node is present

### DIFF
--- a/lua/nvim-tree/actions/finders/find-file.lua
+++ b/lua/nvim-tree/actions/finders/find-file.lua
@@ -30,8 +30,10 @@ function M.fn(fname)
 
   local profile = log.profile_start("find file %s", fname_real)
 
-  -- we cannot wait for watchers
-  reload.refresh_nodes_for_path(vim.fn.fnamemodify(fname_real, ":h"))
+  -- we cannot wait for watchers to populate a new node
+  if utils.get_node_from_path(fname_real) == nil then
+    reload.refresh_nodes_for_path(vim.fn.fnamemodify(fname_real, ":h"))
+  end
 
   local line = core.get_nodes_starting_line()
 


### PR DESCRIPTION
fixes #1961 

Second attempt.

Direct fixes:
* avoid cycles for real and linked paths
* match paths with regex magic characters

Opportunistic fixes:
* find file does not refresh if the file is present in the tree