### PR TITLE
feat: notify [NvimTree] prefix is multiline only if the message is multiline

### DIFF
--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -34,7 +34,7 @@ do
     vim.schedule(function()
       if not M.supports_title() then
         -- add title to the message, with a newline if the message is multiline
-        msg = string.format("[NvimTree]%s%s", msg:match "\n" and "\n" or " ", msg)
+        msg = string.format("[NvimTree]%s%s", (msg:match "\n" and "\n" or " "), msg)
       end
 
       vim.notify(msg, level, { title = "NvimTree" })

--- a/lua/nvim-tree/notify.lua
+++ b/lua/nvim-tree/notify.lua
@@ -27,13 +27,14 @@ local modes = {
 
 do
   local dispatch = function(level, msg)
-    if level < config.threshold then
+    if level < config.threshold or not msg then
       return
     end
 
     vim.schedule(function()
       if not M.supports_title() then
-        msg = "[NvimTree]\n" .. msg
+        -- add title to the message, with a newline if the message is multiline
+        msg = string.format("[NvimTree]%s%s", msg:match "\n" and "\n" or " ", msg)
       end
 
       vim.notify(msg, level, { title = "NvimTree" })


### PR DESCRIPTION
This was a little annoying:
```
[NvimTree]
notify.lua added to clipboard.
Press ENTER or type command to continue
```