### PR TITLE
fix(#2468): always apply filters to subdirectories

### DIFF
--- a/lua/nvim-tree/actions/reloaders/reloaders.lua
+++ b/lua/nvim-tree/actions/reloaders/reloaders.lua
@@ -11,7 +11,7 @@ local M = {}
 local function refresh_nodes(node, projects, unloaded_bufnr)
   Iterator.builder({ node })
     :applier(function(n)
-      if n.open and n.nodes then
+      if n.nodes then
         local toplevel = git.get_toplevel(n.cwd or n.link_to or n.absolute_path)
         explorer_module.reload(n, projects[toplevel] or {}, unloaded_bufnr)
       end


### PR DESCRIPTION
Closes #2468
I might have found a fix for #2468, and if so it's a really simple one. From my tests it seems to apply correctly all filters to all subdirs, not sure about the resource leaks but they should go together as well.