### PR TITLE
chore: remove `TreeExplorer` global variable

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -752,7 +752,7 @@ function M.purge_all_state()
   view.abandon_all_windows()
   if core.get_explorer() ~= nil then
     git.purge_state()
-    TreeExplorer = nil
+    core.reset_explorer()
   end
 end
 

--- a/lua/nvim-tree/core.lua
+++ b/lua/nvim-tree/core.lua
@@ -6,7 +6,7 @@ local log = require "nvim-tree.log"
 
 local M = {}
 
-TreeExplorer = nil
+local TreeExplorer = nil
 local first_init_done = false
 
 function M.init(foldername)
@@ -25,6 +25,10 @@ end
 
 function M.get_explorer()
   return TreeExplorer
+end
+
+function M.reset_explorer()
+  TreeExplorer = nil
 end
 
 function M.get_cwd()

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -11,7 +11,7 @@ local function redraw()
 end
 
 local function reset_filter(node_)
-  node_ = node_ or TreeExplorer
+  node_ = node_ or require("nvim-tree.core").get_explorer()
   Iterator.builder(node_.nodes)
     :hidden()
     :applier(function(node)
@@ -79,7 +79,7 @@ function M.apply_filter(node_)
     node.hidden = not (has_nodes or (ok and is_match))
   end
 
-  iterate(node_ or TreeExplorer)
+  iterate(node_ or require("nvim-tree.core").get_explorer())
 end
 
 local function record_char()


### PR DESCRIPTION
I noticed that there is this `TreeExplorer` global variable that's used just twice, so I simply made it local to `core` and added a simple function to reset it when needed.