### PR TITLE
chore(#2787): minimum nvim version 0.9, replace 0.10 deprecated, enable deprecated warnings

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -9,6 +9,7 @@
   },
   "diagnostics": {
     "libraryFiles": "Disable",
+    "globals": [],
     "neededFileStatus": {
       "ambiguity-1": "Any",
       "assign-type-mismatch": "Any",

--- a/.luarc.json
+++ b/.luarc.json
@@ -9,9 +9,6 @@
   },
   "diagnostics": {
     "libraryFiles": "Disable",
-    "severity": {
-      "deprecated": "Hint"
-    },
     "neededFileStatus": {
       "ambiguity-1": "Any",
       "assign-type-mismatch": "Any",

--- a/.luarc.json
+++ b/.luarc.json
@@ -23,7 +23,7 @@
       "code-after-break": "Any",
       "codestyle-check": "None",
       "count-down-loop": "Any",
-      "deprecated": "None",
+      "deprecated": "Any",
       "different-requires": "Any",
       "discard-returns": "Any",
       "doc-field-no-class": "Any",

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ style-doc:
 	scripts/doc-comments.sh
 
 luals:
-	scripts/luals-check.sh
+	@scripts/luals-check.sh
 
 #
 # fixes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Questions and general support: [Discussions](https://github.com/nvim-tree/nvim-t
 
 ## Requirements
 
-[neovim >=0.8.0](https://github.com/neovim/neovim/wiki/Installing-Neovim)
+[neovim >=0.9.0](https://github.com/neovim/neovim/wiki/Installing-Neovim)
 
 [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) is optional and used to display file icons. It requires a [patched font](https://www.nerdfonts.com/). Your terminal emulator must be configured to use that font, usually "Hack Nerd Font"
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -103,7 +103,7 @@ Git Integration
 
 Requirements
 
-    This file explorer requires `neovim >= 0.8.0`
+    This file explorer requires `neovim >= 0.9.0`
 
 ==============================================================================
  2. QUICKSTART                                          *nvim-tree-quickstart*
@@ -832,7 +832,6 @@ Use nvim-tree in a floating window.
 
 Highlight precedence, additive:
   git < opened < modified < bookmarked < diagnostics < copied < cut
-Neovim <= 0.8 will only show the highest.
 
 *nvim-tree.renderer.add_trailing*
 Appends a trailing slash to folder names.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -31,8 +31,7 @@ function M.change_root(path, bufnr)
     if vim.fn.has "nvim-0.10" == 1 then
       ft = vim.api.nvim_get_option_value("filetype", { buf = bufnr }) or ""
     else
-      ---@diagnostic disable-next-line: deprecated
-      ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
+      ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or "" ---@diagnostic disable-line: deprecated
     end
 
     for _, value in pairs(_config.update_focused_file.update_root.ignore_list) do
@@ -91,8 +90,7 @@ function M.tab_enter()
     if vim.fn.has "nvim-0.10" == 1 then
       ft = vim.api.nvim_get_option_value("filetype", { buf = 0 }) or ""
     else
-      ---@diagnostic disable-next-line: deprecated
-      ft = vim.api.nvim_buf_get_option(0, "ft")
+      ft = vim.api.nvim_buf_get_option(0, "ft") ---@diagnostic disable-line: deprecated
     end
 
     for _, filter in ipairs(M.config.tab.sync.ignore) do

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -26,7 +26,15 @@ local M = {
 function M.change_root(path, bufnr)
   -- skip if current file is in ignore_list
   if type(bufnr) == "number" then
-    local ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
+    local ft
+
+    if vim.fn.has "nvim-0.10" == 1 then
+      ft = vim.api.nvim_get_option_value("filetype", { buf = bufnr }) or ""
+    else
+      ---@diagnostic disable-next-line: deprecated
+      ft = vim.api.nvim_buf_get_option(bufnr, "filetype") or ""
+    end
+
     for _, value in pairs(_config.update_focused_file.update_root.ignore_list) do
       if utils.str_find(path, value) or utils.str_find(ft, value) then
         return
@@ -78,7 +86,15 @@ end
 function M.tab_enter()
   if view.is_visible { any_tabpage = true } then
     local bufname = vim.api.nvim_buf_get_name(0)
-    local ft = vim.api.nvim_buf_get_option(0, "ft")
+
+    local ft
+    if vim.fn.has "nvim-0.10" == 1 then
+      ft = vim.api.nvim_get_option_value("filetype", { buf = 0 }) or ""
+    else
+      ---@diagnostic disable-next-line: deprecated
+      ft = vim.api.nvim_buf_get_option(0, "ft")
+    end
+
     for _, filter in ipairs(M.config.tab.sync.ignore) do
       if bufname:match(filter) ~= nil or ft:match(filter) ~= nil then
         return

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -11,7 +11,6 @@ local core = require "nvim-tree.core"
 local git = require "nvim-tree.git"
 local filters = require "nvim-tree.explorer.filters"
 local buffers = require "nvim-tree.buffers"
-local events = require "nvim-tree.events"
 local notify = require "nvim-tree.notify"
 
 local _config = {}
@@ -335,21 +334,6 @@ local function setup_autocommands(opts)
           buffers.reload_modified()
           actions.reloaders.reload_explorer()
         end)
-      end,
-    })
-  end
-
-  -- TODO #1545 remove similar check from view.resize
-  if vim.fn.has "nvim-0.9" == 1 then
-    create_nvim_tree_autocmd("WinResized", {
-      callback = function()
-        if vim.v.event and vim.v.event.windows then
-          for _, winid in ipairs(vim.v.event.windows) do
-            if vim.api.nvim_win_is_valid(winid) and utils.is_nvim_tree_buf(vim.api.nvim_win_get_buf(winid)) then
-              events._dispatch_on_tree_resize(vim.api.nvim_win_get_width(winid))
-            end
-          end
-        end
       end,
     })
   end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -780,8 +780,8 @@ end
 
 ---@param conf table|nil
 function M.setup(conf)
-  if vim.fn.has "nvim-0.8" == 0 then
-    notify.warn "nvim-tree.lua requires Neovim 0.8 or higher"
+  if vim.fn.has "nvim-0.9" == 0 then
+    notify.warn "nvim-tree.lua requires Neovim 0.9 or higher"
     return
   end
 

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -85,9 +85,17 @@ function M.fn()
     end
     -- reset &path
     if path_existed then
-      vim.api.nvim_buf_set_option(bufnr, "path", path_opt)
+      if vim.fn.has "nvim-0.10" == 1 then
+        vim.api.nvim_set_option_value("path", path_opt, { buf = bufnr })
+      else
+        vim.api.nvim_buf_set_option(bufnr, "path", path_opt) ---@diagnostic disable-line: deprecated
+      end
     else
-      vim.api.nvim_buf_set_option(bufnr, "path", nil)
+      if vim.fn.has "nvim-0.10" == 1 then
+        vim.api.nvim_set_option_value("path", nil, { buf = bufnr })
+      else
+        vim.api.nvim_buf_set_option(bufnr, "path", nil) ---@diagnostic disable-line: deprecated
+      end
     end
 
     -- strip trailing slash

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -69,8 +69,15 @@ function M.fn()
 
   -- temporarily set &path
   local bufnr = vim.api.nvim_get_current_buf()
-  local path_existed, path_opt = pcall(vim.api.nvim_buf_get_option, bufnr, "path")
-  vim.api.nvim_buf_set_option(bufnr, "path", core.get_cwd() .. "/**")
+
+  local path_existed, path_opt
+  if vim.fn.has "nvim-0.10" == 1 then
+    path_existed, path_opt = pcall(vim.api.nvim_get_option_value, "path", { buf = bufnr })
+    vim.api.nvim_set_option_value("path", core.get_cwd() .. "/**", { buf = bufnr })
+  else
+    path_existed, path_opt = pcall(vim.api.nvim_buf_get_option, bufnr, "path") ---@diagnostic disable-line: deprecated
+    vim.api.nvim_buf_set_option(bufnr, "path", core.get_cwd() .. "/**") ---@diagnostic disable-line: deprecated
+  end
 
   vim.ui.input({ prompt = "Search: ", completion = "file_in_path" }, function(input_path)
     if not input_path or input_path == "" then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -116,8 +116,15 @@ local function pick_win_id()
   -- Setup UI
   for _, id in ipairs(selectable) do
     local char = M.window_picker.chars:sub(i, i)
-    local ok_status, statusline = pcall(vim.api.nvim_win_get_option, id, "statusline")
-    local ok_hl, winhl = pcall(vim.api.nvim_win_get_option, id, "winhl")
+
+    local ok_status, statusline, ok_hl, winhl
+    if vim.fn.has "nvim-0.10" == 1 then
+      ok_status, statusline = pcall(vim.api.nvim_get_option_value, "statusline", { win = id })
+      ok_hl, winhl = pcall(vim.api.nvim_get_option_value, "winhl", { win = id })
+    else
+      ok_status, statusline = pcall(vim.api.nvim_win_get_option, id, "statusline") ---@diagnostic disable-line: deprecated
+      ok_hl, winhl = pcall(vim.api.nvim_win_get_option, id, "winhl") ---@diagnostic disable-line: deprecated
+    end
 
     win_opts[id] = {
       statusline = ok_status and statusline or "",
@@ -125,8 +132,13 @@ local function pick_win_id()
     }
     win_map[char] = id
 
-    vim.api.nvim_win_set_option(id, "statusline", "%=" .. char .. "%=")
-    vim.api.nvim_win_set_option(id, "winhl", "StatusLine:NvimTreeWindowPicker,StatusLineNC:NvimTreeWindowPicker")
+    if vim.fn.has "nvim-0.10" == 1 then
+      vim.api.nvim_set_option_value("statusline", "%=" .. char .. "%=", { win = id })
+      vim.api.nvim_set_option_value("winhl", "StatusLine:NvimTreeWindowPicker,StatusLineNC:NvimTreeWindowPicker", { win = id })
+    else
+      vim.api.nvim_win_set_option(id, "statusline", "%=" .. char .. "%=") ---@diagnostic disable-line: deprecated
+      vim.api.nvim_win_set_option(id, "winhl", "StatusLine:NvimTreeWindowPicker,StatusLineNC:NvimTreeWindowPicker") ---@diagnostic disable-line: deprecated
+    end
 
     i = i + 1
     if i > #M.window_picker.chars then
@@ -145,14 +157,22 @@ local function pick_win_id()
   -- Restore window options
   for _, id in ipairs(selectable) do
     for opt, value in pairs(win_opts[id]) do
-      vim.api.nvim_win_set_option(id, opt, value)
+      if vim.fn.has "nvim-0.10" == 1 then
+        vim.api.nvim_set_option_value(opt, value, { win = id })
+      else
+        vim.api.nvim_win_set_option(id, opt, value) ---@diagnostic disable-line: deprecated
+      end
     end
   end
 
   if laststatus == 3 then
     for _, id in ipairs(not_selectable) do
       for opt, value in pairs(win_opts[id]) do
-        vim.api.nvim_win_set_option(id, opt, value)
+        if vim.fn.has "nvim-0.10" == 1 then
+          vim.api.nvim_set_option_value(opt, value, { win = id })
+        else
+          vim.api.nvim_win_set_option(id, opt, value) ---@diagnostic disable-line: deprecated
+        end
       end
     end
   end

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -26,7 +26,13 @@ local function usable_win_ids()
   return vim.tbl_filter(function(id)
     local bufid = vim.api.nvim_win_get_buf(id)
     for option, v in pairs(M.window_picker.exclude) do
-      local ok, option_value = pcall(vim.api.nvim_buf_get_option, bufid, option)
+      local ok, option_value
+      if vim.fn.has "nvim-0.10" == 1 then
+        ok, option_value = pcall(vim.api.nvim_get_option_value, option, { buf = bufid })
+      else
+        ok, option_value = pcall(vim.api.nvim_buf_get_option, bufid, option) ---@diagnostic disable-line: deprecated
+      end
+
       if ok and vim.tbl_contains(v, option_value) then
         return false
       end

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -258,7 +258,15 @@ local function open_in_new_window(filename, mode)
     -- If `hidden` is not enabled, check if buffer in target window is
     -- modified, and create new split if it is.
     local target_bufid = vim.api.nvim_win_get_buf(target_winid)
-    if vim.api.nvim_buf_get_option(target_bufid, "modified") then
+
+    local modified
+    if vim.fn.has "nvim-0.10" == 1 then
+      modified = vim.api.nvim_get_option_value("modified", { buf = target_bufid })
+    else
+      modified = vim.api.nvim_buf_get_option(target_bufid, "modified") ---@diagnostic disable-line: deprecated
+    end
+
+    if modified then
       if not mode:match "split$" then
         mode = "vsplit"
       end

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -89,8 +89,15 @@ local function pick_win_id()
 
   if laststatus == 3 then
     for _, win_id in ipairs(not_selectable) do
-      local ok_status, statusline = pcall(vim.api.nvim_win_get_option, win_id, "statusline")
-      local ok_hl, winhl = pcall(vim.api.nvim_win_get_option, win_id, "winhl")
+      local ok_status, statusline, ok_hl, winhl
+
+      if vim.fn.has "nvim-0.10" == 1 then
+        ok_status, statusline = pcall(vim.api.nvim_get_option_value, "statusline", { win = win_id })
+        ok_hl, winhl = pcall(vim.api.nvim_get_option_value, "winhl", { win = win_id })
+      else
+        ok_status, statusline = pcall(vim.api.nvim_win_get_option, win_id, "statusline") ---@diagnostic disable-line: deprecated
+        ok_hl, winhl = pcall(vim.api.nvim_win_get_option, win_id, "winhl") ---@diagnostic disable-line: deprecated
+      end
 
       win_opts[win_id] = {
         statusline = ok_status and statusline or "",
@@ -98,7 +105,11 @@ local function pick_win_id()
       }
 
       -- Clear statusline for windows not selectable
-      vim.api.nvim_win_set_option(win_id, "statusline", " ")
+      if vim.fn.has "nvim-0.10" == 1 then
+        vim.api.nvim_set_option_value("statusline", " ", { win = win_id })
+      else
+        vim.api.nvim_win_set_option(win_id, "statusline", " ") ---@diagnostic disable-line: deprecated
+      end
     end
   end
 

--- a/lua/nvim-tree/appearance/diagnostics.lua
+++ b/lua/nvim-tree/appearance/diagnostics.lua
@@ -129,7 +129,12 @@ function M.hi_test()
   render_displays("other, long", displays_long, bufnr, l)
 
   -- finalise and focus the buffer
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+  if vim.fn.has "nvim-0.10" == 1 then
+    vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  else
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", false) ---@diagnostic disable-line: deprecated
+  end
+
   vim.cmd.buffer(bufnr)
 end
 

--- a/lua/nvim-tree/appearance/init.lua
+++ b/lua/nvim-tree/appearance/init.lua
@@ -183,15 +183,8 @@ function M.setup()
 
   -- hard link override when legacy only is present
   for from, to in pairs(M.LEGACY_LINKS) do
-    local hl_from
-    local hl_to
-    if vim.fn.has "nvim-0.9" == 1 then
-      hl_from = vim.api.nvim_get_hl(0, { name = from })
-      hl_to = vim.api.nvim_get_hl(0, { name = to })
-    else
-      hl_from = vim.api.nvim__get_hl_defs(0)[from] or {}
-      hl_to = vim.api.nvim__get_hl_defs(0)[to] or {}
-    end
+    local hl_from = vim.api.nvim_get_hl(0, { name = from })
+    local hl_to = vim.api.nvim_get_hl(0, { name = to })
     if vim.tbl_isempty(hl_from) and not vim.tbl_isempty(hl_to) then
       vim.api.nvim_command("hi link " .. from .. " " .. to)
     end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,14 +39,15 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_disabled = false
-  if vim.fn.has "nvim-0.9" == 1 then
-    -- replacement is_enabled is not present in all 0.10 builds/releases, see #2781
-    -- wait until 0.11
-    is_disabled = vim.diagnostic.is_disabled() ---@diagnostic disable-line: deprecated
+  -- is_enabled is not present in all 0.10 builds/releases, see #2781
+  local is_enabled = false
+  if vim.fn.has "nvim-0.10" == 1 and type(vim.diagnostic.is_enabled) == "function" then
+    is_enabled = vim.diagnostic.is_enabled()
+  elseif type(vim.diagnostic.is_disabled) == "function" then ---@diagnostic disable-line: deprecated
+    is_enabled = not vim.diagnostic.is_disabled() ---@diagnostic disable-line: deprecated
   end
 
-  if not is_disabled then
+  if is_enabled then
     for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
       if diagnostic.severity and diagnostic.bufnr and vim.api.nvim_buf_is_valid(diagnostic.bufnr) then
         local bufname = uniformize_path(vim.api.nvim_buf_get_name(diagnostic.bufnr))

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -41,7 +41,9 @@ local function from_nvim_lsp()
 
   local is_disabled = false
   if vim.fn.has "nvim-0.9" == 1 then
-    is_disabled = vim.diagnostic.is_disabled()
+    -- replacement is_enabled is not present in all 0.10 builds/releases, see #2781
+    -- wait until 0.11
+    is_disabled = vim.diagnostic.is_disabled() ---@diagnostic disable-line: deprecated
   end
 
   if not is_disabled then

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,12 +39,14 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_disabled = false
-  if vim.fn.has "nvim-0.9" == 1 then
-    is_disabled = vim.diagnostic.is_disabled()
+  local is_enabled
+  if vim.fn.has "nvim-0.10" == 1 then
+    is_enabled = vim.diagnostic.is_enabled()
+  else
+    is_enabled = not vim.diagnostic.is_disabled() ---@diagnostic disable-line: deprecated
   end
 
-  if not is_disabled then
+  if is_enabled then
     for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
       if diagnostic.severity and diagnostic.bufnr and vim.api.nvim_buf_is_valid(diagnostic.bufnr) then
         local bufname = uniformize_path(vim.api.nvim_buf_get_name(diagnostic.bufnr))

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -39,14 +39,12 @@ end
 local function from_nvim_lsp()
   local buffer_severity = {}
 
-  local is_enabled
-  if vim.fn.has "nvim-0.10" == 1 then
-    is_enabled = vim.diagnostic.is_enabled()
-  else
-    is_enabled = not vim.diagnostic.is_disabled() ---@diagnostic disable-line: deprecated
+  local is_disabled = false
+  if vim.fn.has "nvim-0.9" == 1 then
+    is_disabled = vim.diagnostic.is_disabled()
   end
 
-  if is_enabled then
+  if not is_disabled then
     for _, diagnostic in ipairs(vim.diagnostic.get(nil, { severity = M.severity })) do
       if diagnostic.severity and diagnostic.bufnr and vim.api.nvim_buf_is_valid(diagnostic.bufnr) then
         local bufname = uniformize_path(vim.api.nvim_buf_get_name(diagnostic.bufnr))

--- a/lua/nvim-tree/help.lua
+++ b/lua/nvim-tree/help.lua
@@ -173,7 +173,13 @@ local function open()
 
   -- populate it
   vim.api.nvim_buf_set_lines(M.bufnr, 0, -1, false, lines)
-  vim.api.nvim_buf_set_option(M.bufnr, "modifiable", false)
+
+  if vim.fn.has "nvim-0.10" == 1 then
+    vim.api.nvim_set_option_value("modifiable", false, { buf = M.bufnr })
+  else
+    ---@diagnostic disable-next-line: deprecated
+    vim.api.nvim_buf_set_option(M.bufnr, "modifiable", false)
+  end
 
   -- highlight it
   for _, h in ipairs(hl) do

--- a/lua/nvim-tree/help.lua
+++ b/lua/nvim-tree/help.lua
@@ -177,8 +177,7 @@ local function open()
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", false, { buf = M.bufnr })
   else
-    ---@diagnostic disable-next-line: deprecated
-    vim.api.nvim_buf_set_option(M.bufnr, "modifiable", false)
+    vim.api.nvim_buf_set_option(M.bufnr, "modifiable", false) ---@diagnostic disable-line: deprecated
   end
 
   -- highlight it

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -85,8 +85,7 @@ function M.get_last_group_node(node)
     node = node.group_next
   end
 
-  ---@diagnostic disable-next-line: return-type-mismatch -- it can't be nil
-  return node
+  return node ---@diagnostic disable-line: return-type-mismatch -- it can't be nil
 end
 
 ---Group empty folders

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -198,8 +198,15 @@ end
 local function should_hijack_current_buf()
   local bufnr = vim.api.nvim_get_current_buf()
   local bufname = vim.api.nvim_buf_get_name(bufnr)
-  local bufmodified = vim.api.nvim_buf_get_option(bufnr, "modified")
-  local ft = vim.api.nvim_buf_get_option(bufnr, "ft")
+
+  local bufmodified, ft
+  if vim.fn.has "nvim-0.10" == 1 then
+    bufmodified = vim.api.nvim_get_option_value("modified", { buf = bufnr })
+    ft = vim.api.nvim_get_option_value("ft", { buf = bufnr })
+  else
+    bufmodified = vim.api.nvim_buf_get_option(bufnr, "modified") ---@diagnostic disable-line: deprecated
+    ft = vim.api.nvim_buf_get_option(bufnr, "ft") ---@diagnostic disable-line: deprecated
+  end
 
   local should_hijack_unnamed = M.hijack_unnamed_buffer_when_opening and bufname == "" and not bufmodified and ft == ""
   local should_hijack_dir = bufname ~= "" and vim.fn.isdirectory(bufname) == 1 and M.hijack_directories.enable

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -154,8 +154,7 @@ local function create_overlay()
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", true, { buf = overlay_bufnr })
   else
-    ---@diagnostic disable-next-line: deprecated
-    vim.api.nvim_buf_set_option(overlay_bufnr, "modifiable", true)
+    vim.api.nvim_buf_set_option(overlay_bufnr, "modifiable", true) ---@diagnostic disable-line: deprecated
   end
 
   vim.api.nvim_buf_set_lines(overlay_bufnr, 0, -1, false, { M.filter })

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -150,7 +150,14 @@ local function create_overlay()
     border = "none",
     style = "minimal",
   })
-  vim.api.nvim_buf_set_option(overlay_bufnr, "modifiable", true)
+
+  if vim.fn.has "nvim-0.10" == 1 then
+    vim.api.nvim_set_option_value("modifiable", true, { buf = overlay_bufnr })
+  else
+    ---@diagnostic disable-next-line: deprecated
+    vim.api.nvim_buf_set_option(overlay_bufnr, "modifiable", true)
+  end
+
   vim.api.nvim_buf_set_lines(overlay_bufnr, 0, -1, false, { M.filter })
   vim.cmd "startinsert"
   vim.api.nvim_win_set_cursor(overlay_winnr, { 1, #M.filter + 1 })

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -295,24 +295,16 @@ function Builder:add_highlights(node)
     table.insert(name_groups, name)
   end
 
-  -- one or many icon groups; <= 0.8 always uses highest due to lack of a practical nvim_get_hl equivalent
+  -- one or many icon groups
   if #icon_groups > 1 then
-    if vim.fn.has "nvim-0.9" == 1 then
-      icon_hl_group = self:create_combined_group(icon_groups)
-    else
-      icon_hl_group = icon_groups[#icon_groups]
-    end
+    icon_hl_group = self:create_combined_group(icon_groups)
   else
     icon_hl_group = icon_groups[1]
   end
 
-  -- one or many name groups; <= 0.8 always uses highest due to lack of a practical nvim_get_hl equivalent
+  -- one or many name groups
   if #name_groups > 1 then
-    if vim.fn.has "nvim-0.9" == 1 then
-      name_hl_group = self:create_combined_group(name_groups)
-    else
-      name_hl_group = name_groups[#name_groups]
-    end
+    name_hl_group = self:create_combined_group(name_groups)
   else
     name_hl_group = name_groups[1]
   end

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -22,8 +22,7 @@ local function _draw(bufnr, lines, hl_args, signs)
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
   else
-    ---@diagnostic disable-next-line: deprecated
-    vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", true) ---@diagnostic disable-line: deprecated
   end
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
@@ -32,8 +31,7 @@ local function _draw(bufnr, lines, hl_args, signs)
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
   else
-    ---@diagnostic disable-next-line: deprecated
-    vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", false) ---@diagnostic disable-line: deprecated
   end
 
   vim.fn.sign_unplace(SIGN_GROUP)

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -19,10 +19,23 @@ local namespace_id = vim.api.nvim_create_namespace "NvimTreeHighlights"
 ---@param hl_args AddHighlightArgs[]
 ---@param signs string[]
 local function _draw(bufnr, lines, hl_args, signs)
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+  if vim.fn.has "nvim-0.10" == 1 then
+    vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+  else
+    ---@diagnostic disable-next-line: deprecated
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+  end
+
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   M.render_hl(bufnr, hl_args)
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+
+  if vim.fn.has "nvim-0.10" == 1 then
+    vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  else
+    ---@diagnostic disable-next-line: deprecated
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+  end
+
   vim.fn.sign_unplace(SIGN_GROUP)
   for i, sign_name in pairs(signs) do
     vim.fn.sign_place(0, SIGN_GROUP, sign_name, bufnr, { lnum = i + 1 })

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -226,7 +226,14 @@ function M.rename_loaded_buffers(old_path, new_path)
         vim.api.nvim_buf_set_name(buf, new_path .. buf_name:sub(#old_path + 1))
         -- to avoid the 'overwrite existing file' error message on write for
         -- normal files
-        if vim.api.nvim_buf_get_option(buf, "buftype") == "" then
+        local buftype
+        if vim.fn.has "nvim-0.10" == 1 then
+          buftype = vim.api.nvim_get_option_value("buftype", { buf = buf })
+        else
+          buftype = vim.api.nvim_buf_get_option(buf, "buftype") ---@diagnostic disable-line: deprecated
+        end
+
+        if buftype == "" then
           vim.api.nvim_buf_call(buf, function()
             vim.cmd "silent! write!"
             vim.cmd "edit"

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -348,11 +348,7 @@ function M.resize(size)
   local new_size = get_width()
   vim.api.nvim_win_set_width(M.get_winnr() or 0, new_size)
 
-  -- TODO #1545 remove similar check from setup_autocommands
-  -- We let nvim handle sending resize events after 0.9
-  if vim.fn.has "nvim-0.9" == 0 then
-    events._dispatch_on_tree_resize(new_size)
-  end
+  events._dispatch_on_tree_resize(new_size)
 
   if not M.View.preserve_window_proportions then
     vim.cmd ":wincmd ="


### PR DESCRIPTION
fixes #2787 

- [ ] tag `compat-nvim-0.8`