### PR TITLE
fix: nil access exception with git integration when changing branches

### DIFF
--- a/lua/nvim-tree/explorer/node.lua
+++ b/lua/nvim-tree/explorer/node.lua
@@ -29,7 +29,7 @@ end
 ---@param absolute_path string
 ---@return GitStatus
 local function get_git_status(parent_ignored, status, absolute_path)
-  local file_status = parent_ignored and "!!" or status.files and status.files[absolute_path]
+  local file_status = parent_ignored and "!!" or (status and status.files and status.files[absolute_path])
   return { file = file_status }
 end
 


### PR DESCRIPTION
This PR fixes an infrequent (once every couple days), but annoying, nil access exception.

Occasionally, when switching git branches, to where some open files no longer existed, nvim-tree would raise a nil access exception, which would disable git integration until nvim was restarted. The stack trace brought me to this line.

I made this change a few weeks ago and have stopped seeing the error entirely, with no other changes to my local config. Seemed like a small enough fix to just contribute without any further research, as it's helped me on my local setup! Though, if you would prefer to dig into a root cause of why `status` was being passed as nil here, I would not be offended 😄