### PR TITLE
fix: add nil check to git status

### DIFF
--- a/lua/nvim-tree/explorer/node.lua
+++ b/lua/nvim-tree/explorer/node.lua
@@ -14,7 +14,7 @@ local function get_dir_git_status(parent_ignored, status, absolute_path)
     return { file = "!!" }
   end
 
-  if type(status) ~= nil and status ~= nil then
+  if status then
     return {
       file = status.files and status.files[absolute_path],
       dir = status.dirs and {

--- a/lua/nvim-tree/explorer/node.lua
+++ b/lua/nvim-tree/explorer/node.lua
@@ -14,13 +14,15 @@ local function get_dir_git_status(parent_ignored, status, absolute_path)
     return { file = "!!" }
   end
 
-  return {
-    file = status.files and status.files[absolute_path],
-    dir = status.dirs and {
-      direct = status.dirs.direct[absolute_path],
-      indirect = status.dirs.indirect[absolute_path],
-    },
-  }
+  if type(status) ~= nil and status ~= nil then
+    return {
+      file = status.files and status.files[absolute_path],
+      dir = status.dirs and {
+        direct = status.dirs.direct[absolute_path],
+        indirect = status.dirs.indirect[absolute_path],
+      },
+    }
+  end
 end
 
 local function get_git_status(parent_ignored, status, absolute_path)


### PR DESCRIPTION
Requisite config:

```lua
local nvim_tree_setup = function()
  require('nvim-tree').setup({
    on_attach = on_attach,
    diagnostics = {
      enable = true,
    },
    update_focused_file = {
      enable = true,
      update_root = false,
    },
    respect_buf_cwd = false,
    sync_root_with_cwd = false,
    view = {
      width = 40,
      side = 'right',
      --mappings = {
      --  custom_only = false,
      --  list = {
      --    { key = { '<CR>', '<Tab>' }, action = 'edit' },
      --  },
      --},
    },
  })
end
```

Occasionally, with the above config, `nvim-tree` will spit out the following error message:

`node.lua attempt to index local 'status' a nil value`

creating a nice big traceback of the complaint and stealing focus briefly. You can immediately press `q` and leave it and go back to what you were doing, but it happens a few times in a couple seconds, then chills out. 

**Working theory:** I think there were points at which the git status of a node wasn't set, and `nvim-tree` would still try to get its git status, leading to ... `local 'status' a nil value`. This change simply quietly does not return anything at the time of that check (but we don't care, it'll get run again soon). 

```
Error executing vim.schedule lua callback: .../nvim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/node.lua:19: attempt to index local 'status' (a nil value)
stack traceback:
        .../nvim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/node.lua:19: in function 'get_status'
        .../nvim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/node.lua:46: in function 'update_git_status'
        ...vim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/reload.lua:54: in function 'update_parent_statuses'
        ...vim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/reload.lua:180: in function 'callback'
        ...vim/lazy/nvim-tree.lua/lua/nvim-tree/explorer/reload.lua:28: in function 'callback'
        ...share/nvim/lazy/nvim-tree.lua/lua/nvim-tree/git/init.lua:111: in function 'callback'
        ...are/nvim/lazy/nvim-tree.lua/lua/nvim-tree/git/runner.lua:194: in function 'callback'
        ...are/nvim/lazy/nvim-tree.lua/lua/nvim-tree/git/runner.lua:101: in function 'on_finish'
        ...are/nvim/lazy/nvim-tree.lua/lua/nvim-tree/git/runner.lua:113: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```