### PR TITLE
fix(#2382): git watcher handles worktrees and submodules, via --absolute-git-dir when it is available

### DIFF
--- a/lua/nvim-tree/actions/reloaders/reloaders.lua
+++ b/lua/nvim-tree/actions/reloaders/reloaders.lua
@@ -12,8 +12,8 @@ local function refresh_nodes(node, projects, unloaded_bufnr)
   Iterator.builder({ node })
     :applier(function(n)
       if n.open and n.nodes then
-        local project_root = git.get_project_root(n.cwd or n.link_to or n.absolute_path)
-        explorer_module.reload(n, projects[project_root] or {}, unloaded_bufnr)
+        local toplevel = git.get_toplevel(n.cwd or n.link_to or n.absolute_path)
+        explorer_module.reload(n, projects[toplevel] or {}, unloaded_bufnr)
       end
     end)
     :recursor(function(n)
@@ -23,8 +23,8 @@ local function refresh_nodes(node, projects, unloaded_bufnr)
 end
 
 function M.reload_node_status(parent_node, projects)
-  local project_root = git.get_project_root(parent_node.absolute_path)
-  local status = projects[project_root] or {}
+  local toplevel = git.get_toplevel(parent_node.absolute_path)
+  local status = projects[toplevel] or {}
   for _, node in ipairs(parent_node.nodes) do
     explorer_node.update_git_status(node, explorer_node.is_git_ignored(parent_node), status)
     if node.nodes and #node.nodes > 0 then

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -22,10 +22,10 @@ local function update_status(nodes_by_path, node_ignored, status)
 end
 
 local function reload_and_get_git_project(path, callback)
-  local project_root = git.get_project_root(path)
+  local toplevel = git.get_toplevel(path)
 
-  git.reload_project(project_root, path, function()
-    callback(project_root, git.get_project(project_root) or {})
+  git.reload_project(toplevel, path, function()
+    callback(toplevel, git.get_project(toplevel) or {})
   end)
 end
 
@@ -38,7 +38,7 @@ local function update_parent_statuses(node, project, root)
         break
       end
 
-      root = git.get_project_root(node.parent.absolute_path)
+      root = git.get_toplevel(node.parent.absolute_path)
 
       -- stop when no more projects
       if not root then
@@ -174,10 +174,10 @@ function M.refresh_node(node, callback)
 
   local parent_node = utils.get_parent_of_group(node)
 
-  reload_and_get_git_project(node.absolute_path, function(project_root, project)
+  reload_and_get_git_project(node.absolute_path, function(toplevel, project)
     require("nvim-tree.explorer.reload").reload(parent_node, project)
 
-    update_parent_statuses(parent_node, project, project_root)
+    update_parent_statuses(parent_node, project, toplevel)
 
     callback()
   end)
@@ -211,11 +211,11 @@ function M.refresh_parent_nodes_for_path(path)
 
   -- refresh in order; this will expand groups as needed
   for _, node in ipairs(parent_nodes) do
-    local project_root = git.get_project_root(node.absolute_path)
-    local project = git.get_project(project_root) or {}
+    local toplevel = git.get_toplevel(node.absolute_path)
+    local project = git.get_project(toplevel) or {}
 
     M.reload(node, project)
-    update_parent_statuses(node, project, project_root)
+    update_parent_statuses(node, project, toplevel)
   end
 
   log.profile_end(profile)

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -98,7 +98,7 @@ function M.reload_project(toplevel, path, callback)
   end
 
   local opts = {
-    project_root = toplevel,
+    toplevel = toplevel,
     path = path,
     list_untracked = git_utils.should_show_untracked(toplevel),
     list_ignored = true,
@@ -226,7 +226,7 @@ function M.load_project_status(path)
   end
 
   local git_status = Runner.run {
-    project_root = toplevel,
+    toplevel = toplevel,
     list_untracked = git_utils.should_show_untracked(toplevel),
     list_ignored = true,
     timeout = M.config.git.timeout,

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -246,9 +246,7 @@ function M.load_project_status(path)
       end)
     end
 
-    local git_dir = vim.env.GIT_DIR
-      or M._git_dirs_by_toplevel[toplevel]
-      or utils.path_join { toplevel, ".git" }
+    local git_dir = vim.env.GIT_DIR or M._git_dirs_by_toplevel[toplevel] or utils.path_join { toplevel, ".git" }
     watcher = Watcher:new(git_dir, WATCHED_FILES, callback, {
       toplevel = toplevel,
     })

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -217,7 +217,9 @@ function M.load_project_status(cwd)
       end)
     end
 
-    local git_dir = vim.env.GIT_DIR or M.project_root_to_git_dir[project_root] or utils.path_join { project_root, ".git" }
+    local git_dir = vim.env.GIT_DIR
+      or M.project_root_to_git_dir[project_root]
+      or utils.path_join { project_root, ".git" }
     watcher = Watcher:new(git_dir, WATCHED_FILES, callback, {
       project_root = project_root,
     })

--- a/lua/nvim-tree/git/runner.lua
+++ b/lua/nvim-tree/git/runner.lua
@@ -14,7 +14,7 @@ function Runner:_parse_status_output(status, path)
     path = path:gsub("/", "\\")
   end
   if #status > 0 and #path > 0 then
-    self.output[utils.path_remove_trailing(utils.path_join { self.project_root, path })] = status
+    self.output[utils.path_remove_trailing(utils.path_join { self.toplevel, path })] = status
   end
 end
 
@@ -57,7 +57,7 @@ function Runner:_getopts(stdout_handle, stderr_handle)
   local ignored = (self.list_untracked and self.list_ignored) and "--ignored=matching" or "--ignored=no"
   return {
     args = { "--no-optional-locks", "status", "--porcelain=v1", "-z", ignored, untracked, self.path },
-    cwd = self.project_root,
+    cwd = self.toplevel,
     stdio = { nil, stdout_handle, stderr_handle },
   }
 end
@@ -151,7 +151,7 @@ end
 
 function Runner:_finalise(opts)
   if self.rc == -1 then
-    log.line("git", "job timed out  %s %s", opts.project_root, opts.path)
+    log.line("git", "job timed out  %s %s", opts.toplevel, opts.path)
     timeouts = timeouts + 1
     if timeouts == MAX_TIMEOUTS then
       notify.warn(
@@ -164,9 +164,9 @@ function Runner:_finalise(opts)
       require("nvim-tree.git").disable_git_integration()
     end
   elseif self.rc ~= 0 then
-    log.line("git", "job fail rc %d %s %s", self.rc, opts.project_root, opts.path)
+    log.line("git", "job fail rc %d %s %s", self.rc, opts.toplevel, opts.path)
   else
-    log.line("git", "job success    %s %s", opts.project_root, opts.path)
+    log.line("git", "job success    %s %s", opts.toplevel, opts.path)
   end
 end
 
@@ -176,7 +176,7 @@ end
 --- @return table|nil status by absolute path, nil if callback present
 function Runner.run(opts, callback)
   local self = setmetatable({
-    project_root = opts.project_root,
+    toplevel = opts.toplevel,
     path = opts.path,
     list_untracked = opts.list_untracked,
     list_ignored = opts.list_ignored,
@@ -186,7 +186,7 @@ function Runner.run(opts, callback)
   }, Runner)
 
   local async = callback ~= nil
-  local profile = log.profile_start("git %s job %s %s", async and "async" or "sync", opts.project_root, opts.path)
+  local profile = log.profile_start("git %s job %s %s", async and "async" or "sync", opts.toplevel, opts.path)
 
   if async and callback then
     -- async, always call back

--- a/lua/nvim-tree/git/utils.lua
+++ b/lua/nvim-tree/git/utils.lua
@@ -24,7 +24,7 @@ function M.get_toplevel(cwd)
     return nil, nil
   end
 
-  local toplevel, git_dir = out:match("([^\n]+)\n+([^\n]+)")
+  local toplevel, git_dir = out:match "([^\n]+)\n+([^\n]+)"
   if not toplevel then
     return nil, nil
   end

--- a/lua/nvim-tree/git/utils.lua
+++ b/lua/nvim-tree/git/utils.lua
@@ -1,40 +1,55 @@
 local M = {}
 local log = require "nvim-tree.log"
+local utils = require "nvim-tree.utils"
 
 local has_cygpath = vim.fn.executable "cygpath" == 1
 
 --- Retrieve the git toplevel directory
 --- @param cwd string path
 --- @return string|nil toplevel absolute path
+--- @return string|nil git_dir absolute path
 function M.get_toplevel(cwd)
-  local profile = log.profile_start("git toplevel %s", cwd)
+  local profile = log.profile_start("git toplevel git_dir %s", cwd)
 
-  local cmd = { "git", "-C", cwd, "rev-parse", "--show-toplevel" }
-  log.line("git", "%s", vim.inspect(cmd))
+  -- both paths are absolute
+  local cmd = { "git", "-C", cwd, "rev-parse", "--show-toplevel", "--absolute-git-dir" }
+  log.line("git", "%s", table.concat(cmd, " "))
 
-  local toplevel = vim.fn.system(cmd)
+  local out = vim.fn.system(cmd)
 
-  log.raw("git", toplevel)
+  log.raw("git", out)
   log.profile_end(profile)
 
-  if vim.v.shell_error ~= 0 or not toplevel or #toplevel == 0 or toplevel:match "fatal" then
-    return nil
+  if vim.v.shell_error ~= 0 or not out or #out == 0 or out:match "fatal" then
+    return nil, nil
+  end
+
+  local toplevel, git_dir = out:match("([^\n]+)\n+([^\n]+)")
+  if not toplevel then
+    return nil, nil
+  end
+  if not git_dir then
+    git_dir = utils.path_join { toplevel, ".git" }
   end
 
   -- git always returns path with forward slashes
   if vim.fn.has "win32" == 1 then
     -- msys2 git support
     if has_cygpath then
-      toplevel = vim.fn.system("cygpath -w " .. vim.fn.shellescape(toplevel:sub(0, -2)))
+      toplevel = vim.fn.system("cygpath -w " .. vim.fn.shellescape(toplevel))
       if vim.v.shell_error ~= 0 then
-        return nil
+        return nil, nil
+      end
+      git_dir = vim.fn.system("cygpath -w " .. vim.fn.shellescape(git_dir))
+      if vim.v.shell_error ~= 0 then
+        return nil, nil
       end
     end
     toplevel = toplevel:gsub("/", "\\")
+    git_dir = git_dir:gsub("/", "\\")
   end
 
-  -- remove newline
-  return toplevel:sub(0, -2)
+  return toplevel, git_dir
 end
 
 local untracked = {}
@@ -47,7 +62,7 @@ function M.should_show_untracked(cwd)
   local profile = log.profile_start("git untracked %s", cwd)
 
   local cmd = { "git", "-C", cwd, "config", "status.showUntrackedFiles" }
-  log.line("git", vim.inspect(cmd))
+  log.line("git", table.concat(cmd, " "))
 
   local has_untracked = vim.fn.system(cmd)
 


### PR DESCRIPTION
fixes #2382 

This is clunky: using yet another map for project roots is fragile and not easily maintainable.

Possible refactor: make `get_project_root` private, migrating to `get_project` or similar. Trim down init to do nothing but create the entire project and watchers.