### PR TITLE
fix: use highlight default for DEFAULT_DEFS

### DIFF
--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -191,7 +191,7 @@ local LEGACY_LINKS = {
 function M.setup()
   -- non-linked
   for k, d in pairs(DEFAULT_DEFS) do
-    vim.api.nvim_command("hi " .. k .. " " .. d)
+    vim.api.nvim_command("hi def " .. k .. " " .. d)
   end
 
   -- hard link override when legacy only is present


### PR DESCRIPTION
In the previous `colors.setup()` the highlight groups were setup using `hi def` but that was missing for those groups under `DEFAULT_DEFS`. 

I use catppuccin's `custom_highlights` to override `NvimTreeFolderIcon` and `NvimTreeWindowPicker`, which did not work in overriding the default highlights after the recently pushed commits.