### PR TITLE
fix: add nil check to `get_cwd`

### DIFF
--- a/lua/nvim-tree/core.lua
+++ b/lua/nvim-tree/core.lua
@@ -28,7 +28,7 @@ function M.get_explorer()
 end
 
 function M.get_cwd()
-  return TreeExplorer.absolute_path
+  return TreeExplorer and TreeExplorer.absolute_path
 end
 
 function M.get_nodes_starting_line()


### PR DESCRIPTION
In a recent update, I found the restore of rmagatti/auto-session doesn't work, and from my debugging, it looks like the function `get_cwd` needs a nil check.

When `get_cwd` is used in the `autocmd` (`BufEnter`), the `core` is not initialized and thus `TreeExplorer` is nil and thus `TreeExplorer.absolute_path` throws exception, this PR adds a nil check to the `TreeExplorer`

https://github.com/nvim-tree/nvim-tree.lua/blob/de752768cf8eac363b4fb02501286234af37592c/lua/nvim-tree.lua#L287

## Reproducible Configs

I'm using LazyVIM

### `~/.config/nvim/lua/custom/plugins/nvim-tree.lua`

```
return {
  "nvim-tree/nvim-tree.lua",
  lazy = false,
  dependencies = {
    "nvim-tree/nvim-web-devicons",
  },
  config = function()
    require("nvim-tree").setup {}

    -- restore nvim-tree with auto-session
    local api = require "nvim-tree.api"
    local view = require "nvim-tree.view"
    vim.api.nvim_create_autocmd("BufEnter", {
      pattern = "NvimTree*",
      callback = function()
        if not view.is_visible() then
          api.tree.open()
        end
      end,
    })
  end,
}
```

### `~/.config/nvim/lua/custom/plugins/auto-session.lua`

```
return {
  'rmagatti/auto-session',
  config = function()
    require("auto-session").setup {
      log_level = "error",
      auto_session_suppress_dirs = { "~/", "~/Projects", "~/Downloads", "/", "/tmp" },
    }
  end
}
```

Then open neovim, open a file and open the NvimTree, then `:SessionSave`, and exit neovim. Next time you open neovim a exception will be thrown.