### PR TITLE
feat(#2313): sort_by -> sort.sorter, add sort.folders_first default true

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -313,6 +313,7 @@ applying configuration.
       hijack_netrw = true,
       hijack_unnamed_buffer_when_opening = false,
       sort_by = "name",
+      sort_folders_first = true,
       root_dirs = {},
       prefer_startup_root = false,
       sync_root_with_cwd = false,
@@ -591,6 +592,11 @@ Can be one of `"name"`, `"case_sensitive"`, `"modification_time"`, `"extension"`
       end)
     end
 <
+*nvim-tree.sort_folders_first*
+Sort folders before files. Has no effect when |nvim-tree.sort_by| is a
+function.
+  Type: `boolean`, Default: `true`
+
 *nvim-tree.hijack_unnamed_buffer_when_opening*
 Opens in place of the unnamed buffer if it's empty.
   Type: `boolean`, Default: `false`

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -95,7 +95,9 @@ Setup the plugin in your `init.lua` >
 
   -- OR setup with some options
   require("nvim-tree").setup({
-    sort_by = "case_sensitive",
+    sort = {
+      sorter = "case_sensitive",
+    },
     view = {
       width = 30,
     },
@@ -312,8 +314,10 @@ applying configuration.
       hijack_cursor = false,
       hijack_netrw = true,
       hijack_unnamed_buffer_when_opening = false,
-      sort_by = "name",
-      sort_folders_first = true,
+      sort = {
+        sorter = "name",
+        folders_first = true,
+      },
       root_dirs = {},
       prefer_startup_root = false,
       sync_root_with_cwd = false,
@@ -567,35 +571,38 @@ Hijack netrw windows (overridden if |disable_netrw| is `true`)
 Reloads the explorer every time a buffer is written to.
   Type: `boolean`, Default: `true`
 
-*nvim-tree.sort_by*
-Changes how files within the same directory are sorted.
-Can be one of `"name"`, `"case_sensitive"`, `"modification_time"`, `"extension"`,
-`"suffix"`, `"filetype"` or a function.
-`"extension"` uses all suffixes e.g. `foo.tar.gz` -> `.tar.gz`
-`"suffix"` uses the last e.g. `.gz`
-  Type: `string` | `function(nodes)`, Default: `"name"`
+*nvim-tree.sort*
+File and folder sorting options.
 
-  Function may perform a sort or return a string with one of the above
-  methods. It is passed a table of nodes to be sorted, each node containing:
-  - `absolute_path`: `string`
-  - `executable`:    `boolean`
-  - `extension`:     `string`
-  - `filetype`:      `string`
-  - `link_to`:       `string`
-  - `name`:          `string`
-  - `type`:          `"directory"` | `"file"` | `"link"`
+    *nvim-tree.sort.sorter*  (previously `sort_by`)
+    Changes how files within the same directory are sorted.
+    Can be one of `"name"`, `"case_sensitive"`, `"modification_time"`, `"extension"`,
+    `"suffix"`, `"filetype"` or a function.
+    `"extension"` uses all suffixes e.g. `foo.tar.gz` -> `.tar.gz`
+    `"suffix"` uses the last e.g. `.gz`
+      Type: `string` | `function(nodes)`, Default: `"name"`
 
-  Example: sort by name length: >
-    local sort_by = function(nodes)
-      table.sort(nodes, function(a, b)
-        return #a.name < #b.name
-      end)
-    end
+      Function may perform a sort or return a string with one of the above
+      methods. It is passed a table of nodes to be sorted, each node containing:
+      - `absolute_path`: `string`
+      - `executable`:    `boolean`
+      - `extension`:     `string`
+      - `filetype`:      `string`
+      - `link_to`:       `string`
+      - `name`:          `string`
+      - `type`:          `"directory"` | `"file"` | `"link"`
+
+      Example: sort by name length: >
+        local sorter = function(nodes)
+          table.sort(nodes, function(a, b)
+            return #a.name < #b.name
+          end)
+        end
 <
-*nvim-tree.sort_folders_first*
-Sort folders before files. Has no effect when |nvim-tree.sort_by| is a
-function.
-  Type: `boolean`, Default: `true`
+    *nvim-tree.sort.sort_folders_first*
+    Sort folders before files. Has no effect when |nvim-tree.sort.sorter| is a
+    function.
+      Type: `boolean`, Default: `true`
 
 *nvim-tree.hijack_unnamed_buffer_when_opening*
 Opens in place of the unnamed buffer if it's empty.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -367,6 +367,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   hijack_netrw = true,
   hijack_unnamed_buffer_when_opening = false,
   sort_by = "name",
+  sort_folders_first = true,
   root_dirs = {},
   prefer_startup_root = false,
   sync_root_with_cwd = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -366,8 +366,10 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   hijack_cursor = false,
   hijack_netrw = true,
   hijack_unnamed_buffer_when_opening = false,
-  sort_by = "name",
-  sort_folders_first = true,
+  sort = {
+    sorter = "name",
+    folders_first = true,
+  },
   root_dirs = {},
   prefer_startup_root = false,
   sync_root_with_cwd = false,
@@ -614,7 +616,7 @@ local FIELD_OVERRIDE_TYPECHECK = {
   min = { string = true, ["function"] = true, number = true },
   remove_keymaps = { boolean = true, table = true },
   on_attach = { ["function"] = true, string = true },
-  sort_by = { ["function"] = true, string = true },
+  sorter = { ["function"] = true, string = true },
   root_folder_label = { ["function"] = true, string = true, boolean = true },
   picker = { ["function"] = true, string = true },
 }

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -3,10 +3,10 @@ local M = {}
 local C = {}
 
 --- Predefined comparator, defaulting to name
---- @param sort_by string as per options
+--- @param sorter string as per options
 --- @return function
-local function get_comparator(sort_by)
-  return C[sort_by] or C.name
+local function get_comparator(sorter)
+  return C[sorter] or C.name
 end
 
 ---Create a shallow copy of a portion of a list.
@@ -68,7 +68,7 @@ local function split_merge(t, first, last, comparator)
   merge(t, first, mid, last, comparator)
 end
 
----Perform a merge sort using sort_by option.
+---Perform a merge sort using sorter option.
 ---@param t table nodes
 function M.sort(t)
   if C.user then
@@ -115,7 +115,7 @@ function M.sort(t)
 
     split_merge(t, 1, #t, mini_comparator) -- sort by user order
   else
-    split_merge(t, 1, #t, get_comparator(M.config.sort_by))
+    split_merge(t, 1, #t, get_comparator(M.config.sort.sorter))
   end
 end
 
@@ -124,7 +124,7 @@ local function node_comparator_name_ignorecase_or_not(a, b, ignorecase)
     return true
   end
 
-  if M.config.sort_folders_first then
+  if M.config.sort.folders_first then
     if a.nodes and not b.nodes then
       return true
     elseif not a.nodes and b.nodes then
@@ -152,7 +152,7 @@ function C.modification_time(a, b)
     return true
   end
 
-  if M.config.sort_folders_first then
+  if M.config.sort.folders_first then
     if a.nodes and not b.nodes then
       return true
     elseif not a.nodes and b.nodes then
@@ -180,7 +180,7 @@ function C.suffix(a, b)
   end
 
   -- directories go first
-  if M.config.sort_folders_first then
+  if M.config.sort.folders_first then
     if a.nodes and not b.nodes then
       return true
     elseif not a.nodes and b.nodes then
@@ -231,7 +231,7 @@ function C.extension(a, b)
     return true
   end
 
-  if M.config.sort_folders_first then
+  if M.config.sort.folders_first then
     if a.nodes and not b.nodes then
       return true
     elseif not a.nodes and b.nodes then
@@ -259,7 +259,7 @@ function C.filetype(a, b)
   local b_ft = vim.filetype.match { filename = b.name }
 
   -- directories first
-  if M.config.sort_folders_first then
+  if M.config.sort.folders_first then
     if a.nodes and not b.nodes then
       return true
     elseif not a.nodes and b.nodes then
@@ -284,11 +284,10 @@ end
 
 function M.setup(opts)
   M.config = {}
-  M.config.sort_by = opts.sort_by
-  M.config.sort_folders_first = opts.sort_folders_first
+  M.config.sort = opts.sort
 
-  if type(opts.sort_by) == "function" then
-    C.user = opts.sort_by
+  if type(M.config.sort.sorter) == "function" then
+    C.user = M.config.sort.sorter
   end
 end
 

--- a/lua/nvim-tree/explorer/sorters.lua
+++ b/lua/nvim-tree/explorer/sorters.lua
@@ -123,10 +123,13 @@ local function node_comparator_name_ignorecase_or_not(a, b, ignorecase)
   if not (a and b) then
     return true
   end
-  if a.nodes and not b.nodes then
-    return true
-  elseif not a.nodes and b.nodes then
-    return false
+
+  if M.config.sort_folders_first then
+    if a.nodes and not b.nodes then
+      return true
+    elseif not a.nodes and b.nodes then
+      return false
+    end
   end
 
   if ignorecase then
@@ -148,10 +151,13 @@ function C.modification_time(a, b)
   if not (a and b) then
     return true
   end
-  if a.nodes and not b.nodes then
-    return true
-  elseif not a.nodes and b.nodes then
-    return false
+
+  if M.config.sort_folders_first then
+    if a.nodes and not b.nodes then
+      return true
+    elseif not a.nodes and b.nodes then
+      return false
+    end
   end
 
   local last_modified_a = 0
@@ -174,12 +180,14 @@ function C.suffix(a, b)
   end
 
   -- directories go first
-  if a.nodes and not b.nodes then
-    return true
-  elseif not a.nodes and b.nodes then
-    return false
-  elseif a.nodes and b.nodes then
-    return C.name(a, b)
+  if M.config.sort_folders_first then
+    if a.nodes and not b.nodes then
+      return true
+    elseif not a.nodes and b.nodes then
+      return false
+    elseif a.nodes and b.nodes then
+      return C.name(a, b)
+    end
   end
 
   -- dotfiles go second
@@ -223,10 +231,12 @@ function C.extension(a, b)
     return true
   end
 
-  if a.nodes and not b.nodes then
-    return true
-  elseif not a.nodes and b.nodes then
-    return false
+  if M.config.sort_folders_first then
+    if a.nodes and not b.nodes then
+      return true
+    elseif not a.nodes and b.nodes then
+      return false
+    end
   end
 
   if a.extension and not b.extension then
@@ -249,10 +259,12 @@ function C.filetype(a, b)
   local b_ft = vim.filetype.match { filename = b.name }
 
   -- directories first
-  if a.nodes and not b.nodes then
-    return true
-  elseif not a.nodes and b.nodes then
-    return false
+  if M.config.sort_folders_first then
+    if a.nodes and not b.nodes then
+      return true
+    elseif not a.nodes and b.nodes then
+      return false
+    end
   end
 
   -- one is nil, the other wins
@@ -273,6 +285,7 @@ end
 function M.setup(opts)
   M.config = {}
   M.config.sort_by = opts.sort_by
+  M.config.sort_folders_first = opts.sort_folders_first
 
   if type(opts.sort_by) == "function" then
     C.user = opts.sort_by

--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -41,6 +41,9 @@ local function refactored(opts)
     end
     opts.view.adaptive_size = nil
   end
+
+  -- 2023/07/15
+  utils.move_missing_val(opts, "", "sort_by", opts, "sort", "sorter", true)
 end
 
 local function deprecated(opts)


### PR DESCRIPTION
fixes #2313

`rm -rf * ; mkdir -p a/10 a/20 z/10 z/20 ; touch a/5 a/15 a/25 z/15 b`

sort_by = "name"
sort_folders_first = true
```
  ~/2313/..                   │
    a                       │~
      10                    │~
      20                    │~
       15                    │~
       25                    │~
       5                     │~
    z                       │~
      10                    │~
      20                    │~
       15                    │~
     b                       │~
```

sort_by = "name"
sort_folders_first = false
```
  ~/2313/..                   │
    a                       │~
      10                    │~
       15                    │~
      20                    │~
       25                    │~
       5                     │~
     b                       │~
    z                       │~
      10                    │~
       15                    │~
      20                    │~
```


`rm -rf * ; mkdir -p a.z/10 a.z/20 z.a/10 z.a/20 ; touch a.z/5 a.z/15 a.z/25 z.a/15 b.a`

sort_by = "extension"
sort_folders_first = true
```
  ~/2313/..                   │
    a.z                     │~
      10                    │~
      20                    │~
       15                    │~
       25                    │~
       5                     │~
    z.a                     │~
      10                    │~
      20                    │~
       15                    │~
     b.a                     │~
```

sort_by = "extension"
sort_folders_first = false
```
  ~/2313/..                   │
     b.a                     │~
    a.z                     │~
       15                    │~
       25                    │~
       5                     │~
      10                    │~
      20                    │~
    z.a                     │~
       15                    │~
      10                    │~
      20                    │~
```


`rm -rf * ; mkdir -p a.a.z/10 a.a.z/20 z.a.a/10 z.a.a/20 ; touch a.a.z/5 a.a.z/15 a.a.z/25 z.a.a/15 b.a.a`

sort_by = "suffix"
sort_folders_first = true

```
  ~/2313/..                   │
    a.a.z                   │~
      10                    │~
      20                    │~
       15                    │~
       25                    │~
       5                     │~
    z.a.a                   │~
      10                    │~
      20                    │~
       15                    │~
     b.a.a                   │~
```

sort_by = "suffix"
sort_folders_first = false
```
  ~/2313/..                   │
     b.a.a                   │~
    z.a.a                   │~
      10                    │~
       15                    │~
      20                    │~
    a.a.z                   │~
      10                    │~
       15                    │~
      20                    │~
       25                    │~
       5                     │~
```


`rm -rf * ; mkdir -p a.a.z/10 a.a.z/20 z.a.a/10 z.a.a/20 ; touch a.a.z/5 a.a.z/15 a.a.z/25 z.a.a/15 b.a.a ; sleep 1; touch c.a.a ; sleep 1; touch d.a.a`

sort_by = "modification_time"
sort_folders_first = true
```
  ~/2313/..                   │
    z.a.a                   │~
      10                    │~
      20                    │~
       15                    │~
    a.a.z                   │~
      10                    │~
      20                    │~
       15                    │~
       25                    │~
       5                     │~
     d.a.a                   │~
     c.a.a                   │~
     b.a.a                   │~
```

sort_by = "modification_time"
sort_folders_first = false
```
  ~/2313/..                   │
     d.a.a                   │~
    z.a.a                   │~
      10                    │~
       15                    │~
      20                    │~
     c.a.a                   │~
    a.a.z                   │~
      10                    │~
       15                    │~
      20                    │~
       25                    │~
       5                     │~
     b.a.a                   │~
```


`rm -rf * ; mkdir -p a/10.zig a/20.toml z/10.a z/20 ; touch a/5 a/15.c a/25.txt z/15 b.toml c.c`

sort_by = "filetype"
sort_folders_first = true
```
  ~/2313/..                   │
    a                       │~
      20.toml               │~
      10.zig                │~
       15.c                  │~
      󰈙 25.txt                │~
       5                     │~
    z                       │~
      10.a                  │~
      20                    │~
       15                    │~
     c.c                     │~
     b.toml                  │~
```

sort_by = "filetype"
sort_folders_first = false
```
  ~/2313/..                   │
     c.c                     │~
     b.toml                  │~
    a                       │~
       15.c                  │~
      20.toml               │~
      10.zig                │~
      󰈙 25.txt                │~
       5                     │~
    z                       │~
      10.a                  │~
       15                    │~
      20                    │~
```