### PR TITLE
fix(#1931): do not execute git status in git ignored directories

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -205,7 +205,6 @@ local function setup_autocommands(opts)
   create_nvim_tree_autocmd("BufWritePost", {
     callback = function()
       if opts.auto_reload_on_write and not opts.filesystem_watchers.enable then
-        log.line("dev", "BufWritePost reloading")
         reloaders.reload_explorer()
       end
     end,


### PR DESCRIPTION
fixes #1931

Directory is compared to known ignored from all project and status is not executed:
* first open
* refresh