### PR TITLE
fix: live filter delete buffer when removing overlay

### DIFF
--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -37,7 +37,8 @@ local function remove_overlay()
     })
   end
 
-  vim.api.nvim_win_close(overlay_winnr, { force = true })
+  vim.api.nvim_win_close(overlay_winnr, true)
+  vim.api.nvim_buf_delete(overlay_bufnr, { force = true })
   overlay_bufnr = nil
   overlay_winnr = nil
 


### PR DESCRIPTION
Problem: When leaving live filter overlay we delete window, but not buffer, you can debug this and found that these buffers living all time untill you close neovim.
Solution: Add buffer deletion.
Also small improvement, `vim.api.nvim_win_close` as second argument takes `force` as `boolean` not `table`(but maybe this also working) https://neovim.io/doc/user/api.html#nvim_win_close()