### PR TITLE
fix(#2392): bookmarks vertical alignment when group_empty

### DIFF
--- a/lua/nvim-tree/marks/init.lua
+++ b/lua/nvim-tree/marks/init.lua
@@ -62,15 +62,15 @@ function M.draw()
   local buf = view.get_bufnr()
   local add = core.get_nodes_starting_line() - 1
   Iterator.builder(core.get_explorer().nodes)
-      :recursor(function(node)
-        return node.group_next and { node.group_next } or (node.open and node.nodes)
-      end)
-      :applier(function(node, idx)
-        if M.get_mark(node) then
-          vim.fn.sign_place(0, GROUP, SIGN_NAME, buf, { lnum = idx + add, priority = 3 })
-        end
-      end)
-      :iterate()
+    :recursor(function(node)
+      return node.group_next and { node.group_next } or (node.open and node.nodes)
+    end)
+    :applier(function(node, idx)
+      if M.get_mark(node) then
+        vim.fn.sign_place(0, GROUP, SIGN_NAME, buf, { lnum = idx + add, priority = 3 })
+      end
+    end)
+    :iterate()
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/marks/init.lua
+++ b/lua/nvim-tree/marks/init.lua
@@ -62,15 +62,15 @@ function M.draw()
   local buf = view.get_bufnr()
   local add = core.get_nodes_starting_line() - 1
   Iterator.builder(core.get_explorer().nodes)
-    :recursor(function(node)
-      return node.open and node.nodes
-    end)
-    :applier(function(node, idx)
-      if M.get_mark(node) then
-        vim.fn.sign_place(0, GROUP, SIGN_NAME, buf, { lnum = idx + add, priority = 3 })
-      end
-    end)
-    :iterate()
+      :recursor(function(node)
+        return node.group_next and { node.group_next } or (node.open and node.nodes)
+      end)
+      :applier(function(node, idx)
+        if M.get_mark(node) then
+          vim.fn.sign_place(0, GROUP, SIGN_NAME, buf, { lnum = idx + add, priority = 3 })
+        end
+      end)
+      :iterate()
 end
 
 function M.setup(opts)


### PR DESCRIPTION
When `group_empty` is enabled, marks were misaligned if one or more parent nodes were empty. See #2392 

Followed the code logic as proposed [here](https://github.com/nvim-tree/nvim-tree.lua/commit/d8b154c5f0981886fc2b0f1e52d6172e7fdd13e4)

I'm not super confident I've taken all that needs to be into account. It seems to work (see screenshots), but it got fixed quite fast, which doesn't make me confident. Please review with that in mind!..

`group_empty` enabled:
![Screenshot 2023-09-04 at 19 04 48](https://github.com/nvim-tree/nvim-tree.lua/assets/83029642/4f9630d0-5366-401f-a027-c1df5632bb77)

`group_empty` disabled (showing that marks are still aligned):
![Screenshot 2023-09-04 at 19 04 25](https://github.com/nvim-tree/nvim-tree.lua/assets/83029642/86896b41-761e-4d4e-8f53-04fb44ee1a4d)


I used the below tree structure (start is just a start script I made):
![Screenshot 2023-09-04 at 19 15 41](https://github.com/nvim-tree/nvim-tree.lua/assets/83029642/94b92821-779e-4d03-848c-19642fed0c43)

Below was the minimal config I was using:
```lua
vim.g.loaded_netrw = 1
vim.g.loaded_netrwPlugin = 1

vim.cmd [[set runtimepath=$VIMRUNTIME]]
vim.cmd [[set packpath=/tmp/nvt-min/site]]
local package_root = "/tmp/nvt-min/site/pack"
local install_path = package_root .. "/packer/start/packer.nvim"
local function load_plugins()
    require("packer").startup {
        {
            "wbthomason/packer.nvim",
            "~/tjroot/dev/neovim/nvim-tree.lua",
            "nvim-tree/nvim-web-devicons",
            -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
        },
        config = {
            package_root = package_root,
            compile_path = install_path .. "/plugin/packer_compiled.lua",
            display = { non_interactive = true },
        },
    }
end
if vim.fn.isdirectory(install_path) == 0 then
    print "Installing nvim-tree and dependencies."
    vim.fn.system { "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path }
end
load_plugins()
require("packer").sync()
vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]]
vim.opt.termguicolors = true
vim.opt.cursorline = true

_G.setup = function()
    require("nvim-tree").setup {
        renderer = {
            group_empty = true
        },
    }
end
```
