### PR TITLE
feat(#2415): combined hl groups

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2247,9 +2247,6 @@ as per |:highlight|
 
 Default linked group or definition follows name.
 
-neovim 0.9 has a limit of two highlight groups per range. The two highest
-priority groups as per |nvim-tree-opts-renderer| will be used.
-
 Standard: >
     NvimTreeNormal              Normal
     NvimTreeNormalFloat         NormalFloat

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -104,12 +104,6 @@ function M.open_on_directory()
   actions.root.change_dir.force_dirchange(bufname, true)
 end
 
-function M.reset_highlight()
-  colors.setup()
-  view.reset_winhl()
-  renderer.render_hl(view.get_bufnr())
-end
-
 function M.place_cursor_on_node()
   local search = vim.fn.searchcount()
   if search and search.exact_match == 1 then
@@ -168,8 +162,13 @@ local function setup_autocommands(opts)
     vim.api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
   end
 
-  -- reset highlights when colorscheme is changed
-  create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
+  -- reset and draw highlights when colorscheme is changed
+  create_nvim_tree_autocmd("ColorScheme", {
+    callback = function()
+      colors.setup()
+      renderer.render_hl(view.get_bufnr())
+    end,
+  })
 
   -- prevent new opened file from opening in the same window as nvim-tree
   create_nvim_tree_autocmd("BufWipeout", {

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -1,4 +1,7 @@
-local M = {}
+local M = {
+  -- namespace for all tree window highlights
+  NS_ID = vim.api.nvim_create_namespace "nvim_tree",
+}
 
 -- directly defined groups, please keep these to an absolute minimum
 local DEFAULT_DEFS = {
@@ -122,6 +125,21 @@ local DEFAULT_LINKS = {
   NvimTreeDiagnosticHintFolderHL = "NvimTreeDiagnosticHintFileHL",
 }
 
+-- namespace standard links
+local NS_LINKS = {
+  EndOfBuffer = "NvimTreeEndOfBuffer",
+  CursorLine = "NvimTreeCursorLine",
+  CursorLineNr = "NvimTreeCursorLineNr",
+  LineNr = "NvimTreeLineNr",
+  WinSeparator = "NvimTreeWinSeparator",
+  StatusLine = "NvimTreeStatusLine",
+  StatusLineNC = "NvimTreeStatuslineNC",
+  SignColumn = "NvimTreeSignColumn",
+  Normal = "NvimTreeNormal",
+  NormalNC = "NvimTreeNormalNC",
+  NormalFloat = "NvimTreeNormalFloat",
+}
+
 -- nvim-tree highlight groups to legacy
 local LEGACY_LINKS = {
   NvimTreeModifiedIcon = "NvimTreeModifiedFile",
@@ -188,6 +206,11 @@ function M.setup()
   -- default links
   for from, to in pairs(DEFAULT_LINKS) do
     vim.api.nvim_command("hi def link " .. from .. " " .. to)
+  end
+
+  -- window namespace; these don't appear to be cleared on colorscheme however err on the side of caution
+  for from, to in pairs(NS_LINKS) do
+    vim.api.nvim_set_hl(M.NS_ID, from, { link = to })
   end
 end
 

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -259,8 +259,11 @@ function Builder:_build_signs(node)
   end
 end
 
+---Combined group name less than the 200 byte limit of highlight group names
+---@param groups string[] highlight group names
+---@return string name "NvimTreeCombinedHL" .. sha256
 function Builder:_combined_group_name(groups)
-  return table.concat(groups)
+  return string.format("NvimTreeCombinedHL%s", vim.fn.sha256(table.concat(groups)))
 end
 
 ---Create a highlight group for groups with later groups overriding previous.

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -1,3 +1,4 @@
+local colors = require "nvim-tree.colors"
 local utils = require "nvim-tree.utils"
 local notify = require "nvim-tree.notify"
 
@@ -281,8 +282,10 @@ function Builder:_create_combined_group(groups)
       combined_hl = vim.tbl_extend("force", combined_hl, hl)
     end
 
-    -- create and note the name
-    vim.api.nvim_set_hl(0, combined_name, combined_hl)
+    -- highlight directly in the namespace
+    vim.api.nvim_set_hl_ns_fast(colors.NS_ID)
+    vim.api.nvim_set_hl(colors.NS_ID, combined_name, combined_hl)
+
     self.combined_groups[combined_name] = true
   end
 end

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -289,6 +289,7 @@ end
 
 ---Calculate highlight group for icon and name. A combined highlight group will be created
 ---when there is more than one highlight.
+---A highlight group is always calculated and upserted for the case of highlights changing.
 ---@param node Node
 ---@return string|nil icon_hl_group
 ---@return string|nil name_hl_group

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -1,3 +1,4 @@
+local colors = require "nvim-tree.colors"
 local core = require "nvim-tree.core"
 local log = require "nvim-tree.log"
 local view = require "nvim-tree.view"
@@ -24,8 +25,6 @@ local M = {
 
 local SIGN_GROUP = "NvimTreeRendererSigns"
 
-local namespace_id = vim.api.nvim_create_namespace "NvimTreeHighlights"
-
 local function _draw(bufnr, lines, hl, sign_names)
   vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
@@ -41,11 +40,11 @@ function M.render_hl(bufnr, hl)
   if not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  vim.api.nvim_buf_clear_namespace(bufnr, namespace_id, 0, -1)
+  vim.api.nvim_buf_clear_namespace(bufnr, colors.NS_ID, 0, -1)
   for _, data in ipairs(hl or M.last_highlights) do
     if type(data[1]) == "table" then
       for _, group in ipairs(data[1]) do
-        vim.api.nvim_buf_add_highlight(bufnr, namespace_id, group, data[2], data[3], data[4])
+        vim.api.nvim_buf_add_highlight(bufnr, colors.NS_ID, group, data[2], data[3], data[4])
       end
     end
   end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -1,3 +1,4 @@
+local colors = require "nvim-tree.colors"
 local events = require "nvim-tree.events"
 local utils = require "nvim-tree.utils"
 local log = require "nvim-tree.log"
@@ -38,19 +39,6 @@ M.View = {
     cursorlineopt = "both",
     colorcolumn = "0",
     wrap = false,
-    winhl = table.concat({
-      "EndOfBuffer:NvimTreeEndOfBuffer",
-      "CursorLine:NvimTreeCursorLine",
-      "CursorLineNr:NvimTreeCursorLineNr",
-      "LineNr:NvimTreeLineNr",
-      "WinSeparator:NvimTreeWinSeparator",
-      "StatusLine:NvimTreeStatusLine",
-      "StatusLineNC:NvimTreeStatuslineNC",
-      "SignColumn:NvimTreeSignColumn",
-      "Normal:NvimTreeNormal",
-      "NormalNC:NvimTreeNormalNC",
-      "NormalFloat:NvimTreeNormalFloat",
-    }, ","),
   },
 }
 
@@ -147,6 +135,7 @@ local function set_window_options_and_buffer()
     vim.opt_local[k] = v
   end
   vim.opt.eventignore = eventignore
+  vim.api.nvim_win_set_hl_ns(0, colors.NS_ID)
 end
 
 ---@return table
@@ -537,13 +526,6 @@ end
 ---@return boolean
 function M.is_root_folder_visible(cwd)
   return cwd ~= "/" and not M.View.hide_root_folder
-end
-
--- used on ColorScheme event
-function M.reset_winhl()
-  if M.get_winnr() and vim.api.nvim_win_is_valid(M.get_winnr()) then
-    vim.wo[M.get_winnr()].winhl = M.View.winopts.winhl
-  end
 end
 
 function M.setup(opts)


### PR DESCRIPTION
Create a combined highlight group when more than one, to work around the limitations of only two HL groups overriding each other.

TODO:
- [x] avoid polluting global highlight groups

Define highlight groups in a namespace so that they may be removed.

The groups need to be added to the highlight group for the window via `nvim_win_set_hl_ns()`

This overrides view's `winhl` so those will need to be refactored in a similar manner.

This has questionable value.