### PR TITLE
fix(#2343): tree is now correctly abandoned upon an in-place open with eject=false

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -196,8 +196,13 @@ local function setup_autocommands(opts)
   create_nvim_tree_autocmd("BufWipeout", {
     pattern = "NvimTree_*",
     callback = function()
-      if utils.is_nvim_tree_buf(0) and opts.actions.open_file.eject then
+      if not utils.is_nvim_tree_buf(0) then
+        return
+      end
+      if opts.actions.open_file.eject then
         view._prevent_buffer_override()
+      else
+        view.abandon_current_window()
       end
     end,
   })


### PR DESCRIPTION
Closes #2343