### PR TITLE
fix: expand and collapse whole folder groups

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -74,19 +74,19 @@ end
 
 -- If node is grouped, return the last node in the group. Otherwise, return the given node.
 function M.get_last_group_node(node)
-  local next = node
-  while next.group_next do
-    next = next.group_next
+  local next_node = node
+  while next_node.group_next do
+    next_node = next_node.group_next
   end
-  return next
+  return next_node
 end
 
 function M.get_all_nodes_in_group(node)
-  local next = utils.get_parent_of_group(node)
+  local next_node = utils.get_parent_of_group(node)
   local nodes = {}
-  while next do
-    table.insert(nodes, next)
-    next = next.group_next
+  while next_node do
+    table.insert(nodes, next_node)
+    next_node = next_node.group_next
   end
   return nodes
 end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -81,6 +81,16 @@ function M.get_last_group_node(node)
   return next
 end
 
+function M.get_all_nodes_in_group(node)
+  local next = utils.get_parent_of_group(node)
+  local nodes = {}
+  while next do
+    table.insert(nodes, next)
+    next = next.group_next
+  end
+  return nodes
+end
+
 function M.expand_or_collapse(node)
   if node.has_children then
     node.has_children = false
@@ -90,8 +100,10 @@ function M.expand_or_collapse(node)
     core.get_explorer():expand(node)
   end
 
-  node = M.get_last_group_node(node)
-  node.open = not node.open
+  local open = not M.get_last_group_node(node).open
+  for _, n in ipairs(M.get_all_nodes_in_group(node)) do
+    n.open = open
+  end
 
   renderer.draw()
 end


### PR DESCRIPTION
Currently when opening folder groups, the folder icon and arrow indicators don't change correctly.
Current behaviour:
![image](https://github.com/nvim-tree/nvim-tree.lua/assets/63882624/c0646c5f-be10-4bfa-8824-2d5fe5b148ca)
With this fix:
![image](https://github.com/nvim-tree/nvim-tree.lua/assets/63882624/ee9e15db-32dd-496f-94ec-a64e76a53bd3)