### PR TITLE
fix(#2643): correctly apply linked highlight groups in tree window

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -162,12 +162,12 @@ local function setup_autocommands(opts)
     vim.api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
   end
 
-  -- reset and draw highlights when colorscheme is changed
+  -- reset and draw (highlights) when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", {
     callback = function()
       appearance.setup()
       view.reset_winhl()
-      renderer.render_hl(view.get_bufnr())
+      renderer.draw()
     end,
   })
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -166,6 +166,7 @@ local function setup_autocommands(opts)
   create_nvim_tree_autocmd("ColorScheme", {
     callback = function()
       appearance.setup()
+      view.reset_winhl()
       renderer.render_hl(view.get_bufnr())
     end,
   })

--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -1,7 +1,4 @@
-local M = {
-  -- namespace for all tree window highlights
-  NS_ID = vim.api.nvim_create_namespace "nvim_tree",
-}
+local M = {}
 
 -- directly defined groups, please keep these to an absolute minimum
 local DEFAULT_DEFS = {
@@ -125,21 +122,6 @@ local DEFAULT_LINKS = {
   NvimTreeDiagnosticHintFolderHL = "NvimTreeDiagnosticHintFileHL",
 }
 
--- namespace standard links
-local NS_LINKS = {
-  EndOfBuffer = "NvimTreeEndOfBuffer",
-  CursorLine = "NvimTreeCursorLine",
-  CursorLineNr = "NvimTreeCursorLineNr",
-  LineNr = "NvimTreeLineNr",
-  WinSeparator = "NvimTreeWinSeparator",
-  StatusLine = "NvimTreeStatusLine",
-  StatusLineNC = "NvimTreeStatuslineNC",
-  SignColumn = "NvimTreeSignColumn",
-  Normal = "NvimTreeNormal",
-  NormalNC = "NvimTreeNormalNC",
-  NormalFloat = "NvimTreeNormalFloat",
-}
-
 -- nvim-tree highlight groups to legacy
 local LEGACY_LINKS = {
   NvimTreeModifiedIcon = "NvimTreeModifiedFile",
@@ -206,11 +188,6 @@ function M.setup()
   -- default links
   for from, to in pairs(DEFAULT_LINKS) do
     vim.api.nvim_command("hi def link " .. from .. " " .. to)
-  end
-
-  -- window standard; this doesn't appear to clear on ColorScheme however we err on the side of caution
-  for from, to in pairs(NS_LINKS) do
-    vim.api.nvim_set_hl(M.NS_ID, from, { link = to })
   end
 end
 

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -45,7 +45,7 @@ local M = {
 ---@field private root_cwd string absolute path
 ---@field private index number
 ---@field private depth number
----@field private combined_groups string[] combined group names
+---@field private combined_groups table<string, boolean> combined group names
 ---@field private markers boolean[] indent markers
 local Builder = {}
 
@@ -245,22 +245,17 @@ function Builder:build_signs(node)
   end
 end
 
----Combined group name less than the 200 byte limit of highlight group names
----@private
----@param groups string[] highlight group names
----@return string name "NvimTreeCombinedHL" .. sha256
-function Builder:combined_group_name(groups)
-  return string.format("NvimTreeCombinedHL%s", vim.fn.sha256(table.concat(groups)))
-end
-
 ---Create a highlight group for groups with later groups overriding previous.
+---Combined group name is less than the 200 byte limit of highlight group names
 ---@private
 ---@param groups string[] highlight group names
+---@return string group_name "NvimTreeCombinedHL" .. sha256
 function Builder:create_combined_group(groups)
-  local combined_name = self:combined_group_name(groups)
+  local combined_name = string.format("NvimTreeCombinedHL%s", vim.fn.sha256(table.concat(groups)))
 
   -- only create if necessary
-  if not vim.tbl_contains(self.combined_groups, combined_name) then
+  if not self.combined_groups[combined_name] then
+    self.combined_groups[combined_name] = true
     local combined_hl = {}
 
     -- build the highlight, overriding values
@@ -274,6 +269,8 @@ function Builder:create_combined_group(groups)
 
     table.insert(self.combined_groups, combined_name)
   end
+
+  return combined_name
 end
 
 ---Calculate highlight group for icon and name. A combined highlight group will be created
@@ -300,16 +297,14 @@ function Builder:add_highlights(node)
 
   -- one or many icon groups
   if #icon_groups > 1 then
-    icon_hl_group = self:combined_group_name(icon_groups)
-    self:create_combined_group(icon_groups)
+    icon_hl_group = self:create_combined_group(icon_groups)
   else
     icon_hl_group = icon_groups[1]
   end
 
   -- one or many name groups
   if #name_groups > 1 then
-    name_hl_group = self:combined_group_name(name_groups)
-    self:create_combined_group(name_groups)
+    name_hl_group = self:create_combined_group(name_groups)
   else
     name_hl_group = name_groups[1]
   end

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -1,4 +1,3 @@
-local appearance = require "nvim-tree.appearance"
 local core = require "nvim-tree.core"
 local live_filter = require "nvim-tree.live-filter"
 local notify = require "nvim-tree.notify"
@@ -270,8 +269,8 @@ function Builder:create_combined_group(groups)
       combined_hl = vim.tbl_extend("force", combined_hl, hl)
     end
 
-    -- highlight directly in the namespace
-    vim.api.nvim_set_hl(appearance.NS_ID, combined_name, combined_hl)
+    -- add highlights to the global namespace
+    vim.api.nvim_set_hl(0, combined_name, combined_hl)
 
     table.insert(self.combined_groups, combined_name)
   end

--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -1,5 +1,3 @@
-local appearance = require "nvim-tree.appearance"
-
 local M = {}
 
 local utils = require "nvim-tree.utils"
@@ -68,12 +66,13 @@ local function show()
     style = "minimal",
   })
 
-  local extmarks = vim.api.nvim_buf_get_extmarks(0, appearance.NS_ID, { line_nr - 1, 0 }, { line_nr - 1, -1 }, { details = 1 })
+  local ns_id = vim.api.nvim_get_namespaces()["NvimTreeHighlights"]
+  local extmarks = vim.api.nvim_buf_get_extmarks(0, ns_id, { line_nr - 1, 0 }, { line_nr - 1, -1 }, { details = 1 })
   vim.api.nvim_win_call(M.popup_win, function()
     vim.api.nvim_buf_set_lines(0, 0, -1, true, { line })
     for _, extmark in ipairs(extmarks) do
       local hl = extmark[4]
-      vim.api.nvim_buf_add_highlight(0, appearance.NS_ID, hl.hl_group, 0, extmark[3], hl.end_col)
+      vim.api.nvim_buf_add_highlight(0, ns_id, hl.hl_group, 0, extmark[3], hl.end_col)
     end
     vim.cmd [[ setlocal nowrap cursorline noswapfile nobuflisted buftype=nofile bufhidden=hide ]]
   end)

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -1,4 +1,3 @@
-local appearance = require "nvim-tree.appearance"
 local core = require "nvim-tree.core"
 local log = require "nvim-tree.log"
 local view = require "nvim-tree.view"
@@ -14,6 +13,8 @@ local M = {
 }
 
 local SIGN_GROUP = "NvimTreeRendererSigns"
+
+local namespace_id = vim.api.nvim_create_namespace "NvimTreeHighlights"
 
 ---@param bufnr number
 ---@param lines string[]
@@ -34,11 +35,12 @@ function M.render_hl(bufnr, hl)
   if not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  vim.api.nvim_buf_clear_namespace(bufnr, appearance.NS_ID, 0, -1)
+  -- TODO #2643 recalculate highlight overrides in response to colorscheme
+  vim.api.nvim_buf_clear_namespace(bufnr, namespace_id, 0, -1)
   for _, data in ipairs(hl or M.last_hl_args) do
     if type(data[1]) == "table" then
       for _, group in ipairs(data[1]) do
-        vim.api.nvim_buf_add_highlight(bufnr, appearance.NS_ID, group, data[2], data[3], data[4])
+        vim.api.nvim_buf_add_highlight(bufnr, namespace_id, group, data[2], data[3], data[4])
       end
     end
   end

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -8,9 +8,7 @@ local icon_component = require "nvim-tree.renderer.components.icons"
 local full_name = require "nvim-tree.renderer.components.full-name"
 local Builder = require "nvim-tree.renderer.builder"
 
-local M = {
-  last_hl_args = {},
-}
+local M = {}
 
 local SIGN_GROUP = "NvimTreeRendererSigns"
 
@@ -35,9 +33,8 @@ function M.render_hl(bufnr, hl)
   if not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  -- TODO #2643 recalculate highlight overrides in response to colorscheme
   vim.api.nvim_buf_clear_namespace(bufnr, namespace_id, 0, -1)
-  for _, data in ipairs(hl or M.last_hl_args) do
+  for _, data in ipairs(hl) do
     if type(data[1]) == "table" then
       for _, group in ipairs(data[1]) do
         vim.api.nvim_buf_add_highlight(bufnr, namespace_id, group, data[2], data[3], data[4])
@@ -60,8 +57,6 @@ function M.draw()
   local builder = Builder:new():build()
 
   _draw(bufnr, builder.lines, builder.hl_args, builder.signs)
-
-  M.last_hl_args = builder.hl_args
 
   if cursor and #builder.lines >= cursor[1] then
     vim.api.nvim_win_set_cursor(view.get_winnr(), cursor)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -1,4 +1,3 @@
-local appearance = require "nvim-tree.appearance"
 local events = require "nvim-tree.events"
 local utils = require "nvim-tree.utils"
 local log = require "nvim-tree.log"
@@ -39,6 +38,19 @@ M.View = {
     cursorlineopt = "both",
     colorcolumn = "0",
     wrap = false,
+    winhl = table.concat({
+      "EndOfBuffer:NvimTreeEndOfBuffer",
+      "CursorLine:NvimTreeCursorLine",
+      "CursorLineNr:NvimTreeCursorLineNr",
+      "LineNr:NvimTreeLineNr",
+      "WinSeparator:NvimTreeWinSeparator",
+      "StatusLine:NvimTreeStatusLine",
+      "StatusLineNC:NvimTreeStatuslineNC",
+      "SignColumn:NvimTreeSignColumn",
+      "Normal:NvimTreeNormal",
+      "NormalNC:NvimTreeNormalNC",
+      "NormalFloat:NvimTreeNormalFloat",
+    }, ","),
   },
 }
 
@@ -135,9 +147,6 @@ local function set_window_options_and_buffer()
     vim.opt_local[k] = v
   end
   vim.opt.eventignore = eventignore
-
-  -- use highlights from the nvim_tree namespace
-  vim.api.nvim_win_set_hl_ns(M.get_winnr(), appearance.NS_ID)
 end
 
 ---@return table
@@ -528,6 +537,13 @@ end
 ---@return boolean
 function M.is_root_folder_visible(cwd)
   return cwd ~= "/" and not M.View.hide_root_folder
+end
+
+-- used on ColorScheme event
+function M.reset_winhl()
+  if M.get_winnr() and vim.api.nvim_win_is_valid(M.get_winnr()) then
+    vim.wo[M.get_winnr()].winhl = M.View.winopts.winhl
+  end
 end
 
 function M.setup(opts)


### PR DESCRIPTION
fixes #2643
fixes #2651

Reverts to `&winhl` instead of a highlight namespace for the nvim-tree window. See #2634 comments for details on issues encountered.

- [x] TODO: reapply combined highlights on colorscheme change