### PR TITLE
fix: sort_by "extension" falls back to name

### DIFF
--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -178,17 +178,17 @@ function C.extension(a, b)
     return false
   end
 
-  if not (a.extension and b.extension) then
-    return true
-  end
-
   if a.extension and not b.extension then
     return true
   elseif not a.extension and b.extension then
     return false
   end
 
-  return a.extension:lower() <= b.extension:lower()
+  if a.extension:lower() == b.extension:lower() then
+    return C.name(a, b)
+  end
+
+  return a.extension:lower() < b.extension:lower()
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -185,8 +185,8 @@ function C.extension(a, b)
     return false
   end
 
-  local a_ext = (a.extension or ''):lower()
-  local b_ext = (b.extension or ''):lower()
+  local a_ext = (a.extension or ""):lower()
+  local b_ext = (b.extension or ""):lower()
   if a_ext == b_ext then
     return C.name(a, b)
   end

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -184,11 +184,13 @@ function C.extension(a, b)
     return false
   end
 
-  if a.extension:lower() == b.extension:lower() then
+  local a_ext = (a.extension or ''):lower()
+  local b_ext = (b.extension or ''):lower()
+  if a_ext == b_ext then
     return C.name(a, b)
   end
 
-  return a.extension:lower() < b.extension:lower()
+  return a_ext < b_ext
 end
 
 function M.setup(opts)


### PR DESCRIPTION
As suggested by @alex-courtis on #2302 