### PR TITLE
feat: use virtual title in notifications if title is not supported

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -15,8 +15,13 @@ local modified = require "nvim-tree.modified"
 local find_file = require "nvim-tree.actions.tree.find-file"
 local open = require "nvim-tree.actions.tree.open"
 local events = require "nvim-tree.events"
+local notify = require "nvim-tree.notify"
 
 local function notify_once(msg, level)
+  if not notify.supports_title then
+    msg = "[NvimTree]\n" .. msg
+  end
+
   vim.schedule(function()
     vim.notify_once(msg, level or vim.log.levels.WARN, { title = "NvimTree" })
   end)
@@ -729,7 +734,7 @@ local function validate_options(conf)
           if msg then
             msg = string.format("%s\n%s", msg, invalid)
           else
-            msg = string.format("[NvimTree]\n%s", invalid)
+            msg = invalid
           end
           user[k] = nil
         else

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -17,16 +17,6 @@ local open = require "nvim-tree.actions.tree.open"
 local events = require "nvim-tree.events"
 local notify = require "nvim-tree.notify"
 
-local function notify_once(msg, level)
-  if not notify.supports_title then
-    msg = "[NvimTree]\n" .. msg
-  end
-
-  vim.schedule(function()
-    vim.notify_once(msg, level or vim.log.levels.WARN, { title = "NvimTree" })
-  end)
-end
-
 local _config = {}
 
 local M = {
@@ -747,7 +737,7 @@ local function validate_options(conf)
   validate(conf, DEFAULT_OPTS, ACCEPTED_STRINGS, ACCEPTED_TYPES, "")
 
   if msg then
-    notify_once(msg .. "\n\nsee :help nvim-tree-opts for available configuration options")
+    notify.warn(msg .. "\n\nsee :help nvim-tree-opts for available configuration options")
   end
 end
 
@@ -770,7 +760,7 @@ end
 
 function M.setup(conf)
   if vim.fn.has "nvim-0.8" == 0 then
-    notify_once "nvim-tree.lua requires Neovim 0.8 or higher"
+    notify.warn "nvim-tree.lua requires Neovim 0.8 or higher"
     return
   end
 

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+M.supports_title = (pcall(require, "notify") and vim.notify == require "notify" or vim.notify == require("notify").notify)
+  or (pcall(require, "noice") and vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify)
+  or (pcall(require, "notifier") and require("notifier.config").has_component "nvim")
+
 local config = {
   threshold = vim.log.levels.INFO,
   absolute_path = true,
@@ -17,6 +21,10 @@ do
   local dispatch = function(level, msg)
     if level < config.threshold then
       return
+    end
+
+    if not M.supports_title then
+      msg = "[NvimTree]\n" .. msg
     end
 
     vim.schedule(function()

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -11,6 +11,7 @@ function M.supports_title()
     title_support = (package.loaded.notify and (vim.notify == require "notify" or vim.notify == require("notify").notify))
       or (package.loaded.noice and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
       or (package.loaded.notifier and require("notifier.config").has_component "nvim")
+      or false
   end
 
   return title_support

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -1,13 +1,20 @@
 local M = {}
 
-M.supports_title = (package.loaded.notify and (vim.notify == require "notify" or vim.notify == require("notify").notify))
-  or (package.loaded.noice and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
-  or (package.loaded.notifier and require("notifier.config").has_component "nvim")
-
 local config = {
   threshold = vim.log.levels.INFO,
   absolute_path = true,
 }
+
+local title_support
+function M.supports_title()
+  if title_support == nil then
+    title_support = (package.loaded.notify and (vim.notify == require "notify" or vim.notify == require("notify").notify))
+      or (package.loaded.noice and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
+      or (package.loaded.notifier and require("notifier.config").has_component "nvim")
+  end
+
+  return title_support
+end
 
 local modes = {
   { name = "trace", level = vim.log.levels.TRACE },
@@ -23,11 +30,11 @@ do
       return
     end
 
-    if not M.supports_title then
-      msg = "[NvimTree]\n" .. msg
-    end
-
     vim.schedule(function()
+      if not M.supports_title() then
+        msg = "[NvimTree]\n" .. msg
+      end
+
       vim.notify(msg, level, { title = "NvimTree" })
     end)
   end

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-M.supports_title = (pcall(require, "notify") and vim.notify == require "notify" or vim.notify == require("notify").notify)
-  or (pcall(require, "noice") and vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify)
+M.supports_title = (pcall(require, "notify") and (vim.notify == require "notify" or vim.notify == require("notify").notify))
+  or (pcall(require, "noice") and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
   or (pcall(require, "notifier") and require("notifier.config").has_component "nvim")
 
 local config = {

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -7,12 +7,15 @@ local config = {
 
 local title_support
 function M.supports_title()
+  -- TODO increase stylua column_width
+  -- stylua: ignore start
   if title_support == nil then
     title_support = (package.loaded.notify and (vim.notify == require "notify" or vim.notify == require("notify").notify))
       or (package.loaded.noice and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
       or (package.loaded.notifier and require("notifier.config").has_component "nvim")
       or false
   end
+  -- stylua: ignore end
 
   return title_support
 end

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-M.supports_title = (pcall(require, "notify") and (vim.notify == require "notify" or vim.notify == require("notify").notify))
-  or (pcall(require, "noice") and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
-  or (pcall(require, "notifier") and require("notifier.config").has_component "nvim")
+M.supports_title = (package.loaded.notify and (vim.notify == require "notify" or vim.notify == require("notify").notify))
+  or (package.loaded.noice and (vim.notify == require("noice").notify or vim.notify == require("noice.source.notify").notify))
+  or (package.loaded.notifier and require("notifier.config").has_component "nvim")
 
 local config = {
   threshold = vim.log.levels.INFO,


### PR DESCRIPTION
Having `[NvimTree]` as a notification header while using a notification system that actually supports title is redundant, so with this simple change it will be added only if needed.