### PR TITLE
fix(#2370): Better "y/N" prompts

### DIFF
--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -110,8 +110,8 @@ local function do_single_paste(source, dest, action_type, action_fn)
       end)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
-      local prompt_input = prompt_select .. " y/n/R(ename): "
-      lib.prompt(prompt_input, prompt_select, { "r", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
+      local prompt_input = prompt_select .. " R(ename)/y/n: "
+      lib.prompt(prompt_input, prompt_select, { "r", "y" }, { "Rename", "Yes" }, function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -110,8 +110,8 @@ local function do_single_paste(source, dest, action_type, action_fn)
       end)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
-      local prompt_input = prompt_select .. " y/n/r(ename): "
-      lib.prompt(prompt_input, prompt_select, { "y", "n", "r" }, { "Yes", "No", "Rename" }, function(item_short)
+      local prompt_input = prompt_select .. " y/n/R(ename): "
+      lib.prompt(prompt_input, prompt_select, { "r", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -111,11 +111,11 @@ local function do_single_paste(source, dest, action_type, action_fn)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
       local prompt_input = prompt_select .. " R(ename)/y/n: "
-      lib.prompt(prompt_input, prompt_select, { "r", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
+      lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()
-        elseif item_short == "r" then
+        elseif item_short == "" or item_short == "r" then
           vim.ui.input({ prompt = "Rename to ", default = dest, completion = "dir" }, function(new_dest)
             utils.clear_prompt()
             if new_dest then

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -111,7 +111,7 @@ local function do_single_paste(source, dest, action_type, action_fn)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
       local prompt_input = prompt_select .. " R(ename)/y/n: "
-      lib.prompt(prompt_input, prompt_select, { "r", "y" }, { "Rename", "Yes" }, function(item_short)
+      lib.prompt(prompt_input, prompt_select, { "r", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -108,7 +108,7 @@ function M.fn(node)
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "n", "y" }, { "Default(No)", "Yes", "No" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_remove()

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -108,7 +108,7 @@ function M.fn(node)
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_remove()

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -107,8 +107,8 @@ function M.fn(node)
 
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove " .. node.name .. " ?"
-    local prompt_input = prompt_select .. " y/n: "
-    lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
+    local prompt_input = prompt_select .. " y/N: "
+    lib.prompt(prompt_input, prompt_select, { "", "n", "y" }, { "Default(No)", "Yes", "No" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_remove()

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -84,7 +84,7 @@ function M.fn(node)
   if M.config.ui.confirm.trash then
     local prompt_select = "Trash " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_trash()

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -84,7 +84,7 @@ function M.fn(node)
   if M.config.ui.confirm.trash then
     local prompt_select = "Trash " .. node.name .. " ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Default(No)", "Yes", "No" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_trash()

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -83,8 +83,8 @@ function M.fn(node)
 
   if M.config.ui.confirm.trash then
     local prompt_select = "Trash " .. node.name .. " ?"
-    local prompt_input = prompt_select .. " y/n: "
-    lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
+    local prompt_input = prompt_select .. " y/N: "
+    lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Default(No)", "Yes", "No" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_trash()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -148,7 +148,9 @@ function M.prompt(prompt_input, prompt_select, items_short, items_long, callback
     end)
   else
     vim.ui.input({ prompt = prompt_input, default = items_short[1] or "" }, function(item_short)
-      callback(string.lower(item_short and item_short:sub(1, 1)) or nil)
+      if item_short then
+        callback(string.lower(item_short and item_short:sub(1, 1)) or nil)
+      end
     end)
   end
 end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -148,7 +148,7 @@ function M.prompt(prompt_input, prompt_select, items_short, items_long, callback
     end)
   else
     vim.ui.input({ prompt = prompt_input, default = items_short[1] or "" }, function(item_short)
-      callback(item_short and item_short:sub(1, 1) or nil)
+      callback(string.lower(item_short and item_short:sub(1, 1)) or nil)
     end)
   end
 end

--- a/lua/nvim-tree/marks/bulk-delete.lua
+++ b/lua/nvim-tree/marks/bulk-delete.lua
@@ -33,7 +33,7 @@ function M.bulk_delete()
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_delete(nodes)

--- a/lua/nvim-tree/marks/bulk-delete.lua
+++ b/lua/nvim-tree/marks/bulk-delete.lua
@@ -33,7 +33,7 @@ function M.bulk_delete()
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Default(No)", "Yes", "No" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "Default(No)", "Yes" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_delete(nodes)

--- a/lua/nvim-tree/marks/bulk-delete.lua
+++ b/lua/nvim-tree/marks/bulk-delete.lua
@@ -32,8 +32,8 @@ function M.bulk_delete()
 
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove bookmarked ?"
-    local prompt_input = prompt_select .. " y/n: "
-    lib.prompt(prompt_input, prompt_select, { "y", "n" }, { "Yes", "No" }, function(item_short)
+    local prompt_input = prompt_select .. " y/N: "
+    lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Default(No)", "Yes", "No" }, function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_delete(nodes)


### PR DESCRIPTION
fixes #2370.

Packer uses a bool flag comparing to check whether the given input is "y".

I've made it so that the default behaviour of the prompt is set to N for no (don't delete).

The default is set to R(ename) for name conflicts when copy-pasting.

Accidentally clicking enter/return after pressing d/bd should be made less common with this default behaviour.

the default behaviour is shown as a capital letter.