### PR TITLE
feat: add actions.open_file.eject

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -494,6 +494,7 @@ applying configuration.
         },
         open_file = {
           quit_on_open = false,
+          prevent_buffer_override = true,
           resize_window = true,
           window_picker = {
             enable = true,
@@ -1203,8 +1204,11 @@ Configuration for various actions.
 
         *nvim-tree.actions.open_file.quit_on_open*
         Closes the explorer when opening a file.
-        It will also disable preventing a buffer overriding the tree.
           Type: `boolean`, Default: `false`
+
+        *nvim-tree.actions.open_file.prevent_buffer_override*
+        Prevent new opened file from opening in the same window as the tree.
+          Type: `boolean`, Default: `true`
 
         *nvim-tree.actions.open_file.resize_window*  (previously `view.auto_resize`)
         Resizes the tree when opening a file.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -494,7 +494,7 @@ applying configuration.
         },
         open_file = {
           quit_on_open = false,
-          prevent_buffer_override = true,
+          eject = true,
           resize_window = true,
           window_picker = {
             enable = true,
@@ -1206,7 +1206,7 @@ Configuration for various actions.
         Closes the explorer when opening a file.
           Type: `boolean`, Default: `false`
 
-        *nvim-tree.actions.open_file.prevent_buffer_override*
+        *nvim-tree.actions.open_file.eject*
         Prevent new opened file from opening in the same window as the tree.
           Type: `boolean`, Default: `true`
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -196,7 +196,7 @@ local function setup_autocommands(opts)
   create_nvim_tree_autocmd("BufWipeout", {
     pattern = "NvimTree_*",
     callback = function()
-      if utils.is_nvim_tree_buf(0) and opts.actions.open_file.prevent_buffer_override then
+      if utils.is_nvim_tree_buf(0) and opts.actions.open_file.eject then
         view._prevent_buffer_override()
       end
     end,
@@ -545,7 +545,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
     open_file = {
       quit_on_open = false,
-      prevent_buffer_override = true,
+      eject = true,
       resize_window = true,
       window_picker = {
         enable = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -192,17 +192,15 @@ local function setup_autocommands(opts)
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 
-  if opts.actions.open_file.prevent_buffer_override then
-    -- prevent new opened file from opening in the same window as nvim-tree
-    create_nvim_tree_autocmd("BufWipeout", {
-      pattern = "NvimTree_*",
-      callback = function()
-        if utils.is_nvim_tree_buf(0) then
-          view._prevent_buffer_override()
-        end
-      end,
-    })
-  end
+  -- prevent new opened file from opening in the same window as nvim-tree
+  create_nvim_tree_autocmd("BufWipeout", {
+    pattern = "NvimTree_*",
+    callback = function()
+      if utils.is_nvim_tree_buf(0) and opts.actions.open_file.prevent_buffer_override then
+        view._prevent_buffer_override()
+      end
+    end,
+  })
 
   create_nvim_tree_autocmd("BufWritePost", {
     callback = function()

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -192,15 +192,17 @@ local function setup_autocommands(opts)
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 
-  -- prevent new opened file from opening in the same window as nvim-tree
-  create_nvim_tree_autocmd("BufWipeout", {
-    pattern = "NvimTree_*",
-    callback = function()
-      if utils.is_nvim_tree_buf(0) then
-        view._prevent_buffer_override()
-      end
-    end,
-  })
+  if opts.actions.open_file.prevent_buffer_override then
+    -- prevent new opened file from opening in the same window as nvim-tree
+    create_nvim_tree_autocmd("BufWipeout", {
+      pattern = "NvimTree_*",
+      callback = function()
+        if utils.is_nvim_tree_buf(0) then
+          view._prevent_buffer_override()
+        end
+      end,
+    })
+  end
 
   create_nvim_tree_autocmd("BufWritePost", {
     callback = function()
@@ -545,6 +547,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
     open_file = {
       quit_on_open = false,
+      prevent_buffer_override = true,
       resize_window = true,
       window_picker = {
         enable = true,


### PR DESCRIPTION
Hello!

In issue #1628 and PR #1637 the following expected behavior was introduced. When opening a file using `:edit` (or Telescope) while being focused on nvim-tree window, the new file opens in another window (and, depending on `quit_on_open` option, the nvim-tree window either stays or closes). This is useful when using nvim-tree in "expected" way, i.e. as a narrow column window on the side, which can be toggled on and off.

However, I'd like to use nvim-tree as a replacement of netrw: I would mostly want to open files from the tree in-place, overriding the tree window. While there already exists an API function `api.node.open.replace_tree_buffer` which performs an in-place open, issuing `:e` or using Telescope does not make the desired in-place open.

This PR adds an option `nvim-tree.actions.open_file.eject`, which is `true` by default (current behavior). When it's `false`, it disables nvim-tree hijacking of such in-place opens: the new file will be opened in the same window, replacing nvim-tree.

Please provide feedback, whether this option would be useful (or whether there is already another way to achieve the desired effect). Thank you

