### PR TITLE
feat(trash): add synchronized trash support for windows

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2292,7 +2292,7 @@ macOS
   system.
 
 Windows WSL and PowerShell
-- Trash is synchronized.
+- Trash is synchronized
 - Executable file detection is disabled as this is non-performant and can
   freeze nvim
 - Some filesystem watcher error related to permissions will not be reported

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2292,6 +2292,7 @@ macOS
   system.
 
 Windows WSL and PowerShell
+- Trash is synchronized.
 - Executable file detection is disabled as this is non-performant and can
   freeze nvim
 - Some filesystem watcher error related to permissions will not be reported

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1148,7 +1148,6 @@ Configuration options for trashing.
     *nvim-tree.trash.cmd*
     The command used to trash items (must be installed on your system).
     The default is shipped with glib2 which is a common linux package.
-    Only available for UNIX.
       Type: `string`, Default: `"gio trash"`
 
 *nvim-tree.actions*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2292,7 +2292,6 @@ macOS
   system.
 
 Windows WSL and PowerShell
-- Trash is unavailable
 - Executable file detection is disabled as this is non-performant and can
   freeze nvim
 - Some filesystem watcher error related to permissions will not be reported

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -52,12 +52,12 @@ function M.fn(node)
   local function trash_path(on_exit)
     local need_sync_wait = utils.is_windows
     local job = vim.fn.jobstart(M.config.trash.cmd .. ' "' .. node.absolute_path .. '"', {
-      detach = true,
+      detach = not need_sync_wait,
       on_exit = on_exit,
       on_stderr = on_stderr,
     })
     if need_sync_wait then
-      vim.fn.jobwait({job})
+      vim.fn.jobwait { job }
     end
   end
 

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -29,8 +29,8 @@ function M.fn(node)
     return
   end
 
+  -- configs
   if utils.is_unix or utils.is_windows then
-    -- configs
     if M.config.trash.cmd == nil then
       M.config.trash.cmd = "trash"
     end

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -30,16 +30,11 @@ function M.fn(node)
   end
 
   -- configs
-  if utils.is_unix then
-    if M.config.trash.cmd == nil then
-      M.config.trash.cmd = "trash"
-    end
-    if M.config.ui.confirm.trash == nil then
-      M.config.ui.confirm.trash = true
-    end
-  else
-    notify.warn "Trash is currently a UNIX only feature!"
-    return
+  if M.config.trash.cmd == nil then
+    M.config.trash.cmd = "trash"
+  end
+  if M.config.ui.confirm.trash == nil then
+    M.config.ui.confirm.trash = true
   end
 
   local binary = M.config.trash.cmd:gsub(" .*$", "")
@@ -55,11 +50,15 @@ function M.fn(node)
 
   -- trashes a path (file or folder)
   local function trash_path(on_exit)
-    vim.fn.jobstart(M.config.trash.cmd .. ' "' .. node.absolute_path .. '"', {
+    local need_sync_wait = utils.is_windows
+    local job = vim.fn.jobstart(M.config.trash.cmd .. ' "' .. node.absolute_path .. '"', {
       detach = true,
       on_exit = on_exit,
       on_stderr = on_stderr,
     })
+    if need_sync_wait then
+      vim.fn.jobwait({job})
+    end
   end
 
   local function do_trash()

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -29,12 +29,17 @@ function M.fn(node)
     return
   end
 
-  -- configs
-  if M.config.trash.cmd == nil then
-    M.config.trash.cmd = "trash"
-  end
-  if M.config.ui.confirm.trash == nil then
-    M.config.ui.confirm.trash = true
+  if utils.is_unix or utils.is_windows then
+    -- configs
+    if M.config.trash.cmd == nil then
+      M.config.trash.cmd = "trash"
+    end
+    if M.config.ui.confirm.trash == nil then
+      M.config.ui.confirm.trash = true
+    end
+  else
+    notify.warn "Trash is currently a UNIX only feature!"
+    return
   end
 
   local binary = M.config.trash.cmd:gsub(" .*$", "")


### PR DESCRIPTION
fixes #2331

Support trash-cli on Windows, relate to discussion https://github.com/nvim-tree/nvim-tree.lua/discussions/2333 and #2331.

1. remove `Unix only` from trash action.
2. set `detach=false` and `jobwait { job }` on Windows to make trash operation sync on Windows. This is because: in my testing/practicing, when set `detach=true` in jobstart, nvim (running in Windows Terminal app) quickly switch to desktop, then switch back to nvim, that makes the screen blink. I guess the **process detech** behaviour is different under Windows, to avoid this blink I set sync wait under Windows.
3. manual tested on Windows 10 x86_64, nvim v0.9.1, latest nvim-tree master.