### PR TITLE
feat(#2305): find file refreshes up the tree when node is not present

### DIFF
--- a/lua/nvim-tree/actions/finders/find-file.lua
+++ b/lua/nvim-tree/actions/finders/find-file.lua
@@ -2,6 +2,7 @@ local log = require "nvim-tree.log"
 local view = require "nvim-tree.view"
 local utils = require "nvim-tree.utils"
 local renderer = require "nvim-tree.renderer"
+local reload = require "nvim-tree.explorer.reload"
 local core = require "nvim-tree.core"
 local Iterator = require "nvim-tree.iterators.node-iterator"
 
@@ -29,8 +30,10 @@ function M.fn(path)
 
   local profile = log.profile_start("find file %s", path_real)
 
-  -- force a re-expand when the node is not in the tree
-  local node_present = utils.get_node_from_path(path_real) ~= nil
+  -- refresh the contents of all parents, expanding groups as needed
+  if utils.get_node_from_path(path_real) == nil then
+    reload.refresh_parent_nodes_for_path(vim.fn.fnamemodify(path_real, ":h"))
+  end
 
   local line = core.get_nodes_starting_line()
 
@@ -57,7 +60,7 @@ function M.fn(path)
         if not node.group_next then
           node.open = true
         end
-        if #node.nodes == 0 or not node_present then
+        if #node.nodes == 0 then
           core.get_explorer():expand(node)
         end
       end

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -7,6 +7,7 @@ local live_filter = require "nvim-tree.live-filter"
 local git = require "nvim-tree.git"
 local log = require "nvim-tree.log"
 
+local NodeIterator = require "nvim-tree.iterators.node-iterator"
 local Watcher = require "nvim-tree.watcher"
 
 local M = {}
@@ -158,6 +159,44 @@ function M.refresh_node(node, callback)
 
     callback()
   end)
+end
+
+---Refresh contents of all nodes to a path: actual directory and links.
+---Groups will be expanded if needed.
+---@param path string absolute path
+function M.refresh_parent_nodes_for_path(path)
+  local explorer = require("nvim-tree.core").get_explorer()
+  if not explorer then
+    return
+  end
+
+  local profile = log.profile_start("refresh_parent_nodes_for_path %s", path)
+
+  -- collect parent nodes from the top down
+  local parent_nodes = {}
+  NodeIterator.builder({ explorer })
+    :recursor(function(node)
+      return node.nodes
+    end)
+    :applier(function(node)
+      local abs_contains = node.absolute_path and path:find(node.absolute_path, 1, true) == 1
+      local link_contains = node.link_to and path:find(node.link_to, 1, true) == 1
+      if abs_contains or link_contains then
+        table.insert(parent_nodes, node)
+      end
+    end)
+    :iterate()
+
+  -- refresh in order; this will expand groups as needed
+  for _, node in ipairs(parent_nodes) do
+    local project_root = git.get_project_root(node.absolute_path)
+    local project = git.get_project(project_root) or {}
+
+    M.reload(node, project)
+    update_parent_statuses(node, project, project_root)
+  end
+
+  log.profile_end(profile)
 end
 
 function M.setup(opts)


### PR DESCRIPTION
fixes #2305 
fixes #2347

I think I've finally got it right this time. Recursion should be no problem as the tree is not mutated during traversal.