### PR TITLE
ci: ubuntu packages -> luarocks action, pin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,35 @@ on:
     branches:
       - master
 
-jobs:
-  luacheck:
-    name: luacheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+permissions:
+  contents: read
 
-      - name: Prepare
-        run: |
-          sudo apt-get update
-          sudo add-apt-repository universe
-          sudo apt install luarocks -y
-          sudo luarocks install luacheck
-      - name: Run luacheck
-        run: luacheck .
-  stylua:
-    name: stylua
+jobs:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: JohnnyMorganz/stylua-action@v3
+      - uses: actions/checkout@v3
+
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - uses: leafo/gh-actions-luarocks@v4
+
+      - name: luacheck
+        run: |
+          luarocks install luacheck 1.1.1
+          luacheck lua
+
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: stylua
+        uses: JohnnyMorganz/stylua-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: latest
-          args: --color always --check lua/
+          version: "0.19"
+          args: --check lua
+


### PR DESCRIPTION
Brings in line with https://github.com/nvim-tree/nvim-web-devicons/pull/341

* versions pinned
* avoids ubuntu packages