### PR TITLE
fix(#2535): TextYankPost event sends vim.v.event

### DIFF
--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -279,17 +279,17 @@ local function copy_to_clipboard(content)
   local reg
   if M.config.actions.use_system_clipboard == true then
     clipboard_name = "system"
-    reg = '+'
+    reg = "+"
   else
     clipboard_name = "neovim"
-    reg = '1'
+    reg = "1"
   end
 
   -- manually firing TextYankPost does not set vim.v.event
   -- workaround: create a scratch buffer with the clipboard contents and send a yank command
   local temp_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_text(temp_buf, 0, 0, 0, 0, { content })
-  vim.api.nvim_buf_call(temp_buf, function ()
+  vim.api.nvim_buf_call(temp_buf, function()
     vim.cmd(string.format('normal! "%sy$', reg))
   end)
   vim.api.nvim_buf_delete(temp_buf, {})

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -285,6 +285,8 @@ local function copy_to_clipboard(content)
     reg = '1'
   end
 
+  -- manually firing TextYankPost does not set vim.v.event
+  -- workaround: create a scratch buffer with the clipboard contents and send a yank command
   local temp_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_text(temp_buf, 0, 0, 0, 0, { content })
   vim.api.nvim_buf_call(temp_buf, function ()

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -290,7 +290,7 @@ local function copy_to_clipboard(content)
   local temp_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_text(temp_buf, 0, 0, 0, 0, { content })
   vim.api.nvim_buf_call(temp_buf, function ()
-    vim.cmd(string.format('normal! "%dy$', reg))
+    vim.cmd(string.format('normal! "%sy$', reg))
   end)
   vim.api.nvim_buf_delete(temp_buf, {})
 

--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -276,17 +276,22 @@ end
 ---@param content string
 local function copy_to_clipboard(content)
   local clipboard_name
+  local reg
   if M.config.actions.use_system_clipboard == true then
-    vim.fn.setreg("+", content)
-    vim.fn.setreg('"', content)
     clipboard_name = "system"
+    reg = '+'
   else
-    vim.fn.setreg('"', content)
-    vim.fn.setreg("1", content)
     clipboard_name = "neovim"
+    reg = '1'
   end
 
-  vim.api.nvim_exec_autocmds("TextYankPost", {})
+  local temp_buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_text(temp_buf, 0, 0, 0, 0, { content })
+  vim.api.nvim_buf_call(temp_buf, function ()
+    vim.cmd(string.format('normal! "%dy$', reg))
+  end)
+  vim.api.nvim_buf_delete(temp_buf, {})
+
   notify.info(string.format("Copied %s to %s clipboard!", content, clipboard_name))
 end
 


### PR DESCRIPTION
Try to fix issue https://github.com/nvim-tree/nvim-tree.lua/issues/2535#issuecomment-2028457412 that I also encountered.

I write the data to a temporary buffer and use vim 'y' command to do real yank to trigger TextYankPost event with correct v:event.