### PR TITLE
fix(#2243): fs_watcher not started for .git folders (Win)

### DIFF
--- a/lua/nvim-tree/git/utils.lua
+++ b/lua/nvim-tree/git/utils.lua
@@ -25,7 +25,7 @@ function M.get_toplevel(cwd)
   if vim.fn.has "win32" == 1 then
     -- msys2 git support
     if has_cygpath then
-      toplevel = vim.fn.system("cygpath -w " .. vim.fn.shellescape(toplevel))
+      toplevel = vim.fn.system("cygpath -w " .. vim.fn.shellescape(toplevel:sub(0, -2)))
       if vim.v.shell_error ~= 0 then
         return nil
       end


### PR DESCRIPTION
Resolves #2243
The fix happens inside a `if vim.fn.has "win32"` block and thus, does not affect WSL.
If necessary, I could install cygwin to test it on that too. Also, I wasn't sure, what test case (in CONTRIBUTING.md) meant, as I didnt find a test setup for the repo. The issue describes the exact problematic case and why this fix works for it. If more description is needed, please tell me :)