### PR TITLE
feat: use IEC binary size prefixes

### DIFF
--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -292,7 +292,7 @@ function M.format_bytes(bytes)
 
   pow = pow + 1
 
-  return (units[pow] == nil) and (bytes .. "B") or (value .. units[pow])
+  return (units[pow] == nil) and (bytes .. units[1]) or (value .. units[pow] .. "i" .. units[1])
 end
 
 function M.key_by(tbl, key)

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -281,7 +281,7 @@ function M.move_missing_val(src, src_path, src_pos, dst, dst_path, dst_pos, remo
 end
 
 function M.format_bytes(bytes)
-  local units = { "B", "K", "M", "G", "T" }
+  local units = { "B", "K", "M", "G", "T", "P", "E", "Z", "Y" }
 
   bytes = math.max(bytes, 0)
   local pow = math.floor((bytes and math.log(bytes) or 0) / math.log(1024))


### PR DESCRIPTION
I'm very happy that this project uses 1024 as a divisor instead of 1000. But to explicitly inform user about it the prefixes should consist of 3 letters:
- multiple (K, M, G, T)
- 'i' (bInary)
- 'B' (Byte)

Exception is any number of bytes that are less than 1024, then the prefix is just the 'B' letter.

As an addition I've completed the list with the missing prefixes: P, E, Z, Y.

Quick reference: https://en.wikipedia.org/wiki/Binary_prefix.

P.S. Ri and Qi are not yet confirmed (only SI counterparts exist starting from 2022: R, Q).
