### PR TITLE
Fix duplicated help tags

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1503,7 +1503,7 @@ api.config.mappings.get_keymap()
     Return: ~
         (table) as per |nvim_buf_get_keymap()|
 
-                                  *nvim-tree.api.config.mappings.get_keymap()*
+                                  *nvim-tree.api.config.mappings.get_keymap_default()*
 api.config.mappings.get_keymap_default()
     Retrieves the buffer local mappings for nvim-tree that are applied by
     |nvim-tree.api.config.mappings.default_on_attach()|


### PR DESCRIPTION
The help tag `nvim-tree.api.config.mappings.get_keymap()` was specified twice in the latest commit.