### PR TITLE
fix(#2466): escape \n\r when parsing git toplevel results

### DIFF
--- a/lua/nvim-tree/git/utils.lua
+++ b/lua/nvim-tree/git/utils.lua
@@ -25,7 +25,7 @@ function M.get_toplevel(cwd)
     return nil, nil
   end
 
-  local toplevel, git_dir = out:match "([^\n]+)\n+([^\n]+)"
+  local toplevel, git_dir = out:match "([^\n\r]+)[\n\r]+([^\n\r]+)"
   if not toplevel then
     return nil, nil
   end


### PR DESCRIPTION
fixes #2466