### PR TITLE
#2011 api.tree.find file feature parity

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1332,8 +1332,7 @@ api.tree.find_file({opts})                     *nvim-tree.api.tree.find_file()*
     • {opts} (table) optional parameters with boolean defaults
 
     Options: ~
-    • {path}           (string)         absolute path to find
-    • {bufnr}          (number)         buffer to find, overrides {path}
+    • {buf}            (string|number)  absolute/relative path OR bufnr to find
     • {open}           (boolean, false) open the tree
     • {current_window} (boolean, false) open the tree in the current window
     • {update_root}    (boolean, false) see |nvim-tree.update_focused_file.update_root|

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1324,11 +1324,20 @@ api.tree.get_nodes()                           *nvim-tree.api.tree.get_nodes()*
     Return: ~
       table of nodes
 
-api.tree.find_file({path})                     *nvim-tree.api.tree.find_file()*
-    Find and focus a file or folder in the tree.
+api.tree.find_file({opts})                     *nvim-tree.api.tree.find_file()*
+    Find and focus a file or folder in the tree. Finds current buffer unless
+    otherwise specified.
 
     Parameters: ~
-      • {path} (string) absolute path
+    • {opts} (table) optional parameters with boolean defaults
+
+    Options: ~
+    • {path}           (string)         absolute path to find
+    • {bufnr}          (number)         buffer to find, overrides {path}
+    • {open}           (boolean, false) open the tree
+    • {current_window} (boolean, false) open the tree in the current window
+    • {update_root}    (boolean, false) see |nvim-tree.update_focused_file.update_root|
+    • {focus}          (boolean, false) focus the tree
 
 api.tree.search_node()                       *nvim-tree.api.tree.search_node()*
     Open the search dialogue as per the search_node action.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -103,23 +103,35 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
 
 *:NvimTreeOpen*
 
-    opens the tree. Takes an optional path argument.
+    Opens the tree. See |nvim-tree.api.tree.open()|
+
+    Calls: `api.tree.open({ path = "<arg>" })`
 
 *:NvimTreeClose*
 
-    closes the tree
+    Closes the tree. See |nvim-tree.api.tree.close()|
+
+    Calls: `api.tree.close()`
 
 *:NvimTreeToggle*
 
-    open or close the tree. Takes an optional path argument.
+    Open or close the tree. See |nvim-tree.api.tree.toggle()|
+
+    Calls: `api.tree.toggle({ path = "<arg>" })`
 
 *:NvimTreeFocus*
 
-    open the tree if it is closed, and then focus on the tree
+    Open the tree if it is closed, and then focus on the tree.
+
+    See |nvim-tree.api.tree.toggle()|
+
+    Calls: `api.tree.focus()`
 
 *:NvimTreeRefresh*
 
-    refresh the tree
+    Refresh the tree. See |nvim-tree.api.tree.reload()|
+
+    Calls: `api.tree.reload()`
 
 *:NvimTreeFindFile*
 
@@ -131,6 +143,10 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
 
     Invoke with a bang `:NvimTreeFindFile!` to update the root.
 
+    See |nvim-tree.api.tree.find_file()|
+
+    Calls: `api.tree.find_file { open = true, update_root = <bang> }`
+
 *:NvimTreeFindFileToggle*
 
     close the tree or change the cursor in the tree for the current bufname,
@@ -139,9 +155,17 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
 
     Invoke with a bang `:NvimTreeFindFileToggle!` to update the root.
 
+    See |nvim-tree.api.tree.toggle()|
+
+    Calls: `api.tree.toggle { find_file = true, focus = true, path = "<arg>", update_root = <bang> }`
+
 *:NvimTreeClipboard*
 
     Print clipboard content for both cut and copy
+
+    See |nvim-tree.api.fs.print_clipboard()|
+
+    Calls: `api.fs.print_clipboard()`
 
 *:NvimTreeResize*
 
@@ -155,10 +179,18 @@ Setup should be run in a lua file or in a |lua-heredoc| if using in a vim file.
 
     Collapses the nvim-tree recursively.
 
+    See |nvim-tree.api.tree.collapse_all()|
+
+    Calls: `api.tree.collapse_all(false)`
+
 *:NvimTreeCollapseKeepBuffers*
 
     Collapses the nvim-tree recursively, but keep the directories open, which are
     used in an open buffer.
+
+    See |nvim-tree.api.tree.collapse_all()|
+
+    Calls: `api.tree.collapse_all(true)`
 
 *:NvimTreeGenerateOnAttach*
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1293,7 +1293,8 @@ api.tree.open({opts})                              *nvim-tree.api.tree.open()*
       • {path}           (string)         root directory for the tree
       • {current_window} (boolean, false) open the tree in the current window
       • {find_file}      (boolean, false) find the current buffer
-      • {update_root}    (boolean, false) see |nvim-tree.update_focused_file.update_root|
+      • {update_root}    (boolean, false) requires {find_file}, see
+                                          |nvim-tree.update_focused_file.update_root|
 
 api.tree.toggle({opts})                          *nvim-tree.api.tree.toggle()*
     Open or close the tree.
@@ -1305,7 +1306,8 @@ api.tree.toggle({opts})                          *nvim-tree.api.tree.toggle()*
       • {path}           (string)         root directory for the tree
       • {current_window} (boolean, false) open the tree in the current window
       • {find_file}      (boolean, false) find the current buffer
-      • {update_root}    (boolean, false) see |nvim-tree.update_focused_file.update_root|
+      • {update_root}    (boolean, false) requires {find_file}, see
+                                          |nvim-tree.update_focused_file.update_root|
       • {focus}          (boolean, true)  focus the tree when opening
 
 api.tree.close()                                   *nvim-tree.api.tree.close()*
@@ -1366,7 +1368,7 @@ api.tree.find_file({opts})                     *nvim-tree.api.tree.find_file()*
     Options: ~
     • {buf}            (string|number)  absolute/relative path OR bufnr to find
     • {open}           (boolean, false) open the tree
-    • {current_window} (boolean, false) open the tree in the current window
+    • {current_window} (boolean, false) requires {open}, open in the current window
     • {update_root}    (boolean, false) see |nvim-tree.update_focused_file.update_root|
     • {focus}          (boolean, false) focus the tree
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -15,6 +15,9 @@ local filters = require "nvim-tree.explorer.filters"
 local modified = require "nvim-tree.modified"
 local notify = require "nvim-tree.notify"
 local keymap_legacy = require "nvim-tree.keymap-legacy"
+local find_file = require "nvim-tree.actions.tree.find-file"
+local toggle = require "nvim-tree.actions.tree.toggle"
+local open = require "nvim-tree.actions.tree.open"
 
 local _config = {}
 
@@ -26,47 +29,6 @@ local M = {
 function M.focus()
   M.open()
   view.focus()
-end
-
-function M.change_root(filepath, bufnr)
-  -- skip if current file is in ignore_list
-  local ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
-  for _, value in pairs(_config.update_focused_file.ignore_list) do
-    if utils.str_find(filepath, value) or utils.str_find(ft, value) then
-      return
-    end
-  end
-
-  local cwd = core.get_cwd()
-  local vim_cwd = vim.fn.getcwd()
-
-  -- test if in vim_cwd
-  if utils.path_relative(filepath, vim_cwd) ~= filepath then
-    if vim_cwd ~= cwd then
-      change_dir.fn(vim_cwd)
-    end
-    return
-  end
-  -- test if in cwd
-  if utils.path_relative(filepath, cwd) ~= filepath then
-    return
-  end
-
-  -- otherwise test M.init_root
-  if _config.prefer_startup_root and utils.path_relative(filepath, M.init_root) ~= filepath then
-    change_dir.fn(M.init_root)
-    return
-  end
-  -- otherwise root_dirs
-  for _, dir in pairs(_config.root_dirs) do
-    dir = vim.fn.fnamemodify(dir, ":p")
-    if utils.path_relative(filepath, dir) ~= filepath then
-      change_dir.fn(dir)
-      return
-    end
-  end
-  -- finally fall back to the folder containing the file
-  change_dir.fn(vim.fn.fnamemodify(filepath, ":p:h"))
 end
 
 function M.open_replacing_current_buffer(cwd)
@@ -111,122 +73,6 @@ local function find_existing_windows()
     local buf = vim.api.nvim_win_get_buf(win)
     return vim.api.nvim_buf_get_name(buf):match "NvimTree" ~= nil
   end, vim.api.nvim_list_wins())
-end
-
-local function is_file_readable(fname)
-  local stat = vim.loop.fs_stat(fname)
-  return stat and stat.type == "file" and vim.loop.fs_access(fname, "R")
-end
-
-local function find_file(with_open, bufnr, bang)
-  if not with_open and not core.get_explorer() then
-    return
-  end
-
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-  if not vim.api.nvim_buf_is_valid(bufnr) then
-    return
-  end
-  local bufname = vim.api.nvim_buf_get_name(bufnr)
-  local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ":p"))
-  if not is_file_readable(filepath) then
-    return
-  end
-
-  if with_open then
-    M.open()
-  end
-
-  if bang or _config.update_focused_file.update_root then
-    M.change_root(filepath, bufnr)
-  end
-
-  require("nvim-tree.actions.finders.find-file").fn(filepath)
-end
-
----@deprecated 2022/12/16
-function M.find_file(with_open, bufnr, bang)
-  vim.notify_once(
-    "require('nvim-tree').find_file is not API and will soon be unavailable. Please use api.tree.find_file as per :help nvim-tree-api",
-    vim.log.levels.WARN
-  )
-  find_file(with_open, bufnr, bang)
-end
-
----Open the tree, focusing if already open.
----@param opts ApiTreeOpenOpts|nil|string
-function M.open(opts)
-  -- legacy arguments
-  if type(opts) == "string" then
-    opts = {
-      path = opts,
-    }
-  end
-
-  opts = opts or {}
-
-  local previous_buf = vim.api.nvim_get_current_buf()
-
-  -- sanitise path
-  if type(opts.path) ~= "string" or vim.fn.isdirectory(opts.path) == 0 then
-    opts.path = nil
-  end
-
-  if view.is_visible() then
-    lib.set_target_win()
-    view.focus()
-  else
-    lib.open(opts)
-  end
-
-  if _config.update_focused_file.enable or opts.find_file then
-    find_file(false, previous_buf, opts.update_root)
-  end
-end
-
----Toggle the tree.
----@param opts ApiTreeToggleOpts|nil|boolean
-function M.toggle(opts, no_focus, cwd, bang)
-  -- legacy arguments
-  if type(opts) == "boolean" then
-    opts = {
-      find_file = opts,
-    }
-    if type(cwd) == "string" then
-      opts.path = cwd
-    end
-    if type(no_focus) == "boolean" then
-      opts.focus = not no_focus
-    end
-    if type(bang) == "boolean" then
-      opts.update_root = bang
-    end
-  end
-
-  opts = opts or {}
-
-  -- defaults
-  if opts.focus == nil then
-    opts.focus = true
-  end
-
-  -- sanitise path
-  if type(opts.path) ~= "string" or vim.fn.isdirectory(opts.path) == 0 then
-    opts.path = nil
-  end
-
-  if view.is_visible() then
-    view.close()
-  else
-    local previous_buf = vim.api.nvim_get_current_buf()
-    M.open { path = opts.path, current_window = opts.current_window }
-    if _config.update_focused_file.enable or opts.find_file then
-      find_file(false, previous_buf, opts.update_root)
-    end
-    if not opts.focus then
-      vim.cmd "noautocmd wincmd p"
-    end
-  end
 end
 
 M.resize = view.resize
@@ -353,22 +199,23 @@ local function manage_netrw(disable_netrw, hijack_netrw)
   end
 end
 
+-- TODO #1212 change to API
 local function setup_vim_commands()
   vim.api.nvim_create_user_command("NvimTreeOpen", function(res)
-    M.open { path = res.args }
+    open.fn { path = res.args }
   end, { nargs = "?", complete = "dir" })
   vim.api.nvim_create_user_command("NvimTreeClose", view.close, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeToggle", function(res)
-    M.toggle { find_file = false, focus = true, path = res.args, update_root = false }
+    toggle.fn { find_file = false, focus = true, path = res.args, update_root = false }
   end, { nargs = "?", complete = "dir" })
   vim.api.nvim_create_user_command("NvimTreeFocus", M.focus, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeFindFile", function(res)
-    find_file(true, nil, res.bang)
+    find_file.fn(true, nil, res.bang)
   end, { bang = true, bar = true })
   vim.api.nvim_create_user_command("NvimTreeFindFileToggle", function(res)
-    M.toggle { find_file = true, focus = true, path = res.args, update_root = res.bang }
+    toggle.fn { find_file = true, focus = true, path = res.args, update_root = res.bang }
   end, { bang = true, nargs = "?", complete = "dir" })
   vim.api.nvim_create_user_command("NvimTreeResize", function(res)
     M.resize(res.args)

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -27,7 +27,7 @@ local M = {
 }
 
 function M.focus()
-  M.open()
+  open.fn()
   view.focus()
 end
 
@@ -164,6 +164,9 @@ function M.on_enter(netrw_disabled)
     vim.api.nvim_set_current_win(existing_tree_wins[1])
   end
 
+  log.line("dev", "should_focus_other_window %s", should_focus_other_window)
+  log.line("dev", "should_find %s", should_find)
+
   if should_open or should_hijack or existing_tree_wins[1] ~= nil then
     local cwd
     if is_dir then
@@ -177,11 +180,12 @@ function M.on_enter(netrw_disabled)
     if should_focus_other_window then
       vim.cmd "noautocmd wincmd p"
       if should_find then
-        find_file(false)
+        find_file.fn(false)
       end
     end
   end
   M.initialized = true
+  log.line("dev", "on_enter DONE")
 end
 
 function M.get_config()
@@ -199,7 +203,7 @@ local function manage_netrw(disable_netrw, hijack_netrw)
   end
 end
 
--- TODO #1212 change to API
+-- TODO #2011 change to API
 local function setup_vim_commands()
   vim.api.nvim_create_user_command("NvimTreeOpen", function(res)
     open.fn { path = res.args }
@@ -231,7 +235,7 @@ function M.change_dir(name)
   change_dir.fn(name)
 
   if _config.update_focused_file.enable then
-    find_file(false)
+    find_file.fn(false)
   end
 end
 
@@ -320,7 +324,7 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd("BufEnter", {
       callback = function()
         utils.debounce("BufEnter:find_file", opts.view.debounce_delay, function()
-          find_file(false)
+          find_file.fn(false)
         end)
       end,
     })

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -31,6 +31,47 @@ function M.focus()
   view.focus()
 end
 
+function M.change_root(filepath, bufnr)
+  -- skip if current file is in ignore_list
+  local ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
+  for _, value in pairs(_config.update_focused_file.ignore_list) do
+    if utils.str_find(filepath, value) or utils.str_find(ft, value) then
+      return
+    end
+  end
+
+  local cwd = core.get_cwd()
+  local vim_cwd = vim.fn.getcwd()
+
+  -- test if in vim_cwd
+  if utils.path_relative(filepath, vim_cwd) ~= filepath then
+    if vim_cwd ~= cwd then
+      change_dir.fn(vim_cwd)
+    end
+    return
+  end
+  -- test if in cwd
+  if utils.path_relative(filepath, cwd) ~= filepath then
+    return
+  end
+
+  -- otherwise test M.init_root
+  if _config.prefer_startup_root and utils.path_relative(filepath, M.init_root) ~= filepath then
+    change_dir.fn(M.init_root)
+    return
+  end
+  -- otherwise root_dirs
+  for _, dir in pairs(_config.root_dirs) do
+    dir = vim.fn.fnamemodify(dir, ":p")
+    if utils.path_relative(filepath, dir) ~= filepath then
+      change_dir.fn(dir)
+      return
+    end
+  end
+  -- finally fall back to the folder containing the file
+  change_dir.fn(vim.fn.fnamemodify(filepath, ":p:h"))
+end
+
 function M.open_replacing_current_buffer(cwd)
   if view.is_visible() then
     return

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -8,15 +8,12 @@ local change_dir = require "nvim-tree.actions.root.change-dir"
 local legacy = require "nvim-tree.legacy"
 local core = require "nvim-tree.core"
 local reloaders = require "nvim-tree.actions.reloaders.reloaders"
-local copy_paste = require "nvim-tree.actions.fs.copy-paste"
-local collapse_all = require "nvim-tree.actions.tree-modifiers.collapse-all"
 local git = require "nvim-tree.git"
 local filters = require "nvim-tree.explorer.filters"
 local modified = require "nvim-tree.modified"
 local notify = require "nvim-tree.notify"
 local keymap_legacy = require "nvim-tree.keymap-legacy"
 local find_file = require "nvim-tree.actions.tree.find-file"
-local toggle = require "nvim-tree.actions.tree.toggle"
 local open = require "nvim-tree.actions.tree.open"
 
 local _config = {}
@@ -245,30 +242,39 @@ local function manage_netrw(disable_netrw, hijack_netrw)
   end
 end
 
--- TODO #2011 change to API
 local function setup_vim_commands()
   vim.api.nvim_create_user_command("NvimTreeOpen", function(res)
-    open.fn { path = res.args }
+    require("nvim-tree.api").tree.open { path = res.args }
   end, { nargs = "?", complete = "dir" })
-  vim.api.nvim_create_user_command("NvimTreeClose", view.close, { bar = true })
+  vim.api.nvim_create_user_command("NvimTreeClose", function()
+    require("nvim-tree.api").tree.close()
+  end, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeToggle", function(res)
-    toggle.fn { find_file = false, focus = true, path = res.args, update_root = false }
+    require("nvim-tree.api").tree.toggle { find_file = false, focus = true, path = res.args, update_root = false }
   end, { nargs = "?", complete = "dir" })
-  vim.api.nvim_create_user_command("NvimTreeFocus", M.focus, { bar = true })
-  vim.api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, { bar = true })
-  vim.api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, { bar = true })
+  vim.api.nvim_create_user_command("NvimTreeFocus", function()
+    require("nvim-tree.api").tree.focus()
+  end, { bar = true })
+  vim.api.nvim_create_user_command("NvimTreeRefresh", function()
+    require("nvim-tree.api").tree.reload()
+  end, { bar = true })
+  vim.api.nvim_create_user_command("NvimTreeClipboard", function()
+    require("nvim-tree.api").fs.print_clipboard()
+  end, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeFindFile", function(res)
-    find_file.fn { open = true, update_root = res.bang }
+    require("nvim-tree.api").tree.find_file { open = true, update_root = res.bang }
   end, { bang = true, bar = true })
   vim.api.nvim_create_user_command("NvimTreeFindFileToggle", function(res)
-    toggle.fn { find_file = true, focus = true, path = res.args, update_root = res.bang }
+    require("nvim-tree.api").tree.toggle { find_file = true, focus = true, path = res.args, update_root = res.bang }
   end, { bang = true, nargs = "?", complete = "dir" })
   vim.api.nvim_create_user_command("NvimTreeResize", function(res)
     M.resize(res.args)
   end, { nargs = 1, bar = true })
-  vim.api.nvim_create_user_command("NvimTreeCollapse", collapse_all.fn, { bar = true })
+  vim.api.nvim_create_user_command("NvimTreeCollapse", function()
+    require("nvim-tree.api").tree.collapse_all(false)
+  end, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeCollapseKeepBuffers", function()
-    collapse_all.fn(true)
+    require("nvim-tree.api").tree.collapse_all(true)
   end, { bar = true })
   vim.api.nvim_create_user_command("NvimTreeGenerateOnAttach", keymap_legacy.cmd_generate_on_attach, {})
 end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -205,9 +205,6 @@ function M.on_enter(netrw_disabled)
     vim.api.nvim_set_current_win(existing_tree_wins[1])
   end
 
-  log.line("dev", "should_focus_other_window %s", should_focus_other_window)
-  log.line("dev", "should_find %s", should_find)
-
   if should_open or should_hijack or existing_tree_wins[1] ~= nil then
     local cwd
     if is_dir then
@@ -226,7 +223,6 @@ function M.on_enter(netrw_disabled)
     end
   end
   M.initialized = true
-  log.line("dev", "on_enter DONE")
 end
 
 function M.get_config()

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -11,6 +11,9 @@ function M.setup(opts)
   require("nvim-tree.actions.fs.remove-file").setup(opts)
   require("nvim-tree.actions.fs.copy-paste").setup(opts)
   require("nvim-tree.actions.tree-modifiers.expand-all").setup(opts)
+  require("nvim-tree.actions.tree.find-file").setup(opts)
+  require("nvim-tree.actions.tree.open").setup(opts)
+  require("nvim-tree.actions.tree.toggle").setup(opts)
 end
 
 return M

--- a/lua/nvim-tree/actions/tree/find-file.lua
+++ b/lua/nvim-tree/actions/tree/find-file.lua
@@ -1,31 +1,18 @@
 local core = require "nvim-tree.core"
 local lib = require "nvim-tree.lib"
-local utils = require "nvim-tree.utils"
 local view = require "nvim-tree.view"
+local finders_find_file = require "nvim-tree.actions.finders.find-file"
 
 local M = {}
 
-local function is_file_readable(fname)
-  local stat = vim.loop.fs_stat(fname)
-  return stat and stat.type == "file" and vim.loop.fs_access(fname, "R")
-end
-
 --- Find file or buffer
---- @param opts ApiTreeFindFileOpts|nil|boolean legacy -> opts.open
---- @param bufnr number|nil legacy -> opts.bufnr
---- @param bang boolean|nil legacy -> opts.update_root
-function M.fn(opts, bufnr, bang)
+--- @param opts ApiTreeFindFileOpts|nil|boolean legacy -> opts.buf
+function M.fn(opts)
   -- legacy arguments
-  if type(opts) == "boolean" then
+  if type(opts) == "string" then
     opts = {
-      open = opts,
+      buf = opts,
     }
-    if type(bufnr) == "number" then
-      opts.bufnr = bufnr
-    end
-    if type(bang) == "boolean" then
-      opts.update_root = bang
-    end
   end
   opts = opts or {}
 
@@ -34,34 +21,43 @@ function M.fn(opts, bufnr, bang)
     return
   end
 
-  -- determine the (current) buffer path
-  opts.bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-  if not vim.api.nvim_buf_is_valid(opts.bufnr) then
-    return
-  end
-  local bufname = vim.api.nvim_buf_get_name(opts.bufnr)
-  local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ":p"))
-  if not is_file_readable(filepath) then
+  local bufnr, path
+
+  -- (optional) buffer number and path
+  if type(opts.buf) == "nil" then
+    bufnr = vim.api.nvim_get_current_buf()
+    path = vim.api.nvim_buf_get_name(bufnr)
+  elseif type(opts.buf) == "number" then
+    bufnr = tonumber(opts.buf)
+    path = vim.api.nvim_buf_get_name(bufnr)
+  elseif type(opts.buf) == "string" then
+    bufnr = nil
+    path = tostring(opts.buf)
+  else
     return
   end
 
-  -- open or focus
-  if opts.open then
-    if view.is_visible() then
+  if view.is_visible() then
+    -- focus
+    if opts.focus then
       lib.set_target_win()
       view.focus()
-    else
-      lib.open { current_window = opts.current_window }
+    end
+  elseif opts.open then
+    -- open
+    lib.open { current_window = opts.current_window }
+    if not opts.focus then
+      vim.cmd "noautocmd wincmd p"
     end
   end
 
   -- update root
   if opts.update_root or M.config.update_focused_file.update_root then
-    require("nvim-tree").change_root(filepath, opts.bufnr)
+    require("nvim-tree").change_root(path, bufnr)
   end
 
   -- find
-  require("nvim-tree.actions.finders.find-file").fn(filepath)
+  finders_find_file.fn(path)
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/actions/tree/find-file.lua
+++ b/lua/nvim-tree/actions/tree/find-file.lua
@@ -1,0 +1,91 @@
+local core = require "nvim-tree.core"
+local utils = require "nvim-tree.utils"
+local open = require "nvim-tree.actions.tree.open"
+
+local M = {}
+
+local function is_file_readable(fname)
+  local stat = vim.loop.fs_stat(fname)
+  return stat and stat.type == "file" and vim.loop.fs_access(fname, "R")
+end
+
+local function change_dir(name)
+  change_dir.fn(name)
+
+  if M.config.update_focused_file.enable then
+    M.fn(false)
+  end
+end
+
+local function change_root(filepath, bufnr)
+  -- skip if current file is in ignore_list
+  local ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
+  for _, value in pairs(M.config.update_focused_file.ignore_list) do
+    if utils.str_find(filepath, value) or utils.str_find(ft, value) then
+      return
+    end
+  end
+
+  local cwd = core.get_cwd()
+  local vim_cwd = vim.fn.getcwd()
+
+  -- test if in vim_cwd
+  if utils.path_relative(filepath, vim_cwd) ~= filepath then
+    if vim_cwd ~= cwd then
+      change_dir.fn(vim_cwd)
+    end
+    return
+  end
+  -- test if in cwd
+  if utils.path_relative(filepath, cwd) ~= filepath then
+    return
+  end
+
+  -- otherwise test M.init_root
+  if M.config.prefer_startup_root and utils.path_relative(filepath, M.init_root) ~= filepath then
+    change_dir.fn(M.init_root)
+    return
+  end
+  -- otherwise root_dirs
+  for _, dir in pairs(M.config.root_dirs) do
+    dir = vim.fn.fnamemodify(dir, ":p")
+    if utils.path_relative(filepath, dir) ~= filepath then
+      change_dir.fn(dir)
+      return
+    end
+  end
+  -- finally fall back to the folder containing the file
+  change_dir.fn(vim.fn.fnamemodify(filepath, ":p:h"))
+end
+
+function M.fn(with_open, bufnr, bang)
+  if not with_open and not core.get_explorer() then
+    return
+  end
+
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ":p"))
+  if not is_file_readable(filepath) then
+    return
+  end
+
+  if with_open then
+    open.fn()
+  end
+
+  if bang or M.config.update_focused_file.update_root then
+    change_root(filepath, bufnr)
+  end
+
+  require("nvim-tree.actions.finders.find-file").fn(filepath)
+end
+
+function M.setup(opts)
+  M.config = opts or {}
+end
+
+return M

--- a/lua/nvim-tree/actions/tree/find-file.lua
+++ b/lua/nvim-tree/actions/tree/find-file.lua
@@ -28,6 +28,9 @@ function M.fn(opts)
     bufnr = vim.api.nvim_get_current_buf()
     path = vim.api.nvim_buf_get_name(bufnr)
   elseif type(opts.buf) == "number" then
+    if not vim.api.nvim_buf_is_valid(opts.buf) then
+      return
+    end
     bufnr = tonumber(opts.buf)
     path = vim.api.nvim_buf_get_name(bufnr)
   elseif type(opts.buf) == "string" then

--- a/lua/nvim-tree/actions/tree/find-file.lua
+++ b/lua/nvim-tree/actions/tree/find-file.lua
@@ -1,6 +1,7 @@
 local core = require "nvim-tree.core"
+local lib = require "nvim-tree.lib"
 local utils = require "nvim-tree.utils"
-local open = require "nvim-tree.actions.tree.open"
+local view = require "nvim-tree.view"
 
 local M = {}
 
@@ -9,78 +10,57 @@ local function is_file_readable(fname)
   return stat and stat.type == "file" and vim.loop.fs_access(fname, "R")
 end
 
-local function change_dir(name)
-  change_dir.fn(name)
-
-  if M.config.update_focused_file.enable then
-    M.fn(false)
-  end
-end
-
-local function change_root(filepath, bufnr)
-  -- skip if current file is in ignore_list
-  local ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
-  for _, value in pairs(M.config.update_focused_file.ignore_list) do
-    if utils.str_find(filepath, value) or utils.str_find(ft, value) then
-      return
+--- Find file or buffer
+--- @param opts ApiTreeFindFileOpts|nil|boolean legacy -> opts.open
+--- @param bufnr number|nil legacy -> opts.bufnr
+--- @param bang boolean|nil legacy -> opts.update_root
+function M.fn(opts, bufnr, bang)
+  -- legacy arguments
+  if type(opts) == "boolean" then
+    opts = {
+      open = opts,
+    }
+    if type(bufnr) == "number" then
+      opts.bufnr = bufnr
+    end
+    if type(bang) == "boolean" then
+      opts.update_root = bang
     end
   end
+  opts = opts or {}
 
-  local cwd = core.get_cwd()
-  local vim_cwd = vim.fn.getcwd()
-
-  -- test if in vim_cwd
-  if utils.path_relative(filepath, vim_cwd) ~= filepath then
-    if vim_cwd ~= cwd then
-      change_dir.fn(vim_cwd)
-    end
-    return
-  end
-  -- test if in cwd
-  if utils.path_relative(filepath, cwd) ~= filepath then
+  -- do nothing if closed and open not requested
+  if not opts.open and not core.get_explorer() then
     return
   end
 
-  -- otherwise test M.init_root
-  if M.config.prefer_startup_root and utils.path_relative(filepath, M.init_root) ~= filepath then
-    change_dir.fn(M.init_root)
+  -- determine the (current) buffer path
+  opts.bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  if not vim.api.nvim_buf_is_valid(opts.bufnr) then
     return
   end
-  -- otherwise root_dirs
-  for _, dir in pairs(M.config.root_dirs) do
-    dir = vim.fn.fnamemodify(dir, ":p")
-    if utils.path_relative(filepath, dir) ~= filepath then
-      change_dir.fn(dir)
-      return
-    end
-  end
-  -- finally fall back to the folder containing the file
-  change_dir.fn(vim.fn.fnamemodify(filepath, ":p:h"))
-end
-
-function M.fn(with_open, bufnr, bang)
-  if not with_open and not core.get_explorer() then
-    return
-  end
-
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-  if not vim.api.nvim_buf_is_valid(bufnr) then
-    return
-  end
-  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  local bufname = vim.api.nvim_buf_get_name(opts.bufnr)
   local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ":p"))
   if not is_file_readable(filepath) then
     return
   end
 
-  if with_open then
-    open.fn()
+  -- open or focus
+  if opts.open then
+    if view.is_visible() then
+      lib.set_target_win()
+      view.focus()
+    else
+      lib.open { current_window = opts.current_window }
+    end
   end
 
-  if bang or M.config.update_focused_file.update_root then
-    change_root(filepath, bufnr)
+  -- update root
+  if opts.update_root or M.config.update_focused_file.update_root then
+    require("nvim-tree").change_root(filepath, opts.bufnr)
   end
 
+  -- find
   require("nvim-tree.actions.finders.find-file").fn(filepath)
 end
 

--- a/lua/nvim-tree/actions/tree/open.lua
+++ b/lua/nvim-tree/actions/tree/open.lua
@@ -1,5 +1,6 @@
 local lib = require "nvim-tree.lib"
 local view = require "nvim-tree.view"
+local finders_find_file = require "nvim-tree.actions.finders.find-file"
 
 local M = {}
 
@@ -39,7 +40,7 @@ function M.fn(opts)
     end
 
     -- find
-    require("nvim-tree.actions.finders.find-file").fn(previous_path)
+    finders_find_file.fn(previous_path)
   end
 end
 

--- a/lua/nvim-tree/actions/tree/open.lua
+++ b/lua/nvim-tree/actions/tree/open.lua
@@ -1,0 +1,41 @@
+local lib = require "nvim-tree.lib"
+local view = require "nvim-tree.view"
+
+local M = {}
+
+---Open the tree, focusing if already open.
+---@param opts ApiTreeOpenOpts|nil|string
+function M.fn(opts)
+  -- legacy arguments
+  if type(opts) == "string" then
+    opts = {
+      path = opts,
+    }
+  end
+
+  opts = opts or {}
+
+  local previous_buf = vim.api.nvim_get_current_buf()
+
+  -- sanitise path
+  if type(opts.path) ~= "string" or vim.fn.isdirectory(opts.path) == 0 then
+    opts.path = nil
+  end
+
+  if view.is_visible() then
+    lib.set_target_win()
+    view.focus()
+  else
+    lib.open(opts)
+  end
+
+  if M.config.update_focused_file.enable or opts.find_file then
+    require("nvim-tree.actions.tree.find-file").fn(false, previous_buf, opts.update_root)
+  end
+end
+
+function M.setup(opts)
+  M.config = opts or {}
+end
+
+return M

--- a/lua/nvim-tree/actions/tree/toggle.lua
+++ b/lua/nvim-tree/actions/tree/toggle.lua
@@ -1,11 +1,13 @@
+local lib = require "nvim-tree.lib"
 local view = require "nvim-tree.view"
-local open = require "nvim-tree.actions.tree.open"
-local find_file = require "nvim-tree.actions.tree.find-file"
 
 local M = {}
 
 ---Toggle the tree.
----@param opts ApiTreeToggleOpts|nil|boolean
+---@param opts ApiTreeToggleOpts|nil|boolean legacy -> opts.find_file
+---@param no_focus string|nil legacy -> opts.focus
+---@param cwd boolean|nil legacy -> opts.path
+---@param bang boolean|nil legacy -> opts.update_root
 function M.fn(opts, no_focus, cwd, bang)
   -- legacy arguments
   if type(opts) == "boolean" then
@@ -22,7 +24,6 @@ function M.fn(opts, no_focus, cwd, bang)
       opts.update_root = bang
     end
   end
-
   opts = opts or {}
 
   -- defaults
@@ -30,19 +31,33 @@ function M.fn(opts, no_focus, cwd, bang)
     opts.focus = true
   end
 
+  local previous_buf = vim.api.nvim_get_current_buf()
+  local previous_path = vim.api.nvim_buf_get_name(previous_buf)
+
   -- sanitise path
   if type(opts.path) ~= "string" or vim.fn.isdirectory(opts.path) == 0 then
     opts.path = nil
   end
 
   if view.is_visible() then
+    -- close
     view.close()
   else
-    local previous_buf = vim.api.nvim_get_current_buf()
-    open.fn { path = opts.path, current_window = opts.current_window }
+    -- open
+    lib.open { path = opts.path, current_window = opts.current_window }
+
+    -- find file
     if M.config.update_focused_file.enable or opts.find_file then
-      find_file.fn(false, previous_buf, opts.update_root)
+      -- update root
+      if opts.update_root then
+        require("nvim-tree").change_root(previous_path, previous_buf)
+      end
+
+      -- find
+      require("nvim-tree.actions.finders.find-file").fn(previous_path)
     end
+
+    -- restore focus
     if not opts.focus then
       vim.cmd "noautocmd wincmd p"
     end

--- a/lua/nvim-tree/actions/tree/toggle.lua
+++ b/lua/nvim-tree/actions/tree/toggle.lua
@@ -1,0 +1,56 @@
+local view = require "nvim-tree.view"
+local open = require "nvim-tree.actions.tree.open"
+local find_file = require "nvim-tree.actions.tree.find-file"
+
+local M = {}
+
+---Toggle the tree.
+---@param opts ApiTreeToggleOpts|nil|boolean
+function M.fn(opts, no_focus, cwd, bang)
+  -- legacy arguments
+  if type(opts) == "boolean" then
+    opts = {
+      find_file = opts,
+    }
+    if type(cwd) == "string" then
+      opts.path = cwd
+    end
+    if type(no_focus) == "boolean" then
+      opts.focus = not no_focus
+    end
+    if type(bang) == "boolean" then
+      opts.update_root = bang
+    end
+  end
+
+  opts = opts or {}
+
+  -- defaults
+  if opts.focus == nil then
+    opts.focus = true
+  end
+
+  -- sanitise path
+  if type(opts.path) ~= "string" or vim.fn.isdirectory(opts.path) == 0 then
+    opts.path = nil
+  end
+
+  if view.is_visible() then
+    view.close()
+  else
+    local previous_buf = vim.api.nvim_get_current_buf()
+    open.fn { path = opts.path, current_window = opts.current_window }
+    if M.config.update_focused_file.enable or opts.find_file then
+      find_file.fn(false, previous_buf, opts.update_root)
+    end
+    if not opts.focus then
+      vim.cmd "noautocmd wincmd p"
+    end
+  end
+end
+
+function M.setup(opts)
+  M.config = opts or {}
+end
+
+return M

--- a/lua/nvim-tree/actions/tree/toggle.lua
+++ b/lua/nvim-tree/actions/tree/toggle.lua
@@ -1,5 +1,6 @@
 local lib = require "nvim-tree.lib"
 local view = require "nvim-tree.view"
+local finders_find_file = require "nvim-tree.actions.finders.find-file"
 
 local M = {}
 
@@ -54,7 +55,7 @@ function M.fn(opts, no_focus, cwd, bang)
       end
 
       -- find
-      require("nvim-tree.actions.finders.find-file").fn(previous_path)
+      finders_find_file.fn(previous_path)
     end
 
     -- restore focus

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -64,15 +64,13 @@ Api.tree.get_node_under_cursor = require("nvim-tree.lib").get_node_at_cursor
 Api.tree.get_nodes = require("nvim-tree.lib").get_nodes
 
 ---@class ApiTreeFindFileOpts
----@field path string|nil
----@field bufnr number|nil
+---@field buf string|number|nil
 ---@field open boolean|nil default false
 ---@field current_window boolean|nil default false
 ---@field update_root boolean|nil default false
 ---@field focus boolean|nil default false
 
--- TODO #2011 change to actions.tree.find-file
-Api.tree.find_file = require("nvim-tree.actions.finders.find-file").fn
+Api.tree.find_file = require("nvim-tree.actions.tree.find-file").fn
 
 Api.tree.search_node = require("nvim-tree.actions.finders.search-node").fn
 

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -65,10 +65,13 @@ Api.tree.get_nodes = require("nvim-tree.lib").get_nodes
 
 ---@class ApiTreeFindFileOpts
 ---@field path string|nil
+---@field bufnr number|nil
 ---@field open boolean|nil default false
+---@field current_window boolean|nil default false
 ---@field update_root boolean|nil default false
+---@field focus boolean|nil default false
 
--- TODO #1212 change to actions.tree.find-file
+-- TODO #2011 change to actions.tree.find-file
 Api.tree.find_file = require("nvim-tree.actions.finders.find-file").fn
 
 Api.tree.search_node = require("nvim-tree.actions.finders.search-node").fn

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -22,9 +22,7 @@ end
 ---@field find_file boolean|nil default false
 ---@field update_root boolean|nil default false
 
-Api.tree.open = function(...)
-  require("nvim-tree").open(...)
-end
+Api.tree.open = require("nvim-tree.actions.tree.open").fn
 
 ---@class ApiTreeToggleOpts
 ---@field path string|nil
@@ -33,9 +31,7 @@ end
 ---@field update_root boolean|nil default false
 ---@field focus boolean|nil default true
 
-Api.tree.toggle = function(...)
-  require("nvim-tree").toggle(...)
-end
+Api.tree.toggle = require("nvim-tree.actions.tree.toggle").fn
 
 Api.tree.close = require("nvim-tree.view").close
 
@@ -67,6 +63,12 @@ Api.tree.get_node_under_cursor = require("nvim-tree.lib").get_node_at_cursor
 
 Api.tree.get_nodes = require("nvim-tree.lib").get_nodes
 
+---@class ApiTreeFindFileOpts
+---@field path string|nil
+---@field open boolean|nil default false
+---@field update_root boolean|nil default false
+
+-- TODO #1212 change to actions.tree.find-file
 Api.tree.find_file = require("nvim-tree.actions.finders.find-file").fn
 
 Api.tree.search_node = require("nvim-tree.actions.finders.search-node").fn

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -4,6 +4,10 @@ local core = require "nvim-tree.core"
 local utils = require "nvim-tree.utils"
 local events = require "nvim-tree.events"
 
+---@class LibOpenOpts
+---@field path string|nil path
+---@field current_window boolean|nil default false
+
 local M = {
   target_winid = nil,
 }
@@ -152,7 +156,7 @@ function M.prompt(prompt_input, prompt_select, items_short, items_long, callback
 end
 
 ---Open the tree, initialising as needed. Maybe hijack the current buffer.
----@param opts ApiTreeOpenOpts|string|nil legacy case opts is path string
+---@param opts LibOpenOpts|nil
 function M.open(opts)
   opts = opts or {}
 


### PR DESCRIPTION
fixes #2011 

Requires dogfooding

* api.tree.find_file feature parity
* commands call API
* large refactor of open, toggle, find_file

## find-file
```
legacy path        - x - - - - - - - - -
buf path           - - x - x - - - - - -
buf number         - - - x - - - - - - -
open               - - - - x x - - x x -
current_window     - - - - - x - - - x -
update_root        - - - - - - x - - - x
focus              - - - - - - - x x x -
ignore_list        - - - - - - - - - - x
```

## open
```
path               x - - - - - - - - x x x x
current_window     - x - - - - x x x - x x x
find_file          - - x - x x x x x x x x x
update_root        - - - x x x - x x - - x x
ignore_list        - - - - - x - - x - - - x
```

## toggle
```
path               - x - - - - - - - - - -
current_window     - - x - - - - x x x x -
find_file          - - - x - x - x x - - x
update_root        - - - - x x - - x - x x
! focus            - - - - - - x - - x - -
ignore_list        - - - - - - - - - - - x
```