### PR TITLE
ci: luarocks releases

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
   pull_request: # Will test luarocks installation on PR, without uploading
 jobs:

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -15,13 +15,23 @@ jobs:
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
-          summary: A file explorer tree for neovim written in lua
+          summary: A File Explorer For Neovim
           detailed_description: |
-            Customisable file tree explorer for neovim
+            Automatic updates
 
-            Git, LSP Diagnostics, Auto-Update, Live Filtering, File Icons
+            File type icons
 
-            ...and more
+            Git integration
+
+            Diagnostics integration - LSP and COC
+
+            (Live) filtering
+
+            Cut, copy, paste, rename, delete, create etc.
+
+            Highly customisable
+
+            Rich API
           license: "GPL-3.0"
           labels: neovim
           dependencies: |

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,29 +1,28 @@
-name: Push to Luarocks
+name: Release
 on:
   push:
     tags:
-      - '*'
-  release:
-    types:
-      - created
-    tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
-  pull_request: # Will test the luarocks installation on PR, without uploading
+  pull_request: # Will test luarocks installation on PR, without uploading
 jobs:
   luarocks-upload:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Required to count the commits
-      - name: Get Version
-        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
         uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
-          version: ${{ env.LUAROCKS_VERSION }}
+          summary: A file explorer tree for neovim written in lua
+          detailed_description: |
+            Customisable file tree explorer for neovim
+
+            Git, LSP Diagnostics, Auto-Update, Live Filtering, File Icons
+
+            ...and more
+          license: "GPL-3.0"
+          labels: neovim
           dependencies: |
             nvim-web-devicons

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
-  pull_request: # Will test luarocks installation on PR, without uploading
 jobs:
   luarocks-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,29 @@
+name: Push to Luarocks
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+    tags:
+      - '*'
+  workflow_dispatch:
+  pull_request: # Will test the luarocks installation on PR, without uploading
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            nvim-web-devicons


### PR DESCRIPTION
 Hey 👋
 
 ### Summary
 This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).
 
 See also:
 
 * [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
 * [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).
 
 With luarocks/rocks.nvim, it is [the plugin authors' responsibility to declare dependencies - not the user's](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#grey_question-why-rocksnvim). Installing this plugin is as simple as `:Rocks install nvim-tree.lua`.
 
 ### Things done:
 * Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.
 
 ### Notes:
 > [!IMPORTANT]
 > **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.
 
 * Tagged releases are installed locally and then published to luarocks.org.
   
   * If you push tags from a local checkout, the workflow is triggered automatically.
   * If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
 * Due to a shortcoming in LuaRocks ([label doesn't get picked up from rockspec luarocks/luarocks-site#188](https://github.com/luarocks/luarocks-site/issues/188)), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.
 
 See also [this guide](https://github.com/vhyrro/sample-luarocks-plugin).
