### PR TITLE
fix(#2519): Diagnostics Not Updated When Tree Not Visible

### DIFF
--- a/lua/nvim-tree/actions/moves/item.lua
+++ b/lua/nvim-tree/actions/moves/item.lua
@@ -3,6 +3,7 @@ local view = require "nvim-tree.view"
 local core = require "nvim-tree.core"
 local lib = require "nvim-tree.lib"
 local explorer_node = require "nvim-tree.explorer.node"
+local diagnostics = require "nvim-tree.diagnostics"
 
 local M = {}
 
@@ -33,7 +34,8 @@ function M.fn(opts)
         local git_status = explorer_node.get_git_status(node)
         valid = git_status ~= nil and (not opts.skip_gitignored or git_status[1] ~= "!!")
       elseif opts.what == "diag" then
-        valid = node.diag_status ~= nil
+        local diag_status = diagnostics.get_diag_status(node)
+        valid = diag_status ~= nil and diag_status.value ~= nil
       elseif opts.what == "opened" then
         valid = vim.fn.bufloaded(node.absolute_path) ~= 0
       end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -66,7 +66,7 @@ local function handle_coc_exception(err)
   local notify = true
 
   -- avoid distractions on interrupts (CTRL-C)
-  if err:find "Vim:Interrupt" then
+  if err:find "Vim:Interrupt" or err:find "Keyboard interrupt" then
     notify = false
   end
 

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -1,6 +1,7 @@
 local utils = require "nvim-tree.utils"
 local view = require "nvim-tree.view"
 local log = require "nvim-tree.log"
+local renderer = require "nvim-tree.renderer"
 
 local M = {}
 
@@ -128,7 +129,7 @@ function M.update()
     log.node("diagnostics", buffer_severity_dict, "update")
     log.profile_end(profile)
     if view.is_buf_valid(view.get_bufnr()) then
-      require("nvim-tree.renderer").draw()
+      renderer.draw()
     end
   end)
 end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -125,7 +125,11 @@ function M.update()
       BUFFER_SEVERITY = from_nvim_lsp()
     end
     BUFFER_SEVERITY_VERSION = BUFFER_SEVERITY_VERSION + 1
-    log.node("diagnostics", BUFFER_SEVERITY, "update")
+    if log.enabled("diagnostics") then
+      for bufname, severity in pairs(BUFFER_SEVERITY) do
+        log.line("diagnostics", "Indexing bufname '%s' with severity %d", bufname, severity)
+      end
+    end
     log.profile_end(profile)
     if view.is_buf_valid(view.get_bufnr()) then
       require("nvim-tree.renderer").draw()

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -1,7 +1,6 @@
 local utils = require "nvim-tree.utils"
 local view = require "nvim-tree.view"
 local log = require "nvim-tree.log"
-local renderer = require "nvim-tree.renderer"
 
 local M = {}
 
@@ -129,7 +128,7 @@ function M.update()
     log.node("diagnostics", buffer_severity_dict, "update")
     log.profile_end(profile)
     if view.is_buf_valid(view.get_bufnr()) then
-      renderer.draw()
+      require("nvim-tree.renderer").draw()
     end
   end)
 end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -66,7 +66,7 @@ local function handle_coc_exception(err)
   local notify = true
 
   -- avoid distractions on interrupts (CTRL-C)
-  if err:find("Vim:Interrupt") then
+  if err:find "Vim:Interrupt" then
     notify = false
   end
 
@@ -82,7 +82,7 @@ local function from_coc()
   end
 
   local ok, diagnostic_list = xpcall(function()
-    return vim.fn.CocAction("diagnosticList")
+    return vim.fn.CocAction "diagnosticList"
   end, handle_coc_exception)
   if not ok or type(diagnostic_list) ~= "table" or vim.tbl_isempty(diagnostic_list) then
     return {}
@@ -142,7 +142,7 @@ function M.update()
       BUFFER_SEVERITY = from_nvim_lsp()
     end
     BUFFER_SEVERITY_VERSION = BUFFER_SEVERITY_VERSION + 1
-    if log.enabled("diagnostics") then
+    if log.enabled "diagnostics" then
       for bufname, severity in pairs(BUFFER_SEVERITY) do
         log.line("diagnostics", "Indexing bufname '%s' with severity %d", bufname, severity)
       end

--- a/lua/nvim-tree/node.lua
+++ b/lua/nvim-tree/node.lua
@@ -17,7 +17,7 @@
 ---@field parent DirNode
 ---@field type string
 ---@field watcher function|nil
----@field diag_status integer|nil
+---@field diag_status DiagStatus|nil
 
 ---@class DirNode: BaseNode
 ---@field has_children boolean

--- a/lua/nvim-tree/node.lua
+++ b/lua/nvim-tree/node.lua
@@ -17,6 +17,7 @@
 ---@field parent DirNode
 ---@field type string
 ---@field watcher function|nil
+---@field diag_status integer|nil
 
 ---@class DirNode: BaseNode
 ---@field has_children boolean

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -413,6 +413,8 @@ end
 function Builder:_build_line(node, idx, num_children, unloaded_bufnr)
   local copy_paste = require "nvim-tree.actions.fs.copy-paste"
 
+  require("nvim-tree.diagnostics").update_node_severity_level(node)
+
   -- various components
   local indent_markers = pad.get_indent_markers(self.depth, idx, num_children, node, self.markers)
   local arrows = pad.get_arrows(node)

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -413,8 +413,6 @@ end
 function Builder:_build_line(node, idx, num_children, unloaded_bufnr)
   local copy_paste = require "nvim-tree.actions.fs.copy-paste"
 
-  require("nvim-tree.diagnostics").update_node_severity_level(node)
-
   -- various components
   local indent_markers = pad.get_indent_markers(self.depth, idx, num_children, node, self.markers)
   local arrows = pad.get_arrows(node)

--- a/lua/nvim-tree/renderer/components/diagnostics.lua
+++ b/lua/nvim-tree/renderer/components/diagnostics.lua
@@ -1,4 +1,5 @@
 local HL_POSITION = require("nvim-tree.enum").HL_POSITION
+local diagnostics = require "nvim-tree.diagnostics"
 
 local M = {
   HS_FILE = {},
@@ -17,10 +18,11 @@ function M.get_highlight(node)
   end
 
   local group
+  local diag_status = diagnostics.get_diag_status(node)
   if node.nodes then
-    group = M.HS_FOLDER[node.diag_status]
+    group = M.HS_FOLDER[diag_status and diag_status.value]
   else
-    group = M.HS_FILE[node.diag_status]
+    group = M.HS_FILE[diag_status and diag_status.value]
   end
 
   if group then
@@ -35,7 +37,8 @@ end
 ---@return HighlightedString|nil modified icon
 function M.get_icon(node)
   if node and M.config.diagnostics.enable and M.config.renderer.icons.show.diagnostics then
-    return M.ICON[node.diag_status]
+    local diag_status = diagnostics.get_diag_status(node)
+    return M.ICON[diag_status and diag_status.value]
   end
 end
 


### PR DESCRIPTION
The diagnostic changed event has been untied from the current tree state to ensure the data availability at any time. Now, the diagnostics will be picked up "on the fly" whenever the tree is about to be (re-)drawn, which makes absolute sense, especially, when incrementally exploring the file system structure or when (re-)opening the tree and the diagnostic changed event has already occurred.

All in all, this effectively solves any inconsistencies (see https://github.com/nvim-tree/nvim-tree.lua/discussions/2517), and ensures that the tree shows the freshest diagnostics, regardless of the tree's state and when diagnostics change.