### PR TITLE
revert(#2781): "refactor: replace deprecated use of vim.diagnostic.is_disabled()"

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,14 +39,12 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_enabled
-  if vim.fn.has "nvim-0.10" == 1 then
-    is_enabled = vim.diagnostic.is_enabled()
-  else
-    is_enabled = not vim.diagnostic.is_disabled()
+  local is_disabled = false
+  if vim.fn.has "nvim-0.9" == 1 then
+    is_disabled = vim.diagnostic.is_disabled()
   end
 
-  if is_enabled then
+  if not is_disabled then
     for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
       local buf = diagnostic.bufnr
       if vim.api.nvim_buf_is_valid(buf) then


### PR DESCRIPTION
This reverts commit 4215f33da55cf93163c5f429ec6f73af86be08c2.

#2781 