### PR TITLE
fix(#2097): toggle folders with tab key

### DIFF
--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -130,7 +130,10 @@ local function open_or_expand_or_dir_up(mode)
 end
 
 local function open_preview(node)
-  if node.nodes or node.name == ".." then
+  if node.name == ".." then
+    return
+  elseif node.nodes then
+    require("nvim-tree.lib").expand_or_collapse(node)
     return
   end
 


### PR DESCRIPTION
I hope this is not too opinionated of a change, but I'm pretty sure I was able to toggle folders using the tab key in the past.

fixes #2097 