### PR TITLE
fix(#2705): change NvimTreeWindowPicker cterm background from Cyan to more visible DarkBlue

### DIFF
--- a/lua/nvim-tree/appearance/init.lua
+++ b/lua/nvim-tree/appearance/init.lua
@@ -51,7 +51,7 @@ M.HIGHLIGHT_GROUPS = {
   { group = "NvimTreeIndentMarker", link = "NvimTreeFolderIcon" },
 
   -- Picker
-  { group = "NvimTreeWindowPicker", def = "guifg=#ededed guibg=#4493c8 gui=bold ctermfg=White ctermbg=Cyan" },
+  { group = "NvimTreeWindowPicker", def = "guifg=#ededed guibg=#4493c8 gui=bold ctermfg=White ctermbg=DarkBlue" },
 
   -- LiveFilter
   { group = "NvimTreeLiveFilterPrefix", link = "PreProc" },


### PR DESCRIPTION
fixes #2705