### PR TITLE
fix: searchcount exception on invalid search regex

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -105,8 +105,8 @@ function M.open_on_directory()
 end
 
 function M.place_cursor_on_node()
-  local search = vim.fn.searchcount()
-  if search and search.exact_match == 1 then
+  local ok, search = pcall(vim.fn.searchcount())
+  if ok and search and search.exact_match == 1 then
     return
   end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -105,7 +105,7 @@ function M.open_on_directory()
 end
 
 function M.place_cursor_on_node()
-  local ok, search = pcall(vim.fn.searchcount())
+  local ok, search = pcall(vim.fn.searchcount)
   if ok and search and search.exact_match == 1 then
     return
   end


### PR DESCRIPTION
Hi there, I encountered an error message generated by `vim.fn.searchcount` in `M.place_cursor_on_node` function when having `hijack_cursor` option enabled. 

I don't know if this fix is wanted or not, its just something that bothered me when using `vim.fn.searchcount` and I noticed it occurring when opening NvimTree.


Using `pcall` should fix the occurrence of the error message generated by `vim.fn.searchcount` as showing this error seems to be irrelevant to the `M.place_cursor_on_node` function:

```
E54: Unmatched (                                                                                                                                                    
Error detected while processing CursorMoved Autocommands for "NvimTree_*":                                                                                          
Error executing lua callback: Vim:E54: Unmatched (                                                                                                                  
stack traceback:                                                                                                                                                    
        [C]: in function 'searchcount'                                                                                                                              
        ...e/.local/share/nvim/lazy/nvim-tree.lua/lua/nvim-tree.lua:108: in function 'place_cursor_on_node'                                                         
        ...e/.local/share/nvim/lazy/nvim-tree.lua/lua/nvim-tree.lua:236: in function <...e/.local/share/nvim/lazy/nvim-tree.lua/lua/nvim-tree.lua:234>   
```

To reproduce I just search for `(` in my neovim, then open nvim-tree.
1. `/\v(`
2. `:NvimTreeOpen` 

