### PR TITLE
fix(#2250): Prevent filename from appearing in message box after picking a window.

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -282,7 +282,7 @@ local function open_in_new_window(filename, mode)
   -- Prevents the filename from being displayed in the message
   -- box and thus causing a 'Press enter to continue...' when the
   -- cmdheight=1.
-  cmd = 'silent! ' .. cmd
+  cmd = "silent! " .. cmd
 
   if mode == "preview" and view.View.float.enable then
     -- ignore "WinLeave" autocmd on preview

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -279,6 +279,10 @@ local function open_in_new_window(filename, mode)
   else
     cmd = string.format("edit %s", fname)
   end
+  -- Prevents the filename from being displayed in the message
+  -- box and thus causing a 'Press enter to continue...' when the
+  -- cmdheight=1.
+  cmd = 'silent! ' .. cmd
 
   if mode == "preview" and view.View.float.enable then
     -- ignore "WinLeave" autocmd on preview


### PR DESCRIPTION
Fixes #2250.