### PR TITLE
docs(#2440): view.width.padding may only be a string

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -746,7 +746,7 @@ longest line (previously `view.adaptive_size`).
 
     *nvim-tree.view.width.padding*
     Extra padding to the right.
-      Type: `string | number | function`, Default: `1`
+      Type: `string`, Default: `" "`
 
 *nvim-tree.view.float*
 Use nvim-tree in a floating window.


### PR DESCRIPTION
fixes #2440 