### PR TITLE
fix(#2415): NvimTreeIndentMarker highlight group: FileIcon->FolderIcon

### DIFF
--- a/lua/nvim-tree/appearance.lua
+++ b/lua/nvim-tree/appearance.lua
@@ -52,7 +52,7 @@ local DEFAULT_LINKS = {
   NvimTreeFolderArrowOpen = "NvimTreeIndentMarker",
 
   -- Indent
-  NvimTreeIndentMarker = "NvimTreeFileIcon",
+  NvimTreeIndentMarker = "NvimTreeFolderIcon",
 
   -- LiveFilter
   NvimTreeLiveFilterPrefix = "PreProc",


### PR DESCRIPTION
Did not test clean room with indent markers enabled.