### PR TITLE
fix(#2415): nvim 0.8 highlight overhaul support, limited to only show highest highlight precedence

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -793,6 +793,7 @@ Use nvim-tree in a floating window.
 
 Highlight precedence, additive:
   git < opened < modified < bookmarked < diagnostics < copied < cut
+Neovim <= 0.8 will only show the highest.
 
 *nvim-tree.renderer.add_trailing*
 Appends a trailing slash to folder names.

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -178,12 +178,12 @@ function M.setup()
   for from, to in pairs(LEGACY_LINKS) do
     local hl_from
     local hl_to
-    if vim.fn.has "nvim-0.8" == 1 then
-      hl_from = vim.api.nvim__get_hl_defs(0)[from] or {}
-      hl_to = vim.api.nvim__get_hl_defs(0)[to] or {}
-    else
+    if vim.fn.has "nvim-0.9" == 1 then
       hl_from = vim.api.nvim_get_hl(0, { name = from })
       hl_to = vim.api.nvim_get_hl(0, { name = to })
+    else
+      hl_from = vim.api.nvim__get_hl_defs(0)[from] or {}
+      hl_to = vim.api.nvim__get_hl_defs(0)[to] or {}
     end
     if vim.tbl_isempty(hl_from) and not vim.tbl_isempty(hl_to) then
       vim.api.nvim_command("hi link " .. from .. " " .. to)

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -196,8 +196,15 @@ function M.setup()
 
   -- hard link override when legacy only is present
   for from, to in pairs(LEGACY_LINKS) do
-    local hl_from = vim.api.nvim_get_hl(0, { name = from })
-    local hl_to = vim.api.nvim_get_hl(0, { name = to })
+    local hl_from
+    local hl_to
+    if vim.fn.has "nvim-0.8" == 1 then
+      hl_from = vim.api.nvim__get_hl_defs(0)[from] or {}
+      hl_to = vim.api.nvim__get_hl_defs(0)[to] or {}
+    else
+      hl_from = vim.api.nvim_get_hl(0, { name = from })
+      hl_to = vim.api.nvim_get_hl(0, { name = to })
+    end
     if vim.tbl_isempty(hl_from) and not vim.tbl_isempty(hl_to) then
       vim.api.nvim_command("hi link " .. from .. " " .. to)
     end

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -260,15 +260,7 @@ function Builder:create_combined_group(groups)
 
     -- build the highlight, overriding values
     for _, group in ipairs(groups) do
-      local hl
-      if vim.fn.has "nvim-0.8" == 1 then
-        hl = vim.api.nvim__get_hl_defs(0)[group] or {}
-        if hl["link"] then
-          hl["link"] = nil
-        end
-      else
-        hl = vim.api.nvim_get_hl(0, { name = group, link = false })
-      end
+      local hl = vim.api.nvim_get_hl(0, { name = group, link = false })
       combined_hl = vim.tbl_extend("force", combined_hl, hl)
     end
 
@@ -303,16 +295,24 @@ function Builder:add_highlights(node)
     table.insert(name_groups, name)
   end
 
-  -- one or many icon groups
+  -- one or many icon groups; <= 0.8 always uses highest due to lack of a practical nvim_get_hl equivalent
   if #icon_groups > 1 then
-    icon_hl_group = self:create_combined_group(icon_groups)
+    if vim.fn.has "nvim-0.9" == 1 then
+      icon_hl_group = self:create_combined_group(icon_groups)
+    else
+      icon_hl_group = icon_groups[#icon_groups]
+    end
   else
     icon_hl_group = icon_groups[1]
   end
 
-  -- one or many name groups
+  -- one or many name groups; <= 0.8 always uses highest due to lack of a practical nvim_get_hl equivalent
   if #name_groups > 1 then
-    name_hl_group = self:create_combined_group(name_groups)
+    if vim.fn.has "nvim-0.9" == 1 then
+      name_hl_group = self:create_combined_group(name_groups)
+    else
+      name_hl_group = name_groups[#name_groups]
+    end
   else
     name_hl_group = name_groups[1]
   end

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -266,7 +266,15 @@ function Builder:create_combined_group(groups)
 
     -- build the highlight, overriding values
     for _, group in ipairs(groups) do
-      local hl = vim.api.nvim_get_hl(0, { name = group, link = false })
+      local hl
+      if vim.fn.has "nvim-0.8" == 1 then
+        hl = vim.api.nvim__get_hl_defs(0)[group] or {}
+        if hl["link"] then
+          hl["link"] = nil
+        end
+      else
+        hl = vim.api.nvim_get_hl(0, { name = group, link = false })
+      end
       combined_hl = vim.tbl_extend("force", combined_hl, hl)
     end
 


### PR DESCRIPTION
nvim-tree is using `nvim_get_hl` which was introduced in nvim 0.9 to replace the unstable `get_hl_defs` in the following [commit](https://github.com/neovim/neovim/pull/22693/files).

Unfortunately this raises an error in 0.8 nvim versions due to the function not existing.

```
Failed to run `config` for nvim-tree.lua
...are/nvim/lazy/nvim-tree.lua/lua/nvim-tree/appearance.lua:199: attempt to call field 'nvim_get_hl' (a nil value)
stacktrace:
  - ~/.config/nvim/lua/confidenceman02/plugins/nvim-tree.lua:14 _in_ **config**
  - ~/.config/nvim/lua/confidenceman02/lazy.lua:14
```

- Fall back to get_hl_defs when detecting 0.8
- Set the 'link' property to nil to emulate `link = false` in `builder.lua`