### PR TITLE
ci: triggers, nvim stable version & env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - '*'
-  push:
-    branches:
-      - master
-      - release-please--branches--master--components--nvim-tree
-
   workflow_dispatch:
 
 permissions:
@@ -59,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        nvim_version: [ v0.9.4 ]
+        nvim_version: [ stable, nightly ]
         luals_version: [ 3.7.3 ]
 
     steps:
@@ -76,6 +69,9 @@ jobs:
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
 
       - name: make check
-        run: VIMRUNTIME=/home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime PATH="luals/bin:${PATH}" make check
+        env:
+          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
+          PATH: "luals/bin:${PATH}"
+        run: make check
 
       - run: make help-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,11 @@ jobs:
           mkdir -p luals
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
 
+      - run: echo "luals/bin" >> "$GITHUB_PATH"
+
       - name: make check
         env:
           VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
-          PATH: "luals/bin:${PATH}"
         run: make check
 
       - run: make help-check


### PR DESCRIPTION
This PR updates CI workflow such that
- `push` is no longer triggering runs (we don't need to run it on master as it's guarded on PR level, release-please branch should also be triggered by `pull_request`)
- nvim version is no longer hardcoded but `stable` tag is used instead
- `nightly` is added to nvim versions matrix - this might prepare us for upcoming releases
- environment variables are set vie `env` key instead of inlining them