### PR TITLE
refactor: replace deprecated use of vim.diagnostic.is_disabled() 

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,12 +39,14 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_disabled = false
-  if vim.fn.has "nvim-0.9" == 1 then
-    is_disabled = vim.diagnostic.is_disabled()
+  local is_enabled = false
+  if vim.fn.has "nvim-0.10" == 1 then
+    is_enabled = vim.diagnostic.is_enabled()
+  else
+    is_enabled = not vim.diagnostic.is_disabled()
   end
 
-  if not is_disabled then
+  if is_enabled then
     for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
       local buf = diagnostic.bufnr
       if vim.api.nvim_buf_is_valid(buf) then

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,7 +39,7 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_enabled = false
+  local is_enabled
   if vim.fn.has "nvim-0.10" == 1 then
     is_enabled = vim.diagnostic.is_enabled()
   else


### PR DESCRIPTION
According to [Neovims Release news](https://neovim.io/doc/user/deprecated.html) in the newly released v.0.10 `vim.diagnostic.is_disabled()` is deprecated in favor of `vim.diagnostic.is_enabled()`. 

I wasn't sure if there should be backwards compatibility left in for v0.9 or not. I'm not very solid with Lua, so I don't know if that `if/else` makes sense to 'solve' backwards compatibility. 