### PR TITLE
feat: add `NormalFloat` hl for floating windows

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1981,6 +1981,7 @@ NvimTreeWindowPicker
 There are also links to normal bindings to style the tree itself.
 
 NvimTreeNormal
+NvimTreeNormalFloat
 NvimTreeEndOfBuffer     (NonText)
 NvimTreeCursorLine      (CursorLine)
 NvimTreeCursorLineNr    (CursorLineNr)

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -66,6 +66,7 @@ local function get_links()
     OpenedFolderIcon = "NvimTreeFolderIcon",
     ClosedFolderIcon = "NvimTreeFolderIcon",
     Normal = "Normal",
+    NormalFloat = "NormalFloat",
     NormalNC = "NvimTreeNormal",
     EndOfBuffer = "EndOfBuffer",
     CursorLineNr = "CursorLineNr",

--- a/lua/nvim-tree/help.lua
+++ b/lua/nvim-tree/help.lua
@@ -5,7 +5,7 @@ local PAT_CTRL = "^<C%-"
 local PAT_SPECIAL = "^<.+"
 
 local WIN_HL = table.concat({
-  "Normal:NvimTreeNormal",
+  "Normal:NvimTreeNormalFloat",
   "CursorLine:NvimTreeCursorLine",
 }, ",")
 

--- a/lua/nvim-tree/help.lua
+++ b/lua/nvim-tree/help.lua
@@ -5,7 +5,8 @@ local PAT_CTRL = "^<C%-"
 local PAT_SPECIAL = "^<.+"
 
 local WIN_HL = table.concat({
-  "Normal:NvimTreeNormalFloat",
+  "NormalFloat:NvimTreeNormalFloat",
+  "WinSeparator:NvimTreeWinSeparator",
   "CursorLine:NvimTreeCursorLine",
 }, ",")
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -39,7 +39,9 @@ M.View = {
       "StatusLine:NvimTreeStatusLine",
       "StatusLineNC:NvimTreeStatuslineNC",
       "SignColumn:NvimTreeSignColumn",
+      "Normal:NvimTreeNormal",
       "NormalNC:NvimTreeNormalNC",
+      "NormalFloat:NvimTreeNormalFloat",
     }, ","),
   },
 }
@@ -502,9 +504,6 @@ function M.setup(opts)
   M.View.winopts.relativenumber = options.relativenumber
   M.View.winopts.signcolumn = options.signcolumn
   M.View.float = options.float
-  M.View.winopts.winhl = table.concat({
-    "Normal:" .. (M.View.float.enable and "NvimTreeNormalFloat" or "NvimTreeNormal"),
-  }, ",")
   M.on_attach = opts.on_attach
 
   if type(options.width) == "table" then

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -32,7 +32,6 @@ M.View = {
     wrap = false,
     winhl = table.concat({
       "EndOfBuffer:NvimTreeEndOfBuffer",
-      "Normal:NvimTreeNormal",
       "CursorLine:NvimTreeCursorLine",
       "CursorLineNr:NvimTreeCursorLineNr",
       "LineNr:NvimTreeLineNr",
@@ -503,6 +502,9 @@ function M.setup(opts)
   M.View.winopts.relativenumber = options.relativenumber
   M.View.winopts.signcolumn = options.signcolumn
   M.View.float = options.float
+  M.View.winopts.winhl = table.concat({
+    "Normal:" .. (M.View.float.enable and "NvimTreeNormalFloat" or "NvimTreeNormal"),
+  }, ",")
   M.on_attach = opts.on_attach
 
   if type(options.width) == "table" then


### PR DESCRIPTION
Currently, `NvimTreeNormal` is used for floating window's background. However, when `winblend` is set and `Normal` highlight is set to transparent, the background will turn `black`. Using `NormalFloat` allows users to customize the background and not interfere with normal window.

<details>
<summary>minimal init.lua</summary>

```lua
vim.g.loaded_netrw = 1
vim.g.loaded_netrwPlugin = 1

vim.cmd [[set runtimepath=$VIMRUNTIME]]
vim.cmd [[set packpath=/tmp/nvt-min/site]]
local package_root = "/tmp/nvt-min/site/pack"
local install_path = package_root .. "/packer/start/packer.nvim"
local function load_plugins()
  require("packer").startup {
    {
      "wbthomason/packer.nvim",
      --"jamestansx/nvim-tree.lua",
      "nvim-tree/nvim-tree.lua",
      "nvim-tree/nvim-web-devicons",
      { "catppuccin/nvim", as = "catppuccin" }
      -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
    },
    config = {
      package_root = package_root,
      compile_path = install_path .. "/plugin/packer_compiled.lua",
      display = { non_interactive = true },
    },
  }
end
if vim.fn.isdirectory(install_path) == 0 then
  print "Installing nvim-tree and dependencies."
  vim.fn.system { "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path }
end
load_plugins()
require("packer").sync()
vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]]
vim.opt.termguicolors = true
vim.opt.cursorline = true
vim.opt.winblend = 10

-- MODIFY NVIM-TREE SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
---@diagnostic disable-next-line: duplicate-set-field
_G.setup = function()
  -- run help with `g?` key or enable float
  -- to see the background color in black
  require("nvim-tree").setup {}

  require("catppuccin").setup({
    transparent_background = true, -- to set Normal to transparent
    integrations = {
      nvimtree = false, -- to ensure that no hl is changed by catppuccin
    }
  })
  vim.cmd.colorscheme "catppuccin"
end

```

</details>