### PR TITLE
feat: add kind param to vim.ui.select function calls

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -47,8 +47,9 @@ CONTENTS                                                           *nvim-tree*
   7.1  Mappings: Default                        |nvim-tree-mappings-default|
   8. Highlight                                |nvim-tree-highlight|
   9. Events                                   |nvim-tree-events|
- 10. OS Specific Restrictions                 |nvim-tree-os-specific|
- 11. Netrw                                    |nvim-tree-netrw|
+ 10. Prompts                                  |nvim-tree-prompts|
+ 11. OS Specific Restrictions                 |nvim-tree-os-specific|
+ 12. Netrw                                    |nvim-tree-netrw|
 
 ==============================================================================
  1. INTRODUCTION                                      *nvim-tree-introduction*
@@ -2442,7 +2443,28 @@ Example subscription: >
   })
 <
 ==============================================================================
- 10. OS SPECIFIC RESTRICTIONS                          *nvim-tree-os-specific*
+ 10. PROMPTS                                               *nvim-tree-prompts*
+
+Some of the NvimTree actions such as copy-paste, delete, trash etc. use the
+builtin |vim.ui.select| prompt API for confirmations, if
+`nvim_tree.select_prompts` option is set as true. The API accepts the optional
+`kind` key as part of the `opts` parameter, which can be used to identify the
+type of prompt, to allow user side configurations for different types of
+prompts.
+
+Defined prompt kinds in NvimTree:
+- `nvimtree_copypaste` - Prompt for confirmation to overwrite or rename during
+  copy-paste action
+- `nvimtree_remove` - Prompt for confirmation to delete during remove action
+- `nvimtree_trash` - Prompt for confirmation to send to trash during trash
+  action
+- `nvimtree_bulkdelete` - Prompt for confirmation to delete all bookmarked
+  during bulk-delete action
+- `nvimtree_bulktrash` - Prompt for confirmation to send all bookmarked to
+  trash during bulk-trash action
+
+==============================================================================
+ 11. OS SPECIFIC RESTRICTIONS                          *nvim-tree-os-specific*
 
 macOS
 - Rename to different case is not possible when using a case insensitive file
@@ -2455,7 +2477,7 @@ Windows WSL and PowerShell
 - Some filesystem watcher error related to permissions will not be reported
 
 ==============================================================================
- 11. NETRW                                                  *nvim-tree-netrw*
+ 12. NETRW                                                  *nvim-tree-netrw*
 
 |netrw| is a standard neovim plugin that is enabled by default. It provides,
 amongst other functionality, a file/directory browser.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2445,23 +2445,27 @@ Example subscription: >
 ==============================================================================
  10. PROMPTS                                               *nvim-tree-prompts*
 
-Some of the NvimTree actions such as copy-paste, delete, trash etc. use the
-builtin |vim.ui.select| prompt API for confirmations, if
-`nvim_tree.select_prompts` option is set as true. The API accepts the optional
-`kind` key as part of the `opts` parameter, which can be used to identify the
-type of prompt, to allow user side configurations for different types of
-prompts.
+Some NvimTree actions use the builtin |vim.ui.select| prompt API for
+confirmations when the |nvim_tree.select_prompts| option is set.
 
-Defined prompt kinds in NvimTree:
-- `nvimtree_copypaste` - Prompt for confirmation to overwrite or rename during
-  copy-paste action
-- `nvimtree_remove` - Prompt for confirmation to delete during remove action
-- `nvimtree_trash` - Prompt for confirmation to send to trash during trash
-  action
-- `nvimtree_bulkdelete` - Prompt for confirmation to delete all bookmarked
-  during bulk-delete action
-- `nvimtree_bulktrash` - Prompt for confirmation to send all bookmarked to
-  trash during bulk-trash action
+The API accepts the optional `kind` key as part of the {opts} parameter, which
+can can be used to identify the type of prompt, to allow user side
+configurations for different types of prompts.
+
+- `nvimtree_overwrite_rename`
+    overwrite or rename during |nvim-tree-api.fs.paste()|
+
+- `nvimtree_remove`
+    delete during |nvim-tree-api.fs.remove()|
+
+- `nvimtree_trash`
+    send to trash during |nvim-tree-api.fs.trash()|
+
+- `nvimtree_bulk_delete`
+    delete all bookmarked during |nvim-tree-api.marks.bulk.delete()|
+
+- `nvimtree_bulk_trash`
+    send all bookmarked to trash during |nvim-tree-api.marks.bulk.trash()|
 
 ==============================================================================
  11. OS SPECIFIC RESTRICTIONS                          *nvim-tree-os-specific*

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -131,7 +131,7 @@ local function do_single_paste(source, dest, action_type, action_fn)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
       local prompt_input = prompt_select .. " R(ename)/y/n: "
-      lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Rename", "Yes", "No" }, function(item_short)
+      lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Rename", "Yes", "No" }, "nvimtree_copypaste", function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -131,7 +131,7 @@ local function do_single_paste(source, dest, action_type, action_fn)
     else
       local prompt_select = "Overwrite " .. dest .. " ?"
       local prompt_input = prompt_select .. " R(ename)/y/n: "
-      lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Rename", "Yes", "No" }, "nvimtree_copypaste", function(item_short)
+      lib.prompt(prompt_input, prompt_select, { "", "y", "n" }, { "Rename", "Yes", "No" }, "nvimtree_overwrite_rename", function(item_short)
         utils.clear_prompt()
         if item_short == "y" then
           on_process()

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -130,7 +130,7 @@ function M.fn(node)
       items_long = { "No", "Yes" }
     end
 
-    lib.prompt(prompt_input, prompt_select, items_short, items_long, function(item_short)
+    lib.prompt(prompt_input, prompt_select, items_short, items_long, "nvimtree_remove", function(item_short)
       utils.clear_prompt()
       if item_short == "y" or item_short == (M.config.ui.confirm.default_yes and "") then
         do_remove()

--- a/lua/nvim-tree/actions/fs/trash.lua
+++ b/lua/nvim-tree/actions/fs/trash.lua
@@ -102,7 +102,7 @@ function M.fn(node)
       items_long = { "No", "Yes" }
     end
 
-    lib.prompt(prompt_input, prompt_select, items_short, items_long, function(item_short)
+    lib.prompt(prompt_input, prompt_select, items_short, items_long, "nvimtree_trash", function(item_short)
       utils.clear_prompt()
       if item_short == "y" or item_short == (M.config.ui.confirm.default_yes and "") then
         do_trash()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -157,8 +157,9 @@ end
 ---@param prompt_select string
 ---@param items_short string[]
 ---@param items_long string[]
+---@param kind string|nil
 ---@param callback fun(item_short: string)
-function M.prompt(prompt_input, prompt_select, items_short, items_long, callback)
+function M.prompt(prompt_input, prompt_select, items_short, items_long, kind, callback)
   local function format_item(short)
     for i, s in ipairs(items_short) do
       if short == s then
@@ -169,7 +170,7 @@ function M.prompt(prompt_input, prompt_select, items_short, items_long, callback
   end
 
   if M.select_prompts then
-    vim.ui.select(items_short, { prompt = prompt_select, format_item = format_item }, function(item_short)
+    vim.ui.select(items_short, { prompt = prompt_select, kind = kind, format_item = format_item }, function(item_short)
       callback(item_short)
     end)
   else

--- a/lua/nvim-tree/marks/bulk-delete.lua
+++ b/lua/nvim-tree/marks/bulk-delete.lua
@@ -33,7 +33,7 @@ function M.bulk_delete()
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulkdelete", function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulk_delete", function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_delete(nodes)

--- a/lua/nvim-tree/marks/bulk-delete.lua
+++ b/lua/nvim-tree/marks/bulk-delete.lua
@@ -33,7 +33,7 @@ function M.bulk_delete()
   if M.config.ui.confirm.remove then
     local prompt_select = "Remove bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulkdelete", function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_delete(nodes)

--- a/lua/nvim-tree/marks/bulk-trash.lua
+++ b/lua/nvim-tree/marks/bulk-trash.lua
@@ -28,7 +28,7 @@ function M.bulk_trash()
   if M.config.ui.confirm.trash then
     local prompt_select = "Trash bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulktrash", function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulk_trash", function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_trash(nodes)

--- a/lua/nvim-tree/marks/bulk-trash.lua
+++ b/lua/nvim-tree/marks/bulk-trash.lua
@@ -28,7 +28,7 @@ function M.bulk_trash()
   if M.config.ui.confirm.trash then
     local prompt_select = "Trash bookmarked ?"
     local prompt_input = prompt_select .. " y/N: "
-    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, function(item_short)
+    lib.prompt(prompt_input, prompt_select, { "", "y" }, { "No", "Yes" }, "nvimtree_bulktrash", function(item_short)
       utils.clear_prompt()
       if item_short == "y" then
         do_trash(nodes)


### PR DESCRIPTION
This PR adds the optional `kind` parameter to the `vim.ui.select` function calls.

Having this parameter set to something will help in differentiating the `ui.select` prompts of `nvim-tree` from other sources (like LSP code actions or other plugins). This can help in more finer configurations at the user's end. As an example, with this setup I can configure `nvim-tree`'s select prompts to use the relative to cursor telescope theme, while all other prompts can follow the vertical dropdown telescope theme as default.

This does not create any changes in the UI. It only uses an optional parameter that is already present in the `vim.ui` API for this sort of finer configuration.

I'm open to changing/discussing the values I've used here. Something more generic (like `nvimtree_action`) or maybe more specific would be fine as well. For my usage, just having some value that tells me its from `nvim-tree` works.

For reference, the docs of `vim.ui.select` that reference `kind`:

```vimdoc
:help vim.ui.select
...
      • {opts}       (table) Additional options
                     • prompt (string|nil) Text of the prompt. Defaults to
                       `Select one of:`
                     • format_item (function item -> text) Function to format
                       an individual item from `items`. Defaults to
                       `tostring`.
                     • kind (string|nil) Arbitrary hint string indicating the
                       item shape. Plugins reimplementing `vim.ui.select` may
                       wish to use this to infer the structure or semantics of
                       `items`, or the context in which select() was called.
...
```

Do let me know your thoughts on this. Thanks!