### PR TITLE
fix: trash.cmd defaults to 'trash' on macos

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1149,9 +1149,9 @@ Configuration options for trashing.
     *nvim-tree.trash.cmd*
     The command used to trash items (must be installed on your system).
     The default `"gio trash"` is shipped with glib2 which is a common linux package.
-    The default `"gio trash"` is shipped with glib2 which is a common linux package.
-    The macOS default `"trash"` is part of the base operating system.
-      Type: `string`, Default: `"gio trash"` or `"trash"`
+    macOS default `"trash"` requires the homebrew package `trash`
+    Windows default `"???"` requires TODO @linrongbin16  
+      Type: `string`, Default: `"gio trash"` or `"trash"` or `"TODO @linrongbin16"`
 
 *nvim-tree.actions*
 Configuration for various actions.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1147,9 +1147,10 @@ Configuration options for trashing.
 
     *nvim-tree.trash.cmd*
     The command used to trash items (must be installed on your system).
-    The default is shipped with glib2 which is a common linux package.
     Only available for UNIX.
-      Type: `string`, Default: `"gio trash"`
+    The default `"gio trash"` is shipped with glib2 which is a common linux package.
+    The macOS default `"trash"` is part of the base operating system.
+      Type: `string`, Default: `"gio trash"` or `"trash"`
 
 *nvim-tree.actions*
 Configuration for various actions.
@@ -2288,7 +2289,6 @@ vim.keymap.set("n", "<leader>ms", require("nvim-tree.api").marks.navigate.select
  10. OS SPECIFIC RESTRICTIONS                          *nvim-tree-os-specific*
 
 macOS
-- Trash is unavailable
 - Rename to different case is not possible when using a case insensitive file
   system.
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1148,10 +1148,10 @@ Configuration options for trashing.
 
     *nvim-tree.trash.cmd*
     The command used to trash items (must be installed on your system).
-    The default `"gio trash"` is shipped with glib2 which is a common linux package.
-    macOS default `"trash"` requires the homebrew package `trash`
-    Windows default `"???"` requires TODO @linrongbin16  
-      Type: `string`, Default: `"gio trash"` or `"trash"` or `"TODO @linrongbin16"`
+    The default     `"gio trash"` is shipped with glib2 which is a common linux package.
+    macOS default   `"trash"` requires the homebrew package `trash`
+    Windows default `"trash"` requires `trash-cli` or similar
+      Type: `string`, Default: `"gio trash"` or `"trash"`
 
 *nvim-tree.actions*
 Configuration for various actions.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -673,6 +673,8 @@ end
 local function localise_default_opts()
   if utils.is_macos then
     DEFAULT_OPTS.trash.cmd = "trash"
+  elseif utils.is_windows then
+    DEFAULT_OPTS.trash.cmd = "TODO @linrongbin16"
   end
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -671,10 +671,8 @@ end
 
 --- Apply OS specific localisations to DEFAULT_OPTS
 local function localise_default_opts()
-  if utils.is_macos then
+  if utils.is_macos or utils.is_windows then
     DEFAULT_OPTS.trash.cmd = "trash"
-  elseif utils.is_windows then
-    DEFAULT_OPTS.trash.cmd = "TODO @linrongbin16"
   end
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -663,6 +663,13 @@ local function validate_options(conf)
   end
 end
 
+--- Apply OS specific localisations to DEFAULT_OPTS
+local function localise_default_opts()
+  if utils.is_macos then
+    DEFAULT_OPTS.trash.cmd = "trash"
+  end
+end
+
 function M.purge_all_state()
   require("nvim-tree.watcher").purge_watchers()
   view.close_all_tabs()
@@ -680,6 +687,8 @@ function M.setup(conf)
   end
 
   M.init_root = vim.fn.getcwd()
+
+  localise_default_opts()
 
   legacy.migrate_legacy_options(conf or {})
 

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -29,19 +29,6 @@ function M.fn(node)
     return
   end
 
-  -- configs
-  if utils.is_unix or utils.is_windows then
-    if M.config.trash.cmd == nil then
-      M.config.trash.cmd = "trash"
-    end
-    if M.config.ui.confirm.trash == nil then
-      M.config.ui.confirm.trash = true
-    end
-  else
-    notify.warn "Trash is currently a UNIX only feature!"
-    return
-  end
-
   local binary = M.config.trash.cmd:gsub(" .*$", "")
   if vim.fn.executable(binary) == 0 then
     notify.warn(string.format("trash.cmd '%s' is not available.", M.config.trash.cmd))

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -44,7 +44,7 @@ function M.fn(node)
 
   local binary = M.config.trash.cmd:gsub(" .*$", "")
   if vim.fn.executable(binary) == 0 then
-    notify.warn(binary .. " is not executable.")
+    notify.warn(string.format("trash.cmd '%s' is not available.", M.config.trash.cmd))
     return
   end
 

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -31,7 +31,7 @@ function M.fn(node)
 
   local binary = M.config.trash.cmd:gsub(" .*$", "")
   if vim.fn.executable(binary) == 0 then
-    notify.warn(string.format("trash.cmd '%s' is not available.", M.config.trash.cmd))
+    notify.warn(string.format("trash.cmd '%s' is not an executable.", M.config.trash.cmd))
     return
   end
 


### PR DESCRIPTION
fixes #1366 