### PR TITLE
fix: `api.node.open.preview` should toggle directories

### DIFF
--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -130,11 +130,13 @@ local function open_or_expand_or_dir_up(mode)
 end
 
 local function open_preview(node)
-  if node.nodes or node.name == ".." then
-    return
+  if node.name == ".." then
+    require("nvim-tree.actions.root.change-dir").fn ".."
+  elseif node.nodes then
+    require("nvim-tree.lib").expand_or_collapse(node)
+  else
+    edit("preview", node)
   end
-
-  edit("preview", node)
 end
 
 Api.node.open.edit = inject_node(open_or_expand_or_dir_up "edit")


### PR DESCRIPTION
Regression introduced by 74959750.

Closes #2097 

@alex-courtis I have kept parity with `open_or_expand_or_dir_up` in regards to behaviour on `..`, which might not be desired. I believe we might not want to do anything in that case as it was previously?
If we do want to keep parity perhaps those two functions can be merged into one with `preview` argument.