### PR TITLE
feat: improve help

### DIFF
--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -41,6 +41,7 @@ local Api = {
   },
   commands = {},
   diagnostics = {},
+  meta = {},
 }
 
 --- Do nothing when setup not called.
@@ -76,6 +77,39 @@ local function wrap_node_or_nil(fn)
   end
 end
 
+local function expose_api(group, description, fn)
+  Api.meta[fn] = { group = group, description = description, fn = fn }
+  return fn
+end
+
+local function get_exposed_apis(current_slice, api_path, apis)
+  for path, value in pairs(current_slice) do
+    if path ~= "meta" then
+      if type(value) == "function" and Api.meta[value] then
+        local entry = Api.meta[value]
+
+        table.insert(apis,
+          {
+            group = entry.group,
+            description = entry.description,
+            fn = value,
+            api_path = api_path .. "." .. path
+          })
+      end
+
+      if type(value) == "table" then
+        get_exposed_apis(current_slice[path], api_path .. "." .. path, apis)
+      end
+    end
+  end
+end
+
+Api.meta.get_exposed_apis = function()
+  local apis = {}
+  get_exposed_apis(Api, "api", apis)
+  return apis
+end
+
 ---@class ApiTreeOpenOpts
 ---@field path string|nil path
 ---@field current_window boolean|nil default false
@@ -83,8 +117,10 @@ end
 ---@field find_file boolean|nil default false
 ---@field update_root boolean|nil default false
 
-Api.tree.open = wrap(actions.tree.open.fn)
-Api.tree.focus = Api.tree.open
+Api.tree.open = expose_api("View", "Open", wrap(actions.tree.open.fn))
+Api.tree.focus = function(...)
+  return Api.tree.open(...)
+end
 
 ---@class ApiTreeToggleOpts
 ---@field path string|nil
@@ -94,11 +130,11 @@ Api.tree.focus = Api.tree.open
 ---@field update_root boolean|nil default false
 ---@field focus boolean|nil default true
 
-Api.tree.toggle = wrap(actions.tree.toggle.fn)
-Api.tree.close = wrap(view.close)
-Api.tree.close_in_this_tab = wrap(view.close_this_tab_only)
-Api.tree.close_in_all_tabs = wrap(view.close_all_tabs)
-Api.tree.reload = wrap(actions.reloaders.reload_explorer)
+Api.tree.toggle = expose_api("View", "Toggle", wrap(actions.tree.toggle.fn))
+Api.tree.close = expose_api("View", "Close", wrap(view.close))
+Api.tree.close_in_this_tab = expose_api("View", "Close In This Tab", wrap(view.close_this_tab_only))
+Api.tree.close_in_all_tabs = expose_api("View", "Close In All Tabs", wrap(view.close_all_tabs))
+Api.tree.reload = expose_api("View", "Reload", wrap(actions.reloaders.reload_explorer))
 
 Api.tree.change_root = wrap(function(...)
   require("nvim-tree").change_dir(...)
@@ -128,13 +164,17 @@ Api.tree.find_file = wrap(actions.tree.find_file.fn)
 Api.tree.search_node = wrap(actions.finders.search_node.fn)
 Api.tree.collapse_all = wrap(actions.tree.modifiers.collapse_all.fn)
 Api.tree.expand_all = wrap_node(actions.tree.modifiers.expand_all.fn)
-Api.tree.toggle_gitignore_filter = wrap(actions.tree.modifiers.toggles.git_ignored)
-Api.tree.toggle_git_clean_filter = wrap(actions.tree.modifiers.toggles.git_clean)
-Api.tree.toggle_no_buffer_filter = wrap(actions.tree.modifiers.toggles.no_buffer)
-Api.tree.toggle_custom_filter = wrap(actions.tree.modifiers.toggles.custom)
-Api.tree.toggle_hidden_filter = wrap(actions.tree.modifiers.toggles.dotfiles)
-Api.tree.toggle_no_bookmark_filter = wrap(actions.tree.modifiers.toggles.no_bookmark)
-Api.tree.toggle_help = wrap(help.toggle)
+Api.tree.toggle_gitignore_filter = expose_api("Filters", "Toggle Git Ignore",
+  wrap(actions.tree.modifiers.toggles.git_ignored))
+Api.tree.toggle_git_clean_filter = expose_api("Filters", "Toggle Git Clean",
+  wrap(actions.tree.modifiers.toggles.git_clean))
+Api.tree.toggle_no_buffer_filter = expose_api("Filters", "Toggle No Buffer",
+  wrap(actions.tree.modifiers.toggles.no_buffer))
+Api.tree.toggle_custom_filter = expose_api("Filters", "Toggle Custom", wrap(actions.tree.modifiers.toggles.custom))
+Api.tree.toggle_hidden_filter = expose_api("Filters", "Toggle Hidden", wrap(actions.tree.modifiers.toggles.dotfiles))
+Api.tree.toggle_no_bookmark_filter = expose_api("Filters", "Toggle No Bookmark",
+  wrap(actions.tree.modifiers.toggles.no_bookmark))
+Api.tree.toggle_help = expose_api("Misc", "Help", wrap(help.toggle))
 Api.tree.is_tree_buf = wrap(utils.is_nvim_tree_buf)
 
 ---@class ApiTreeIsVisibleOpts
@@ -148,23 +188,23 @@ Api.tree.is_visible = wrap(view.is_visible)
 
 Api.tree.winid = wrap(view.winid)
 
-Api.fs.create = wrap_node_or_nil(actions.fs.create_file.fn)
-Api.fs.remove = wrap_node(actions.fs.remove_file.fn)
-Api.fs.trash = wrap_node(actions.fs.trash.fn)
+Api.fs.create = expose_api("Files", "Create", wrap_node_or_nil(actions.fs.create_file.fn))
+Api.fs.remove = expose_api("Files", "Delete", wrap_node(actions.fs.remove_file.fn))
+Api.fs.trash = expose_api("Files", "Trash", wrap_node(actions.fs.trash.fn))
 Api.fs.rename_node = wrap_node(actions.fs.rename_file.fn ":t")
-Api.fs.rename = wrap_node(actions.fs.rename_file.fn ":t")
-Api.fs.rename_sub = wrap_node(actions.fs.rename_file.fn ":p:h")
-Api.fs.rename_basename = wrap_node(actions.fs.rename_file.fn ":t:r")
-Api.fs.rename_full = wrap_node(actions.fs.rename_file.fn ":p")
-Api.fs.cut = wrap_node(actions.fs.copy_paste.cut)
-Api.fs.paste = wrap_node(actions.fs.copy_paste.paste)
-Api.fs.clear_clipboard = wrap(actions.fs.copy_paste.clear_clipboard)
-Api.fs.print_clipboard = wrap(actions.fs.copy_paste.print_clipboard)
-Api.fs.copy.node = wrap_node(actions.fs.copy_paste.copy)
-Api.fs.copy.absolute_path = wrap_node(actions.fs.copy_paste.copy_absolute_path)
-Api.fs.copy.filename = wrap_node(actions.fs.copy_paste.copy_filename)
-Api.fs.copy.basename = wrap_node(actions.fs.copy_paste.copy_basename)
-Api.fs.copy.relative_path = wrap_node(actions.fs.copy_paste.copy_path)
+Api.fs.rename = expose_api("Files", "Rename", wrap_node(actions.fs.rename_file.fn ":t"))
+Api.fs.rename_sub = expose_api("Files", "Rename: Omit Files", wrap_node(actions.fs.rename_file.fn ":p:h"))
+Api.fs.rename_basename = expose_api("Files", "Rename: Basename", wrap_node(actions.fs.rename_file.fn ":t:r"))
+Api.fs.rename_full = expose_api("Files", "Rename: Full Path", wrap_node(actions.fs.rename_file.fn ":p"))
+Api.fs.cut = expose_api("Clipboard", "Cut", wrap_node(actions.fs.copy_paste.cut))
+Api.fs.paste = expose_api("Clipboard", "Paste", wrap_node(actions.fs.copy_paste.paste))
+Api.fs.clear_clipboard = expose_api("Clipboard", "Clear", wrap(actions.fs.copy_paste.clear_clipboard))
+Api.fs.print_clipboard = expose_api("Clipboard", "Print", wrap(actions.fs.copy_paste.print_clipboard))
+Api.fs.copy.node = expose_api("Clipboard", "Copy", wrap_node(actions.fs.copy_paste.copy))
+Api.fs.copy.absolute_path = expose_api("Path", "Copy Absolute Path", wrap_node(actions.fs.copy_paste.copy_absolute_path))
+Api.fs.copy.filename = expose_api("Path", "Copy Filename", wrap_node(actions.fs.copy_paste.copy_filename))
+Api.fs.copy.basename = expose_api("Path", "Copy Basename", wrap_node(actions.fs.copy_paste.copy_basename))
+Api.fs.copy.relative_path = expose_api("Path", "Copy Relative Path", wrap_node(actions.fs.copy_paste.copy_path))
 
 ---@param mode string
 ---@param node table
@@ -190,32 +230,35 @@ local function open_or_expand_or_dir_up(mode, toggle_group)
   end
 end
 
-Api.node.open.edit = wrap_node(open_or_expand_or_dir_up "edit")
+-- Api.node.open.edit = wrap_node(open_or_expand_or_dir_up "edit")
+Api.node.open.edit = expose_api("Files", "Open", wrap_node(open_or_expand_or_dir_up "edit"))
 Api.node.open.drop = wrap_node(open_or_expand_or_dir_up "drop")
 Api.node.open.tab_drop = wrap_node(open_or_expand_or_dir_up "tab_drop")
 Api.node.open.replace_tree_buffer = wrap_node(open_or_expand_or_dir_up "edit_in_place")
 Api.node.open.no_window_picker = wrap_node(open_or_expand_or_dir_up "edit_no_picker")
-Api.node.open.vertical = wrap_node(open_or_expand_or_dir_up "vsplit")
-Api.node.open.horizontal = wrap_node(open_or_expand_or_dir_up "split")
-Api.node.open.tab = wrap_node(open_or_expand_or_dir_up "tabnew")
+Api.node.open.vertical = expose_api("Files", "Open: Split V.", wrap_node(open_or_expand_or_dir_up "vsplit"))
+Api.node.open.horizontal = expose_api("Files", "Open: Split H.", wrap_node(open_or_expand_or_dir_up "split"))
+Api.node.open.tab = expose_api("Files", "Open: Tab", wrap_node(open_or_expand_or_dir_up "tabnew"))
 Api.node.open.toggle_group_empty = wrap_node(open_or_expand_or_dir_up("toggle_group_empty", true))
-Api.node.open.preview = wrap_node(open_or_expand_or_dir_up "preview")
+Api.node.open.preview = expose_api("Files", "Preview", wrap_node(open_or_expand_or_dir_up "preview"))
 Api.node.open.preview_no_picker = wrap_node(open_or_expand_or_dir_up "preview_no_picker")
 
-Api.node.show_info_popup = wrap_node(actions.node.file_popup.toggle_file_info)
-Api.node.run.cmd = wrap_node(actions.node.run_command.run_file_command)
-Api.node.run.system = wrap_node(actions.node.system_open.fn)
+Api.node.show_info_popup = expose_api("Files", "File Info", wrap_node(actions.node.file_popup.toggle_file_info))
+Api.node.run.cmd = expose_api("Misc", "Run Command", wrap_node(actions.node.run_command.run_file_command))
+Api.node.run.system = expose_api("Files", "Open: System", wrap_node(actions.node.system_open.fn))
 
-Api.node.navigate.sibling.next = wrap_node(actions.moves.sibling.fn "next")
-Api.node.navigate.sibling.prev = wrap_node(actions.moves.sibling.fn "prev")
-Api.node.navigate.sibling.first = wrap_node(actions.moves.sibling.fn "first")
-Api.node.navigate.sibling.last = wrap_node(actions.moves.sibling.fn "last")
-Api.node.navigate.parent = wrap_node(actions.moves.parent.fn(false))
-Api.node.navigate.parent_close = wrap_node(actions.moves.parent.fn(true))
-Api.node.navigate.git.next = wrap_node(actions.moves.item.fn { where = "next", what = "git" })
+Api.node.navigate.sibling.next = expose_api("Navigation", "Sibling: Next", wrap_node(actions.moves.sibling.fn "next"))
+Api.node.navigate.sibling.prev = expose_api("Navigation", "Sibling: Prev", wrap_node(actions.moves.sibling.fn "prev"))
+Api.node.navigate.sibling.first = expose_api("Navigation", "Sibling: First", wrap_node(actions.moves.sibling.fn "first"))
+Api.node.navigate.sibling.last = expose_api("Navigation", "Sibling: Last", wrap_node(actions.moves.sibling.fn "last"))
+Api.node.navigate.parent = expose_api("Navigation", "Parent Directory", wrap_node(actions.moves.parent.fn(false)))
+Api.node.navigate.parent_close = expose_api("Navigation", "Close Parent", wrap_node(actions.moves.parent.fn(true)))
+Api.node.navigate.git.next = expose_api("Navigation", "Git: Next",
+  (actions.moves.item.fn { where = "next", what = "git" }))
 Api.node.navigate.git.next_skip_gitignored = wrap_node(actions.moves.item.fn { where = "next", what = "git", skip_gitignored = true })
 Api.node.navigate.git.next_recursive = wrap_node(actions.moves.item.fn { where = "next", what = "git", recurse = true })
-Api.node.navigate.git.prev = wrap_node(actions.moves.item.fn { where = "prev", what = "git" })
+Api.node.navigate.git.prev = expose_api("Navigation", "Git: Previous",
+  wrap_node(actions.moves.item.fn { where = "prev", what = "git" }))
 Api.node.navigate.git.prev_skip_gitignored = wrap_node(actions.moves.item.fn { where = "prev", what = "git", skip_gitignored = true })
 Api.node.navigate.git.prev_recursive = wrap_node(actions.moves.item.fn { where = "prev", what = "git", recurse = true })
 Api.node.navigate.diagnostics.next = wrap_node(actions.moves.item.fn { where = "next", what = "diag" })
@@ -225,24 +268,24 @@ Api.node.navigate.diagnostics.prev_recursive = wrap_node(actions.moves.item.fn {
 Api.node.navigate.opened.next = wrap_node(actions.moves.item.fn { where = "next", what = "opened" })
 Api.node.navigate.opened.prev = wrap_node(actions.moves.item.fn { where = "prev", what = "opened" })
 
-Api.git.reload = wrap(actions.reloaders.reload_git)
+Api.git.reload = expose_api("View", "Reload Git", wrap(actions.reloaders.reload_git))
 
 Api.events.subscribe = events.subscribe
 Api.events.Event = events.Event
 
-Api.live_filter.start = wrap(live_filter.start_filtering)
-Api.live_filter.clear = wrap(live_filter.clear_filter)
+Api.live_filter.start = expose_api("Filters", "Live Filter: Start", wrap(live_filter.start_filtering))
+Api.live_filter.clear = expose_api("Filters", "Live Filter: Stop", wrap(live_filter.clear_filter))
 
 Api.marks.get = wrap_node(marks.get_mark)
-Api.marks.list = wrap(marks.get_marks)
-Api.marks.toggle = wrap_node(marks.toggle_mark)
-Api.marks.clear = wrap(marks.clear_marks)
-Api.marks.bulk.delete = wrap(marks_bulk_delete.bulk_delete)
-Api.marks.bulk.trash = wrap(marks_bulk_trash.bulk_trash)
-Api.marks.bulk.move = wrap(marks_bulk_move.bulk_move)
-Api.marks.navigate.next = wrap(marks_navigation.next)
-Api.marks.navigate.prev = wrap(marks_navigation.prev)
-Api.marks.navigate.select = wrap(marks_navigation.select)
+Api.marks.list = expose_api("Marks", "List", wrap(marks.get_marks))
+Api.marks.toggle = expose_api("Marks", "Toggle", wrap_node(marks.toggle_mark))
+Api.marks.clear = expose_api("Marks", "Clear", wrap(marks.clear_marks))
+Api.marks.bulk.delete = expose_api("Marks", "Marked: Delete", wrap(marks_bulk_delete.bulk_delete))
+Api.marks.bulk.trash = expose_api("Marks", "Marked: Trash", wrap(marks_bulk_trash.bulk_trash))
+Api.marks.bulk.move = expose_api("Marks", "Marked: Move", wrap(marks_bulk_move.bulk_move))
+Api.marks.navigate.next = expose_api("Marks", "Navigate To Next", wrap(marks_navigation.next))
+Api.marks.navigate.prev = expose_api("Marks", "Navigate To Prev", wrap(marks_navigation.prev))
+Api.marks.navigate.select = expose_api("Marks", "Select", wrap(marks_navigation.select))
 
 Api.config.mappings.get_keymap = wrap(keymap.get_keymap)
 Api.config.mappings.get_keymap_default = wrap(keymap.get_keymap_default)

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -369,6 +369,37 @@ function M.key_by(tbl, key)
   return keyed
 end
 
+function M.group_by(tbl, key)
+  local grouped = {}
+  for _, val in ipairs(tbl) do
+    if not grouped[val[key]] then
+      grouped[val[key]] = {}
+    end
+
+    table.insert(grouped[val[key]], val)
+  end
+  return grouped
+end
+
+function M.pad_end(str, width, fill_char)
+  fill_char = fill_char or " "
+
+  if #str >= width then
+    return str
+  end
+
+  return str .. string.rep(fill_char, width - #str)
+end
+
+-- Works like vim.tbl_flatten, but flattens one level only
+function M.flatten(tbl)
+  local result = {}
+  for _, value in ipairs(tbl) do
+    vim.list_extend(result, value)
+  end
+  return result
+end
+
 function M.bool_record(tbl, key)
   local keyed = {}
   for _, val in ipairs(tbl) do


### PR DESCRIPTION
Linking discussion https://github.com/nvim-tree/nvim-tree.lua/issues/2710

This is roughly what the help panel looks like. I didn't add all apis and I'd need some help here since I'm not aware of some functionality. 

<img width="686" alt="Screenshot 2024-03-15 at 21 42 59" src="https://github.com/nvim-tree/nvim-tree.lua/assets/6437409/4f263865-8a10-4bb8-a0fc-060cb137f4e4">


It shouldn't change drastically how users write `on_attach`. The only thing is that they don't need to pass eg. `nvim-tree: Open` in opts and it'll catch up if they use api.x.y function. If they pass a custom function as a keybinding, currently it'll not be displayed in help panel