### PR TITLE
fix(#2695): git toplevel guard against missing paths

### DIFF
--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -136,6 +136,10 @@ end
 ---@param path string absolute
 ---@return string|nil
 function M.get_toplevel(path)
+  if not path then
+    return nil
+  end
+
   if not M.config.git.enable then
     return nil
   end


### PR DESCRIPTION
fixes #2695 