### PR TITLE
fix(#2352): windows: escape special filename characters on edit

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -270,7 +270,7 @@ local function open_in_new_window(filename, mode)
   end
 
   local fname = vim.fn.fnameescape(filename)
-  if vim.fn.has "win32" == 1 or vim.fn.has "win32unix" == 1 then
+  if utils.is_windows then
     fname = fname:gsub("%(", "\\("):gsub("%)", "\\)")
   end
 

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -270,9 +270,7 @@ local function open_in_new_window(filename, mode)
   end
 
   local fname = vim.fn.fnameescape(filename)
-  if utils.is_windows then
-    fname = fname:gsub("%(", "\\("):gsub("%)", "\\)")
-  end
+  fname = utils.escape_windows_special_chars(fname)
 
   local cmd
   if create_new_window then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -270,6 +270,9 @@ local function open_in_new_window(filename, mode)
   end
 
   local fname = vim.fn.fnameescape(filename)
+  if vim.fn.has "win32" == 1 or vim.fn.has "win32unix" == 1 then
+    fname = fname:gsub("%(", "\\("):gsub("%)", "\\)")
+  end
 
   local cmd
   if create_new_window then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -270,7 +270,7 @@ local function open_in_new_window(filename, mode)
   end
 
   local fname = vim.fn.fnameescape(filename)
-  fname = utils.escape_windows_special_chars(fname)
+  fname = utils.escape_special_chars(fname)
 
   local cmd
   if create_new_window then

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -211,10 +211,13 @@ function M.canonical_path(path)
 end
 
 -- Escapes special characters in string if windows else returns unmodified string.
--- @param string string
--- @return string
-function M.escape_windows_special_chars(string)
-  return M.is_windows and string:gsub("%(", "\\("):gsub("%)", "\\)") or string
+-- @param path string
+-- @return path
+function M.escape_special_chars(path)
+  if path == nil then
+    return path
+  end
+  return M.is_windows and path:gsub("%(", "\\("):gsub("%)", "\\)") or path
 end
 
 -- Create empty sub-tables if not present

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -214,10 +214,7 @@ end
 -- @param string string
 -- @return string
 function M.escape_windows_special_chars(string)
-  if M.is_windows then
-    return string:gsub("%(", "\\("):gsub("%)", "\\)")
-  end
-  return string
+  return M.is_windows and string:gsub("%(", "\\("):gsub("%)", "\\)") or string
 end
 
 -- Create empty sub-tables if not present

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -210,6 +210,16 @@ function M.canonical_path(path)
   return path
 end
 
+-- Escapes special characters in string if windows else returns unmodified string.
+-- @param string string
+-- @return string
+function M.escape_windows_special_chars(string)
+  if M.is_windows then
+    return string:gsub("%(", "\\("):gsub("%)", "\\)")
+  end
+  return string
+end
+
 -- Create empty sub-tables if not present
 -- @param tbl to create empty inside of
 -- @param path dot separated string of sub-tables


### PR DESCRIPTION
fixes #2352
- add check if environment is windows
- if windows, escape special characters

This works on windows, will need additional linux/mac testing.