### PR TITLE
fix(#2450): highlight for `webp` and `jxl` files

### DIFF
--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -51,6 +51,8 @@ local picture_map = {
   jpeg = true,
   png = true,
   gif = true,
+  webp = true,
+  jxl = true,
 }
 
 function M.draw(unloaded_bufnr)


### PR DESCRIPTION
Closes #2450