### PR TITLE
refactor: api and command focus call tree.open(), soft deprecate tree.focus()

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -250,9 +250,9 @@ via |nvim-tree.on_attach| e.g. >
 
     Open the tree if it is closed, and then focus on the tree.
 
-    See |nvim-tree-api.tree.focus()|
+    See |nvim-tree-api.tree.open()|
 
-    Calls: `api.tree.focus()`
+    Calls: `api.tree.open()`
 
 *:NvimTreeRefresh*
 
@@ -1587,6 +1587,7 @@ tree.close_in_all_tabs()              *nvim-tree-api.tree.close_in_all_tabs()*
 
 tree.focus()                                      *nvim-tree-api.tree.focus()*
     Focus the tree, opening it if necessary.
+    Retained for compatibility, use |tree.open()| with no arguments instead.
 
 tree.reload()                                    *nvim-tree-api.tree.reload()*
     Refresh the tree. Does nothing if closed.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -13,7 +13,6 @@ local git = require "nvim-tree.git"
 local filters = require "nvim-tree.explorer.filters"
 local modified = require "nvim-tree.modified"
 local find_file = require "nvim-tree.actions.tree.find-file"
-local open = require "nvim-tree.actions.tree.open"
 local events = require "nvim-tree.events"
 local notify = require "nvim-tree.notify"
 
@@ -22,11 +21,6 @@ local _config = {}
 local M = {
   init_root = "",
 }
-
-function M.focus()
-  open.fn()
-  view.focus()
-end
 
 --- Update the tree root to a directory or the directory containing
 --- @param path string relative or absolute

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -86,7 +86,7 @@ Api.tree.close_in_this_tab = wrap(require("nvim-tree.view").close_this_tab_only)
 Api.tree.close_in_all_tabs = wrap(require("nvim-tree.view").close_all_tabs)
 
 Api.tree.focus = wrap(function()
-  require("nvim-tree").focus()
+  Api.tree.open()
 end)
 
 Api.tree.reload = wrap(require("nvim-tree.actions.reloaders.reloaders").reload_explorer)

--- a/lua/nvim-tree/commands.lua
+++ b/lua/nvim-tree/commands.lua
@@ -48,7 +48,7 @@ local CMDS = {
       bar = true,
     },
     command = function()
-      api.tree.focus()
+      api.tree.open()
     end,
   },
   {


### PR DESCRIPTION
see #2554 