### PR TITLE
feat: support vim.diagnostic.is_disabled()

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -27,13 +27,20 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
-    local buf = diagnostic.bufnr
-    if vim.api.nvim_buf_is_valid(buf) then
-      local bufname = vim.api.nvim_buf_get_name(buf)
-      local lowest_severity = buffer_severity[bufname]
-      if not lowest_severity or diagnostic.severity < lowest_severity then
-        buffer_severity[bufname] = diagnostic.severity
+  local is_disabled = false
+  if vim.fn.has "nvim-0.9" == 1 then
+    is_disabled = vim.diagnostic.is_disabled()
+  end
+
+  if not is_disabled then
+    for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
+      local buf = diagnostic.bufnr
+      if vim.api.nvim_buf_is_valid(buf) then
+        local bufname = vim.api.nvim_buf_get_name(buf)
+        local lowest_severity = buffer_severity[bufname]
+        if not lowest_severity or diagnostic.severity < lowest_severity then
+          buffer_severity[bufname] = diagnostic.severity
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds support for checking `vim.diagnostic.is_disabled()` on nvim 0.9+. This function was added to support globally enabling or disabling diagnostics. This is especially useful for setups where diagnostics are enabled conditionally or on a project basis. There is no change in behavior for versions prior to 0.9.

Thanks for a great plugin!