### PR TITLE
fix(doc): duplicate help tag in README

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1503,7 +1503,7 @@ api.config.mappings.get_keymap()
     Return: ~
         (table) as per |nvim_buf_get_keymap()|
 
-                                  *nvim-tree.api.config.mappings.get_keymap()*
+                                  *nvim-tree.api.config.mappings.get_keymap_default()*
 api.config.mappings.get_keymap_default()
     Retrieves the buffer local mappings for nvim-tree that are applied by
     |nvim-tree.api.config.mappings.default_on_attach()|


### PR DESCRIPTION
https://github.com/nvim-tree/nvim-tree.lua/commit/4f036342f14378b53ac5d7c6ae8d8f6d1bf9a0f8 added `api.config.mappings.get_keymap` and `get_keymap_default` and introduced duplicated tags in the documentation.