### PR TITLE
fix(#2774): add winfixbuf view option for nvim 0.10

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -572,6 +572,10 @@ function M.setup(opts)
   end
 
   M.View.initial_width = get_width()
+
+  if vim.fn.has("nvim-0.10") == 1 then
+    M.View.winopts.winfixbuf = true
+  end
 end
 
 return M


### PR DESCRIPTION
Hi @alex-courtis I've only added the option for the View class. Dunno if this is useful/needed elsewhere. Feel free to modify the PR as you deem fit.