### PR TITLE
refactor: move `reload` function into `utils` module

### DIFF
--- a/lua/nvim-tree/actions/tree-modifiers/toggles.lua
+++ b/lua/nvim-tree/actions/tree-modifiers/toggles.lua
@@ -1,5 +1,4 @@
 local lib = require "nvim-tree.lib"
-local core = require "nvim-tree.core"
 local utils = require "nvim-tree.utils"
 local filters = require "nvim-tree.explorer.filters"
 local reloaders = require "nvim-tree.actions.reloaders.reloaders"
@@ -9,24 +8,7 @@ local M = {}
 local function reload()
   local node = lib.get_node_at_cursor()
   reloaders.reload_explorer()
-  local explorer = core.get_explorer()
-
-  if explorer == nil then
-    return
-  end
-
-  while node do
-    local found_node, _ = utils.find_node(explorer.nodes, function(node_)
-      return node_.absolute_path == node.absolute_path
-    end)
-
-    if found_node or node.parent == nil then
-      utils.focus_file(node.absolute_path)
-      break
-    end
-
-    node = node.parent
-  end
+  utils.focus_node_or_parent(node)
 end
 
 function M.custom()

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -354,6 +354,10 @@ function M.focus_file(path)
   require("nvim-tree.view").set_cursor { i + 1, 1 }
 end
 
+---Focus node passed as parameter if visible, otherwise focus first visible parent.
+---If none of the parents is visible focus root.
+---If node is nil do nothing.
+---@param node table|nil node to focus
 function M.focus_node_or_parent(node)
   local explorer = require("nvim-tree.core").get_explorer()
 

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -354,6 +354,27 @@ function M.focus_file(path)
   require("nvim-tree.view").set_cursor { i + 1, 1 }
 end
 
+function M.focus_node_or_parent(node)
+  local explorer = require("nvim-tree.core").get_explorer()
+
+  if explorer == nil then
+    return
+  end
+
+  while node do
+    local found_node, i = M.find_node(explorer.nodes, function(node_)
+      return node_.absolute_path == node.absolute_path
+    end)
+
+    if found_node or node.parent == nil then
+      require("nvim-tree.view").set_cursor { i + 1, 1 }
+      break
+    end
+
+    node = node.parent
+  end
+end
+
 function M.get_win_buf_from_path(path)
   for _, w in pairs(vim.api.nvim_tabpage_list_wins(0)) do
     local b = vim.api.nvim_win_get_buf(w)


### PR DESCRIPTION
This is the refactor we discussed in #2202, it will be useful for future fixes.
I also noticed that I called `utils.focus_file` when it was unnecessary, so I replaced it with a simple `view.set_cursor`.