### PR TITLE
fix: tree open from telescope picker

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -152,9 +152,10 @@ end
 
 local function open_window()
   if M.View.float.enable then
-    vim.api.nvim_open_win(0, true, open_win_config())
+    local winid = vim.api.nvim_open_win(M.get_bufnr(), false, open_win_config())
+    vim.api.nvim_set_current_win(winid)
   else
-    vim.api.nvim_command "vsp"
+    vim.api.nvim_command("vsp #" .. M.get_bufnr())
     M.reposition_window()
   end
   setup_tabpage(vim.api.nvim_get_current_tabpage())


### PR DESCRIPTION
Fix #2520

Seems to work fine except for split layout where tree closed:
1. Open file.
2. Close tree.
3. Open telescope.
4. Open tree(NvimTreeOpen/NvimTreeToggle).
5. Now tree would be full screen or if you have opened splits earlier(`file | file`), you lose one of them and layout would be `tree | file`(better would be `tree | file | file`).
I dont know where this one could be fixed, seems  because of `vsp`(and `telescope` stuff) behaviour. For proper working maybe we need to add telescope specific code(is it good?, i'm not sure). Maybe some ideas? Or leave it as is, there are no errors therefore seems to be fixed.

UPD: I think it is a telescope problem, https://github.com/nvim-telescope/telescope.nvim/issues/2781.
ANOTHER UPD: If this telescope issue would be fixed, i think we don't need this pr :). Or maybe for safety reasons
ANOTHER UPD: Fixed.