### PR TITLE
fix(#2415): disambiguate highlight groups, see :help nvim-tree-highlight-overhaul

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -46,7 +46,8 @@ CONTENTS                                                           *nvim-tree*
   7. Mappings                                 |nvim-tree-mappings|
   7.1  Mappings: Default                        |nvim-tree-mappings-default|
   8. Highlight                                |nvim-tree-highlight|
-  8.1  Highlight Overhaul                       |nvim-tree-highlight-overhaul|
+  8.1  Highlight Default                        |nvim-tree-highlight-default|
+  8.2  Highlight Overhaul                       |nvim-tree-highlight-overhaul|
   9. Events                                   |nvim-tree-events|
  10. Prompts                                  |nvim-tree-prompts|
  11. OS Specific Restrictions                 |nvim-tree-os-specific|
@@ -2253,7 +2254,16 @@ squigglies: >
     :hi NvimTreeOpenedHL       guifg=magenta guisp=red  gui=underline
     :hi NvimTreeModifiedFileHL               guisp=cyan gui=undercurl
 <
-Default linked group or definition follows name.
+To prevent usage of a highlight:
+- Before setup: link the group to `Normal` e.g.
+    `:hi NvimTreeExecFile Normal`
+- After setup: link it to `NONE`, to override the default link e.g.
+    `:hi! link NvimTreeExecFile NONE`
+
+==============================================================================
+ 8.1 HIGHLIGHT DEFAULT                           *nvim-tree-highlight-default*
+
+|:highlight-link| `default` or |:highlight-default| define the groups on setup:
 
 Standard: >
     NvimTreeNormal              Normal

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2284,10 +2284,10 @@ Standard: >
     NvimTreeStatusLineNC        StatusLineNC
 <
 File Text: >
-    NvimTreeExecFile            ModeMsg
-    NvimTreeImageFile           ModeMsg
-    NvimTreeSpecialFile         ModeMsg
-    NvimTreeSymlink             ModeMsg
+    NvimTreeExecFile            SpellCap
+    NvimTreeImageFile           SpellCap
+    NvimTreeSpecialFile         SpellCap
+    NvimTreeSymlink             SpellCap
 <
 Folder Text: >
     NvimTreeRootFolder          Title
@@ -2322,7 +2322,7 @@ Clipboard: >
     NvimTreeCutHL               SpellBad
 <
 Bookmarks: >
-    NvimTreeBookmarkIcon        SpecialKey
+    NvimTreeBookmarkIcon        NvimTreeFolderIcon
     NvimTreeBookmarkHL          SpellLocal
 <
 Modified: >

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2240,11 +2240,19 @@ groups.
 Example |:highlight| >
     :hi NvimTreeSymlink guifg=blue gui=bold,underline
 <
-It is recommended to enable 'termguicolors' for the more pleasant 24-bit colours.
+It is recommended to enable 'termguicolors' for the more pleasant 24-bit
+colours.
 
 To view the active highlight groups run `:so $VIMRUNTIME/syntax/hitest.vim`
 as per |:highlight|
 
+The `*HL` groups are additive as per |nvim-tree-opts-renderer| precedence.
+Only present attributes will clobber each other.
+In this example a modified, opened file will have magenta text, with cyan
+squigglies: >
+    :hi NvimTreeOpenedHL       guifg=magenta guisp=red  gui=underline
+    :hi NvimTreeModifiedFileHL               guisp=cyan gui=undercurl
+<
 Default linked group or definition follows name.
 
 Standard: >

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2250,7 +2250,7 @@ as per |:highlight|
 The `*HL` groups are additive as per |nvim-tree-opts-renderer| precedence.
 Only present attributes will clobber each other.
 In this example a modified, opened file will have magenta text, with cyan
-squigglies: >
+undercurl: >
     :hi NvimTreeOpenedHL       guifg=magenta guisp=red  gui=underline
     :hi NvimTreeModifiedFileHL               guisp=cyan gui=undercurl
 <
@@ -2393,16 +2393,16 @@ Diagnostics Folder Highlight: >
 - `highlight_xxx` is additive instead of overwriting. See
   |nvim-tree-opts-renderer| for precedence.
 
-2024-01-22: disambiguate highlights sharing groups:
+2024-01-29: disambiguate default highlights sharing groups:
 
 - NvimTreeRootFolder   PreProc   -> Title
 - NvimTreeModified*    Constant  -> Type
 - NvimTreeOpenedHL     Constant  -> Special
-- NvimTreeBookmarkIcon Constant  -> SpecialKey
-- NvimTreeExecFile     Constant  -> ModeMsg
-- NvimTreeImageFile    PreProc   -> ModeMsg
-- NvimTreeSpecialFile  PreProc   -> ModeMsg
-- NvimTreeSymlink      Statement -> ModeMsg
+- NvimTreeBookmarkIcon Constant  -> NvimTreeFolderIcon
+- NvimTreeExecFile     Constant  -> SpellCap
+- NvimTreeImageFile    PreProc   -> SpellCap
+- NvimTreeSpecialFile  PreProc   -> SpellCap
+- NvimTreeSymlink      Statement -> SpellCap
 
 Legacy highlight group are still obeyed when they are defined and the current
 highlight group is not, hard linking as follows: >

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2290,7 +2290,7 @@ File Text: >
     NvimTreeSymlink             ModeMsg
 <
 Folder Text: >
-    NvimTreeRootFolder          PreProc
+    NvimTreeRootFolder          Title
     NvimTreeFolderName          Directory
     NvimTreeEmptyFolderName     Directory
     NvimTreeOpenedFolderName    Directory
@@ -2395,6 +2395,7 @@ Diagnostics Folder Highlight: >
 
 2024-01-22: disambiguate highlights sharing groups:
 
+- NvimTreeRootFolder   PreProc   -> Title
 - NvimTreeModified*    Constant  -> Type
 - NvimTreeOpenedHL     Constant  -> Special
 - NvimTreeBookmarkIcon Constant  -> SpecialKey

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -846,7 +846,7 @@ Value can be `"none"`, `"icon"`, `"name"` or `"all"`.
 
 *nvim-tree.renderer.highlight_opened_files*
 Highlight icons and/or names for |bufloaded()| files using the
-`NvimTreeOpenedFile` highlight group.
+`NvimTreeOpenedHL` highlight group.
 See |nvim-tree-api.navigate.opened.next()| and |nvim-tree-api.navigate.opened.prev()|
 Value can be `"none"`, `"icon"`, `"name"` or `"all"`.
   Type: `string`, Default: `"none"`
@@ -2266,11 +2266,10 @@ Standard: >
     NvimTreeStatusLineNC        StatusLineNC
 <
 File Text: >
-    NvimTreeExecFile            Constant
-    NvimTreeImageFile           PreProc
-    NvimTreeOpenedFile          Constant
-    NvimTreeSpecialFile         PreProc
-    NvimTreeSymlink             Statement
+    NvimTreeExecFile            WinBar
+    NvimTreeImageFile           WinBar
+    NvimTreeSpecialFile         WinBar
+    NvimTreeSymlink             WinBar
 <
 Folder Text: >
     NvimTreeRootFolder          PreProc
@@ -2282,7 +2281,6 @@ Folder Text: >
 File Icons: >
     NvimTreeFileIcon            NvimTreeNormal
     NvimTreeSymlinkIcon         NvimTreeNormal
-    NvimTreeOpenedFileIcon      NvimTreeOpenedFile
 <
 Folder Icons: >
     NvimTreeFolderIcon          guifg=#8094b4 ctermfg=Blue
@@ -2306,16 +2304,16 @@ Clipboard: >
     NvimTreeCutHL               SpellBad
 <
 Bookmarks: >
-    NvimTreeBookmarkIcon        Constant
+    NvimTreeBookmarkIcon        SpecialKey
     NvimTreeBookmarkHL          SpellLocal
 <
 Modified: >
-    NvimTreeModifiedIcon        Constant
+    NvimTreeModifiedIcon        Type
     NvimTreeModifiedFileHL      NvimTreeModifiedIcon
     NvimTreeModifiedFolderHL    NvimTreeModifiedIcon
 <
 Opened: >
-    NvimTreeOpenedHL            Constant
+    NvimTreeOpenedHL            Special
 <
 Git Icon: >
     NvimTreeGitDeletedIcon      Statement
@@ -2376,6 +2374,16 @@ Diagnostics Folder Highlight: >
 - `highlight_xxx` has highlight groups for both File and Folder
 - `highlight_xxx` is additive instead of overwriting. See
   |nvim-tree-opts-renderer| for precedence.
+
+2024-01-22: disambiguate highlights sharing groups:
+
+- NvimTreeModified*    Constant  -> Type
+- NvimTreeOpenedHL     Constant  -> Special
+- NvimTreeBookmarkIcon Constant  -> SpecialKey
+- NvimTreeExecFile     Constant  -> WinBar
+- NvimTreeImageFile    PreProc   -> WinBar
+- NvimTreeSpecialFile  PreProc   -> WinBar
+- NvimTreeSymlink      Statement -> WinBar
 
 Legacy highlight group are still obeyed when they are defined and the current
 highlight group is not, hard linking as follows: >

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2266,10 +2266,10 @@ Standard: >
     NvimTreeStatusLineNC        StatusLineNC
 <
 File Text: >
-    NvimTreeExecFile            WinBar
-    NvimTreeImageFile           WinBar
-    NvimTreeSpecialFile         WinBar
-    NvimTreeSymlink             WinBar
+    NvimTreeExecFile            ModeMsg
+    NvimTreeImageFile           ModeMsg
+    NvimTreeSpecialFile         ModeMsg
+    NvimTreeSymlink             ModeMsg
 <
 Folder Text: >
     NvimTreeRootFolder          PreProc
@@ -2380,10 +2380,10 @@ Diagnostics Folder Highlight: >
 - NvimTreeModified*    Constant  -> Type
 - NvimTreeOpenedHL     Constant  -> Special
 - NvimTreeBookmarkIcon Constant  -> SpecialKey
-- NvimTreeExecFile     Constant  -> WinBar
-- NvimTreeImageFile    PreProc   -> WinBar
-- NvimTreeSpecialFile  PreProc   -> WinBar
-- NvimTreeSymlink      Statement -> WinBar
+- NvimTreeExecFile     Constant  -> ModeMsg
+- NvimTreeImageFile    PreProc   -> ModeMsg
+- NvimTreeSpecialFile  PreProc   -> ModeMsg
+- NvimTreeSymlink      Statement -> ModeMsg
 
 Legacy highlight group are still obeyed when they are defined and the current
 highlight group is not, hard linking as follows: >

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -38,7 +38,7 @@ local DEFAULT_LINKS = {
   NvimTreeSymlink = "ModeMsg",
 
   -- Folder Text
-  NvimTreeRootFolder = "PreProc",
+  NvimTreeRootFolder = "Title",
   NvimTreeFolderName = "Directory",
   NvimTreeEmptyFolderName = "Directory",
   NvimTreeOpenedFolderName = "Directory",

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -32,10 +32,10 @@ local DEFAULT_LINKS = {
   NvimTreeStatusLineNC = "StatusLineNC",
 
   -- File Text
-  NvimTreeExecFile = "ModeMsg",
-  NvimTreeImageFile = "ModeMsg",
-  NvimTreeSpecialFile = "ModeMsg",
-  NvimTreeSymlink = "ModeMsg",
+  NvimTreeExecFile = "SpellCap",
+  NvimTreeImageFile = "SpellCap",
+  NvimTreeSpecialFile = "SpellCap",
+  NvimTreeSymlink = "SpellCap",
 
   -- Folder Text
   NvimTreeRootFolder = "Title",
@@ -66,7 +66,7 @@ local DEFAULT_LINKS = {
   NvimTreeCopiedHL = "SpellRare",
 
   -- Bookmark
-  NvimTreeBookmarkIcon = "SpecialKey",
+  NvimTreeBookmarkIcon = "NvimTreeFolderIcon",
   NvimTreeBookmarkHL = "SpellLocal",
 
   -- Modified

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -32,10 +32,10 @@ local DEFAULT_LINKS = {
   NvimTreeStatusLineNC = "StatusLineNC",
 
   -- File Text
-  NvimTreeExecFile = "WinBar",
-  NvimTreeImageFile = "WinBar",
-  NvimTreeSpecialFile = "WinBar",
-  NvimTreeSymlink = "WinBar",
+  NvimTreeExecFile = "ModeMsg",
+  NvimTreeImageFile = "ModeMsg",
+  NvimTreeSpecialFile = "ModeMsg",
+  NvimTreeSymlink = "ModeMsg",
 
   -- Folder Text
   NvimTreeRootFolder = "PreProc",

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -32,11 +32,10 @@ local DEFAULT_LINKS = {
   NvimTreeStatusLineNC = "StatusLineNC",
 
   -- File Text
-  NvimTreeExecFile = "Constant",
-  NvimTreeImageFile = "PreProc",
-  NvimTreeOpenedFile = "Constant",
-  NvimTreeSpecialFile = "PreProc",
-  NvimTreeSymlink = "Statement",
+  NvimTreeExecFile = "WinBar",
+  NvimTreeImageFile = "WinBar",
+  NvimTreeSpecialFile = "WinBar",
+  NvimTreeSymlink = "WinBar",
 
   -- Folder Text
   NvimTreeRootFolder = "PreProc",
@@ -48,7 +47,6 @@ local DEFAULT_LINKS = {
   -- File Icons
   NvimTreeFileIcon = "NvimTreeNormal",
   NvimTreeSymlinkIcon = "NvimTreeNormal",
-  NvimTreeOpenedFileIcon = "NvimTreeOpenedFile",
 
   -- Folder Icons
   NvimTreeOpenedFolderIcon = "NvimTreeFolderIcon",
@@ -68,16 +66,16 @@ local DEFAULT_LINKS = {
   NvimTreeCopiedHL = "SpellRare",
 
   -- Bookmark
-  NvimTreeBookmarkIcon = "Constant",
+  NvimTreeBookmarkIcon = "SpecialKey",
   NvimTreeBookmarkHL = "SpellLocal",
 
   -- Modified
-  NvimTreeModifiedIcon = "Constant",
+  NvimTreeModifiedIcon = "Type",
   NvimTreeModifiedFileHL = "NvimTreeModifiedIcon",
   NvimTreeModifiedFolderHL = "NvimTreeModifiedFileHL",
 
   -- Opened
-  NvimTreeOpenedHL = "Constant",
+  NvimTreeOpenedHL = "Special",
 
   -- Git Icon
   NvimTreeGitDeletedIcon = "Statement",


### PR DESCRIPTION
This is a break however it is needed. The normalised highlight groups brought them too close together.

Git groups could do with some disambiguation however there are no standards. We could bring them in line with gitsigns and lualine however that may be too much of a breaking change.

With default dark scheme:

- root: purple->bold purple (Title)
- modified: dark brown->green (Type)
- opened: dark brown->light brow (Special)
- bookmark icon: dark brown->folder icon 
- specials: ->blue undercurl (SpellCap)

Added more documentation.