### PR TITLE
fix: new staged files

### DIFF
--- a/lua/nvim-tree/renderer/components/git.lua
+++ b/lua/nvim-tree/renderer/components/git.lua
@@ -65,7 +65,7 @@ local function build_hl_table()
     ["MM"] = "NvimTreeFileDirty",
     ["AM"] = "NvimTreeFileDirty",
     dirty = "NvimTreeFileDirty",
-    ["A "] = "NvimTreeFileNew",
+    ["A "] = "NvimTreeFileStaged",
     ["??"] = "NvimTreeFileNew",
     ["AU"] = "NvimTreeFileMerge",
     ["UU"] = "NvimTreeFileMerge",


### PR DESCRIPTION
sync icons with highlights:
["A "] = { icons.staged },
and 
["A "] = "NvimTreeFileStaged",