### PR TITLE
fix: custom window pickers that create windows should work

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1121,6 +1121,7 @@ Configuration for various actions.
             Change the default window picker, can be a string `"default"` or a function.
             The function should return the window id that will open the node,
             or `nil` if an invalid window is picked or user cancelled the action.
+            The picker may create a new window.
               Type: `string` | `function`, Default: `"default"`
               e.g. s1n7ax/nvim-window-picker plugin: >
                 window_picker = {


### PR DESCRIPTION
call nvim_list_wins again after the picker is run

also show a warning if it doesn't exist. I don't see why this would happen unless its a bug in the picker, perhaps something else snuck in and deleted the window

Fixes #2126 