### PR TITLE
feat(api): Add new node selection action based on tab :drop command

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1527,13 +1527,6 @@ node.open.edit()                              *nvim-tree-api.node.open.edit()*
     Folder: expand or collapse
     Root:   change directory up
 
-                                          *nvim-tree-api.node.open.tab_drop()*
-node.open.tab_drop()
-    Like edit(), but reuse already-opened window in tab. See also: |:drop| 
-    File:   open already-opened as per |nvim-tree.actions.open_file|
-    Folder: expand or collapse
-    Root:   change directory up 
-
                                *nvim-tree-api.node.open.replace_tree_buffer()*
 node.open.replace_tree_buffer()
     |nvim-tree-api.node.edit()|, file will be opened in place: in the
@@ -1552,6 +1545,15 @@ node.open.horizontal()                  *nvim-tree-api.node.open.horizontal()*
 
 node.open.tab()                                *nvim-tree-api.node.open.tab()*
     |nvim-tree-api.node.edit()|, file will be opened in a new tab.
+
+                                          *nvim-tree-api.node.open.tab_drop()*
+node.open.tab_drop()
+    Switch to tab containing window with selected file if it exists.
+    Open file in new tab otherwise.
+
+    File:   open file using `tab :drop`
+    Folder: expand or collapse
+    Root:   change directory up
 
 node.open.preview()                        *nvim-tree-api.node.open.preview()*
     |nvim-tree-api.node.edit()|, file buffer will have |bufhidden| set to `delete`.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1527,6 +1527,13 @@ node.open.edit()                              *nvim-tree-api.node.open.edit()*
     Folder: expand or collapse
     Root:   change directory up
 
+                                          *nvim-tree-api.node.open.tab_drop()*
+node.open.tab_drop()
+    Like edit(), but reuse already-opened window in tab. See also: |:drop| 
+    File:   open already-opened as per |nvim-tree.actions.open_file|
+    Folder: expand or collapse
+    Root:   change directory up 
+
                                *nvim-tree-api.node.open.replace_tree_buffer()*
 node.open.replace_tree_buffer()
     |nvim-tree-api.node.edit()|, file will be opened in place: in the

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -141,7 +141,6 @@ local function pick_win_id()
   return win_map[resp]
 end
 
-
 local function open_file_in_tab(filename)
   if M.quit_on_open then
     view.close()
@@ -149,7 +148,6 @@ local function open_file_in_tab(filename)
   vim.cmd("tabe " .. vim.fn.fnameescape(filename))
 end
 
--- See :drop command. This will always focus already-opened tab
 local function tab_drop(filename)
   if M.quit_on_open then
     view.close()

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -141,11 +141,20 @@ local function pick_win_id()
   return win_map[resp]
 end
 
+
 local function open_file_in_tab(filename)
   if M.quit_on_open then
     view.close()
   end
   vim.cmd("tabe " .. vim.fn.fnameescape(filename))
+end
+
+-- See :drop command. This will always focus already-opened tab
+local function tab_drop(filename)
+  if M.quit_on_open then
+    view.close()
+  end
+  vim.cmd("tab :drop " .. vim.fn.fnameescape(filename))
 end
 
 local function on_preview(buf_loaded)
@@ -282,6 +291,10 @@ function M.fn(mode, filename)
 
   if mode == "tabnew" then
     return open_file_in_tab(filename)
+  end
+
+  if mode == "tab_drop" then
+    return tab_drop(filename)
   end
 
   if mode == "edit_in_place" then

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -162,6 +162,7 @@ local function open_preview(node)
 end
 
 Api.node.open.edit = wrap_node(open_or_expand_or_dir_up "edit")
+Api.node.open.tab_drop = wrap_node(open_or_expand_or_dir_up "tab_drop")
 Api.node.open.replace_tree_buffer = wrap_node(open_or_expand_or_dir_up "edit_in_place")
 Api.node.open.no_window_picker = wrap_node(open_or_expand_or_dir_up "edit_no_picker")
 Api.node.open.vertical = wrap_node(open_or_expand_or_dir_up "vsplit")


### PR DESCRIPTION
https://user-images.githubusercontent.com/8136158/233742234-c4f4bb4b-1927-4ab4-b0cc-779c64a0e1b1.mov

* Demo of the new action allowing to always jumpt to an already-opened window based in built-in command. Every time `<CR>` is hit, the same buffer window of the file is focused.
* Usage docs added


Demo link: `https://user-images.githubusercontent.com/8136158/233742234-c4f4bb4b-1927-4ab4-b0cc-779c64a0e1b1.mov`

### PRs
**PREVIOUS PRs got CLOSED BECAUSE OF FORCE-PUSH, GITHUB IS REALLY NUTS**

### Usage example
```lua
    require("nvim-tree").setup({
        on_attach = function(bufnr)
            local function opts(desc)
                return { desc = 'nvim-tree: ' .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
            end
            local ok, api = pcall(require, "nvim-tree.api")
            assert(ok, "api module is not found")
            vim.keymap.set("n", "<CR>", api.node.open.tab_drop, opts("Tab drop"))
        end
    })
```