### PR TITLE
fix(#2658): change SpellCap groups to reduce confusion: ExecFile->Question, ImageFile->Question, SpecialFile->Title, Symlink->Underlined; add all other highlight groups to :NvimTreeHiTest

### DIFF
--- a/lua/nvim-tree/appearance/diagnostics.lua
+++ b/lua/nvim-tree/appearance/diagnostics.lua
@@ -8,7 +8,7 @@ local M = {}
 ---@field def string :hi concrete definition after following any links
 local HighlightDisplay = {}
 
----@param group string nvim-tree highlight group
+---@param group string nvim-tree highlight group name
 ---@return HighlightDisplay
 function HighlightDisplay:new(group)
   local o = {}
@@ -39,38 +39,83 @@ function HighlightDisplay:new(group)
   return o
 end
 
+---Render one group.
+---@param bufnr number to render in
+---@param fmt string format string for group, links, def
+---@param l number line number to render at
+---@return number l next line number
 function HighlightDisplay:render(bufnr, fmt, l)
   local text = string.format(fmt, self.group, self.links, self.def)
 
   vim.api.nvim_buf_set_lines(bufnr, l, -1, true, { text })
   vim.api.nvim_buf_add_highlight(bufnr, -1, self.group, l, 0, #self.group)
+
+  return l + 1
 end
 
----Run a test similar to :so $VIMRUNTIME/syntax/hitest.vim
----Display all nvim-tree highlight groups, their link chain and actual definition
-function M.hi_test()
-  local displays = {}
+---Render many groups.
+---@param header string before with underline line
+---@param groups string[] highlight group names
+---@param bufnr number to render in
+---@param l number line number to start at
+---@return number l next line number
+local function render_groups(header, groups, bufnr, l)
   local max_group_len = 0
   local max_links_len = 0
 
-  -- build all highlight groups, name only
-  for _, highlight_group in ipairs(appearance.HIGHLIGHT_GROUPS) do
-    local display = HighlightDisplay:new(highlight_group.group)
+  ---@type HighlightDisplay[]
+  local displays = {}
+
+  -- build all highlight groups, using name only
+  for _, group in ipairs(groups) do
+    local display = HighlightDisplay:new(group)
     table.insert(displays, display)
     max_group_len = math.max(max_group_len, #display.group)
     max_links_len = math.max(max_links_len, #display.links)
   end
 
+  -- header
+  vim.api.nvim_buf_set_lines(bufnr, l, -1, true, { header, (header:gsub(".", "-")) })
+  l = l + 2
+
+  -- render and highlight
+  local fmt = string.format("%%-%d.%ds %%-%d.%ds %%s", max_group_len, max_group_len, max_links_len, max_links_len)
+  for _, display in ipairs(displays) do
+    l = display:render(bufnr, fmt, l)
+  end
+
+  return l
+end
+
+---Run a test similar to :so $VIMRUNTIME/syntax/hitest.vim
+---Display all nvim-tree and neovim highlight groups, their link chain and actual definition
+function M.hi_test()
   -- create a buffer
   local bufnr = vim.api.nvim_create_buf(false, true)
 
-  -- render and highlight
   local l = 0
-  local fmt = string.format("%%-%d.%ds %%-%d.%ds %%s", max_group_len, max_group_len, max_links_len, max_links_len)
-  for _, display in ipairs(displays) do
-    display:render(bufnr, fmt, l)
-    l = l + 1
+
+  -- nvim-tree groups, ordered
+  local groups = {}
+  for _, highlight_group in ipairs(appearance.HIGHLIGHT_GROUPS) do
+    table.insert(groups, highlight_group.group)
   end
+  l = render_groups("nvim-tree", groups, bufnr, l)
+
+  vim.api.nvim_buf_set_lines(bufnr, l, -1, true, { "" })
+  l = l + 1
+
+  -- built in groups, ordered opaquely by nvim
+  groups = {}
+  local ok, out = pcall(vim.api.nvim_cmd, { cmd = "highlight" }, { output = true })
+  if ok then
+    for group in string.gmatch(out, "(%w*)%s+xxx") do
+      if group:find("NvimTree", 1, true) ~= 1 then
+        table.insert(groups, group)
+      end
+    end
+  end
+  l = render_groups("neovim", groups, bufnr, l)
 
   -- finalise and focus the buffer
   vim.api.nvim_buf_set_option(bufnr, "modifiable", false)

--- a/lua/nvim-tree/appearance/diagnostics.lua
+++ b/lua/nvim-tree/appearance/diagnostics.lua
@@ -126,7 +126,7 @@ function M.hi_test()
   l = l + 1
 
   -- long
-  l = render_displays("other, long", displays_long, bufnr, l)
+  render_displays("other, long", displays_long, bufnr, l)
 
   -- finalise and focus the buffer
   vim.api.nvim_buf_set_option(bufnr, "modifiable", false)

--- a/lua/nvim-tree/appearance/init.lua
+++ b/lua/nvim-tree/appearance/init.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+---@class HighlightGroup
+---@field group string
+---@field link string|nil
+---@field def string|nil
+
+---@type HighlightGroup[]
 -- All highlight groups: linked or directly defined.
 -- Please add new groups to help and preserve order.
 -- Please avoid directly defined groups to preserve accessibility for TUI.

--- a/lua/nvim-tree/appearance/init.lua
+++ b/lua/nvim-tree/appearance/init.lua
@@ -30,10 +30,10 @@ M.HIGHLIGHT_GROUPS = {
   { group = "NvimTreeStatusLineNC", link = "StatusLineNC" },
 
   -- File Text
-  { group = "NvimTreeExecFile", link = "SpellCap" },
-  { group = "NvimTreeImageFile", link = "SpellCap" },
-  { group = "NvimTreeSpecialFile", link = "SpellCap" },
-  { group = "NvimTreeSymlink", link = "SpellCap" },
+  { group = "NvimTreeExecFile", link = "Question" },
+  { group = "NvimTreeImageFile", link = "Question" },
+  { group = "NvimTreeSpecialFile", link = "Title" },
+  { group = "NvimTreeSymlink", link = "Underlined" },
 
   -- Folder Text
   { group = "NvimTreeRootFolder", link = "Title" },


### PR DESCRIPTION
fixes #2658 