### PR TITLE
fix(#1545): dispatch Event.Resize on all window resizes, requires nvim 0.9+

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -15,6 +15,7 @@ local modified = require "nvim-tree.modified"
 local keymap_legacy = require "nvim-tree.keymap-legacy"
 local find_file = require "nvim-tree.actions.tree.find-file"
 local open = require "nvim-tree.actions.tree.open"
+local events = require "nvim-tree.events"
 
 local _config = {}
 
@@ -334,6 +335,21 @@ local function setup_autocommands(opts)
           modified.reload()
           reloaders.reload_explorer()
         end)
+      end,
+    })
+  end
+
+  -- TODO #1545 remove similar check from view.resize
+  if vim.fn.has "nvim-0.9" == 1 then
+    create_nvim_tree_autocmd("WinResized", {
+      callback = function()
+        if vim.v.event and vim.v.event.windows then
+          for _, winid in ipairs(vim.v.event.windows) do
+            if vim.api.nvim_win_is_valid(winid) and utils.is_nvim_tree_buf(vim.api.nvim_win_get_buf(winid)) then
+              events._dispatch_on_tree_resize(vim.api.nvim_win_get_width(winid))
+            end
+          end
+        end
       end,
     })
   end

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -409,7 +409,7 @@ function M.is_nvim_tree_buf(bufnr)
   if bufnr == nil then
     bufnr = 0
   end
-  if vim.fn.bufexists(bufnr) then
+  if vim.api.nvim_buf_is_valid(bufnr) then
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     if vim.fn.fnamemodify(bufname, ":t"):match "^NvimTree_[0-9]+$" then
       if vim.bo[bufnr].filetype == "NvimTree" then

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -330,7 +330,11 @@ function M.resize(size)
   local new_size = get_width()
   vim.api.nvim_win_set_width(M.get_winnr(), new_size)
 
-  events._dispatch_on_tree_resize(new_size)
+  -- TODO #1545 remove similar check from setup_autocommands
+  -- We let nvim handle sending resize events after 0.9
+  if vim.fn.has "nvim-0.9" == 0 then
+    events._dispatch_on_tree_resize(new_size)
+  end
 
   if not M.View.preserve_window_proportions then
     vim.cmd ":wincmd ="


### PR DESCRIPTION
fixes #1545

@wlh320 @Tcholly I'd be most grateful if you tested this fix:

```sh
cd /path/to/nvim-tree.lua
git pull
git checkout 1545-resize-events
```