### PR TITLE
feat: support custom $GIT_DIR

### DIFF
--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -8,8 +8,11 @@ local M = {
 }
 
 local function is_git(path)
-  -- If $GIT_DIR is set, consider its value to be equivalent to '.git'
-  if path == vim.env.GIT_DIR then
+  -- If $GIT_DIR is set, consider its value to be equivalent to '.git'.
+  -- Expand $GIT_DIR (and `path`) to a full path (see :help filename-modifiers), since
+  -- it's possible to set it to a relative path. We want to make our best
+  -- effort to expand that to a valid absolute path.
+  if vim.fn.fnamemodify(path, ":p") == vim.fn.fnamemodify(vim.env.GIT_DIR, ":p") then
     return true
   elseif vim.fn.fnamemodify(path, ":t") == ".git" then
     return true

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -8,7 +8,14 @@ local M = {
 }
 
 local function is_git(path)
-  return vim.fn.fnamemodify(path, ":t") == ".git"
+  -- If $GIT_DIR is set, consider its value to be equivalent to '.git'
+  if path == vim.env.GIT_DIR then
+    return true
+  elseif vim.fn.fnamemodify(path, ":t") == ".git" then
+    return true
+  else
+    return false
+  end
 end
 
 local IGNORED_PATHS = {

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -186,7 +186,8 @@ function M.load_project_status(cwd)
       end)
     end
 
-    watcher = Watcher:new(utils.path_join { project_root, ".git" }, WATCHED_FILES, callback, {
+    local git_dir = vim.env.GIT_DIR or utils.path_join { project_root, ".git" }
+    watcher = Watcher:new(git_dir, WATCHED_FILES, callback, {
       project_root = project_root,
     })
   end


### PR DESCRIPTION
## About

While rarely used, it's possible to set the $GIT_DIR environment variable to instruct git to use a directory other than `.git`.

This checks if that environment variable is set; if it is, the plugin will watch that directory. If it's not set, it'll fall back to the default `.git` directory.

## Why?

I use a non-standard `.git` folder in my home directory for my dotfiles (`~/.git_dotfiles`). If I have `$GIT_DIR` set in my env to work on my dotfiles and open up nvim-tree, it'll detect that we're "in a git repo".

Prior to this change, it would produce an error that it can't watch the `.git` directory (since it doesn't exist). With this change, it produces no error and correctly watches the `$GIT_DIR` directory.

## Testing

I tested this in my environment by opening up nvim and nvim-tree in various scenarios, ensuring that no errors are produced and git changes are correctly detected (or correctly absent):

- [x] Not in a git repo and `$GIT_DIR` unset
- [x] In a git repo with a `.git` directory and `$GIT_DIR` unset
- [x] In a git repo with a non-standard git-dir and `$GIT_DIR` unset
- [x] In a git repo with a non-standard git-dir and `$GIT_DIR` set to that directory