### PR TITLE
feat: validate some option string values

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -691,7 +691,7 @@ local function validate_options(conf)
   validate(conf, DEFAULT_OPTS, ACCEPTED_STRINGS, "")
 
   if msg then
-    vim.notify_once(msg .. " | see :help nvim-tree-setup for available configuration options\n", vim.log.levels.WARN)
+    vim.notify_once(msg .. " | see :help nvim-tree-opts for available configuration options\n", vim.log.levels.WARN)
   end
 end
 


### PR DESCRIPTION
This can be useful to warn the user when a string value is not "accepted" in those cases where strings act like a sort of enum. I don't know if this can be considered a feature or something, let me know...