### PR TITLE
fix(#2651): window's LineNrAbove and LineNrBelow map to NvimTreeLineNr

### DIFF
--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -138,6 +138,9 @@ local NS_LINKS = {
   Normal = "NvimTreeNormal",
   NormalNC = "NvimTreeNormalNC",
   NormalFloat = "NvimTreeNormalFloat",
+  -- Not mapped to cyclic LineNr when relativenumber set.
+  LineNrAbove = "NvimTreeLineNr",
+  LineNrBelow = "NvimTreeLineNr",
 }
 
 -- nvim-tree highlight groups to legacy


### PR DESCRIPTION
fixes #2651 