### PR TITLE
fix: add legacy options safety

### DIFF
--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -23,7 +23,7 @@ local function refactored(opts)
   utils.move_missing_val(opts, "trash", "require_confirm", opts, "ui.confirm", "trash", true)
 
   -- 2023/01/15
-  if opts.view and opts.view.adaptive_size ~= nil then
+  if type(opts.view) == "table" and opts.view.adaptive_size ~= nil then
     if opts.view.adaptive_size and type(opts.view.width) ~= "table" then
       local width = opts.view.width
       opts.view.width = {
@@ -52,7 +52,7 @@ local function refactored(opts)
 end
 
 local function deprecated(opts)
-  if opts.view and opts.view.hide_root_folder then
+  if type(opts.view) == "table" and opts.view.hide_root_folder then
     notify.info "view.hide_root_folder is deprecated, please set renderer.root_folder_label = false"
   end
 end


### PR DESCRIPTION
While testing #2414 I noticed that setting `view` to anything but a table would crash due to this problem in `legacy` module, so I fixed it.