### PR TITLE
fix(#2440): `view.width.padding` may be a number or function returning a number

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -746,7 +746,7 @@ longest line (previously `view.adaptive_size`).
 
     *nvim-tree.view.width.padding*
     Extra padding to the right.
-      Type: `string`, Default: `" "`
+      Type: `function | number`, Default: `1`
 
 *nvim-tree.view.float*
 Use nvim-tree in a floating window.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -734,19 +734,23 @@ Width of the window: can be a `%` string, a number representing columns, a
 function or a table.
 A table indicates that the view should be dynamically sized based on the
 longest line (previously `view.adaptive_size`).
-  Type: `string | number | function | table`, Default: `30`
+  Type: `string | number | table | function()` returning a number
+  Default: `30`
 
     *nvim-tree.view.width.min*
     Minimum dynamic width.
-      Type: `string | number | function`, Default: `30`
+      Type: `string | number | function()` returning a number
+      Default: `30`
 
     *nvim-tree.view.width.max*
     Maximum dynamic width, -1 for unbounded.
-      Type: `string | number | function`, Default: `-1`
+      Type: `string | number | function()` returning a number
+      Default: `-1`
 
     *nvim-tree.view.width.padding*
     Extra padding to the right.
-      Type: `function | number`, Default: `1`
+      Type: `number | function()` returning a number
+      Default: `1`
 
 *nvim-tree.view.float*
 Use nvim-tree in a floating window.
@@ -761,7 +765,8 @@ Use nvim-tree in a floating window.
 
     *nvim-tree.view.float.open_win_config*
     Floating window config. See |nvim_open_win| for more details.
-      Type: `table` or `function` that returns a table, Default:
+      Type: `table | function` returning a table
+      Default:
         `{`
           `relative = "editor",`
           `border = "rounded",`

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -642,6 +642,7 @@ local ACCEPTED_TYPES = {
       "table",
       min = { "string", "function", "number" },
       max = { "string", "function", "number" },
+      padding = { "function", "number" },
     },
   },
   renderer = {


### PR DESCRIPTION
Update accepted types for view.width option so padding can be set. See #2440.
Overrides documentation change of #2441