### PR TITLE
feat: add sort_by "filetype"

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -568,8 +568,8 @@ Reloads the explorer every time a buffer is written to.
 
 *nvim-tree.sort_by*
 Changes how files within the same directory are sorted.
-Can be one of `name`, `case_sensitive`, `modification_time`, `extension` or a
-function.
+Can be one of `name`, `case_sensitive`, `modification_time`, `extension`,
+`filetype` or a function.
   Type: `string` | `function(nodes)`, Default: `"name"`
 
   Function may perform a sort or return a string with one of the above
@@ -577,6 +577,7 @@ function.
   - `absolute_path`: `string`
   - `executable`:    `boolean`
   - `extension`:     `string`
+  - `filetype`:      `string`
   - `link_to`:       `string`
   - `name`:          `string`
   - `type`:          `"directory"` | `"file"` | `"link"`

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -191,6 +191,32 @@ function C.extension(a, b)
   return a.extension:lower() <= b.extension:lower()
 end
 
+function C.filetype(a, b)
+  local a_ft = vim.filetype.match { filename = a.name }
+  local b_ft = vim.filetype.match { filename = b.name }
+
+  -- directories first
+  if a.nodes and not b.nodes then
+    return true
+  elseif not a.nodes and b.nodes then
+    return false
+  end
+
+  -- both nil, whatever
+  if not (a_ft and b_ft) then
+    return true
+  end
+
+  -- one is nil, the other wins
+  if a_ft and not b_ft then
+    return true
+  elseif not a_ft and b_ft then
+    return false
+  end
+
+  return a_ft <= b_ft
+end
+
 function M.setup(opts)
   M.config = {}
   M.config.sort_by = opts.sort_by

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -202,11 +202,6 @@ function C.filetype(a, b)
     return false
   end
 
-  -- both nil, whatever
-  if not (a_ft and b_ft) then
-    return true
-  end
-
   -- one is nil, the other wins
   if a_ft and not b_ft then
     return true
@@ -214,7 +209,12 @@ function C.filetype(a, b)
     return false
   end
 
-  return a_ft <= b_ft
+  -- same filetype or both nil, sort by name
+  if a_ft == b_ft then
+    return C.name(a, b)
+  end
+
+  return a_ft < b_ft
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -80,6 +80,7 @@ function M.sort(t)
         absolute_path = n.absolute_path,
         executable = n.executable,
         extension = n.extension,
+        filetype = vim.filetype.match { filename = n.name },
         link_to = n.link_to,
         name = n.name,
         type = n.type,


### PR DESCRIPTION
Fixes nvim-tree/nvim-tree.lua#2288 by proposing a new kind of sorting: by vim's filetype.