### PR TITLE
feat: Allow to expand until certain condition is met

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1817,20 +1817,25 @@ tree.expand_all({opts})                      *nvim-tree-api.tree.expand_all()*
 
     Options: ~
       • {expand_until} (fun(expansion_count: integer, node: Node): boolean)
-        A function returning boolean that 
-        specifies terminating condition for node/tree expansion. If not
-        provided the function that expands recursively entire node/tree will be
-        used.
+
+            A function returning boolean that specifies terminating condition
+            for node/tree expansion. If not provided the function that expands
+            recursively entire node/tree will be used.
+
         Example: >
-
-        -- expand only 5 levels deep
-        local function my_expand(expansion_count, node)
-          local should_halt = expansion_count >= 5
-          return not should_halt
-        end
-
-        -- on_attach
-        vim.keymap.set('n', 'Z', api.tree.expand_all(node, { expand_until = my_expand }))
+          -- expand only 5 levels deep
+          local function my_expand_until(expansion_count, node)
+            print("my_expand_until " .. expansion_count .. " " .. tostring(node and node.absolute_path))
+            local should_halt = expansion_count >= 5
+            return not should_halt
+          end
+  
+          local function my_expand_all()
+            api.tree.expand_all(nil, { expand_until = my_expand_until })
+          end
+  
+          -- on_attach
+          vim.keymap.set("n", "Z", my_expand_all, opts("My Expand All"))
 <
                                   *nvim-tree-api.tree.toggle_enable_filters()*
 tree.toggle_enable_filters()

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1816,7 +1816,8 @@ tree.expand_all({opts})                      *nvim-tree-api.tree.expand_all()*
       • {opts} (table) optional parameters
 
     Options: ~
-      • {expand_until} (function) A function returning boolean that 
+      • {expand_until} (fun(expansion_count: integer, node: Node): boolean)
+        A function returning boolean that 
         specifies terminating condition for node/tree expansion. If not
         provided the function that expands recursively entire node/tree will be
         used.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1808,10 +1808,29 @@ tree.collapse_all({keep_buffers})          *nvim-tree-api.tree.collapse_all()*
     Parameters: ~
       • {keep_buffers} (boolean) do not collapse nodes with open buffers.
 
-tree.expand_all()                            *nvim-tree-api.tree.expand_all()*
+tree.expand_all({opts})                      *nvim-tree-api.tree.expand_all()*
     Recursively expand all nodes in the tree.
     Folder: only the nodes underneath that folder.
 
+    Parameters: ~
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {expand_until} (function) A function returning boolean that 
+        specifies terminating condition for node/tree expansion. If not
+        provided the function that expands recursively entire node/tree will be
+        used.
+        Example: >
+
+        -- expand only 5 levels deep
+        local function my_expand(expansion_count, node)
+          local should_halt = expansion_count >= 5
+          return not should_halt
+        end
+
+        -- on_attach
+        vim.keymap.set('n', 'Z', api.tree.expand_all(node, { expand_until = my_expand }))
+<
                                   *nvim-tree-api.tree.toggle_enable_filters()*
 tree.toggle_enable_filters()
     Toggle |nvim-tree.filters.enable| all filters.

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -39,8 +39,7 @@ end
 local function expand_until_max_or_empty(expansion_count, node)
   local should_halt = expansion_count >= M.MAX_FOLDER_DISCOVERY
   local should_exclude = M.EXCLUDE[node.name]
-  local result = not should_halt and node.nodes and not node.open and not should_exclude
-  return result
+  return not should_halt and node.nodes and not node.open and not should_exclude
 end
 
 local function gen_iterator(should_expand_fn)
@@ -74,8 +73,9 @@ local function gen_iterator(should_expand_fn)
 end
 
 ---@param base_node table
-function M.fn(base_node, expand_until)
-  expand_until = expand_until or expand_until_max_or_empty
+---@param expand_opts ApiTreeExpandAllOpts|nil
+function M.fn(base_node, expand_opts)
+  local expand_until = (expand_opts and expand_opts.expand_until) or expand_until_max_or_empty
   local node = base_node.nodes and base_node or core.get_explorer()
   if gen_iterator(expand_until)(node) then
     notify.warn("expansion iteration was halted after " .. M.MAX_FOLDER_DISCOVERY .. " discovered folders")

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -27,12 +27,12 @@ local function populate_node(node)
   local cwd = node.link_to or node.absolute_path
   local handle = vim.loop.fs_scandir(cwd)
   if not handle then
-      return
+    return
   end
   local status = git.load_project_status(cwd)
 
   if #node.nodes == 0 then
-      core.get_explorer():expand(node, status)
+    core.get_explorer():expand(node, status)
   end
 end
 

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -40,10 +40,6 @@ local function gen_iterator(should_expand_fn)
   local expansion_count = 0
 
   return function(parent)
-    -- if parent.parent and parent.nodes and not parent.open then
-    --   expansion_count = expansion_count + 1
-    --   expand(parent)
-    -- end
     expand(parent)
 
     Iterator.builder({parent})
@@ -55,14 +51,8 @@ local function gen_iterator(should_expand_fn)
           expansion_count = expansion_count + 1
           expand(node)
         end
-        -- print("iterator " .. node.name  .. " " .. vim.inspect(should_expand))
       end)
       :recursor(function(node)
-        -- print(vim.inspect(expansion_count < M.MAX_FOLDER_DISCOVERY))
-        -- print(vim.inspect(node.group_next and { node.group_next }))
-        -- print(vim.inspect((node.open and node.nodes)))
-
-        -- print("recursor " .. node.name .. " " .. vim.inspect(expansion_count < M.MAX_FOLDER_DISCOVERY and (node.group_next and { node.group_next } or (node.open and node.nodes))))
         return expansion_count < M.MAX_FOLDER_DISCOVERY and (node.group_next and { node.group_next } or (node.open and node.nodes))
       end)
       :iterate()

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -24,14 +24,13 @@ local function populate_node(node)
   if node.nodes == nil then
     return
   end
-  local cwd = node.link_to or node.absolute_path
-  local handle = vim.loop.fs_scandir(cwd)
-  if not handle then
-    return
-  end
-  local status = git.load_project_status(cwd)
-
   if #node.nodes == 0 then
+    local cwd = node.link_to or node.absolute_path
+    local handle = vim.loop.fs_scandir(cwd)
+    if not handle then
+      return
+    end
+    local status = git.load_project_status(cwd)
     core.get_explorer():expand(node, status)
   end
 end
@@ -51,6 +50,7 @@ local function gen_iterator(should_expand_fn)
   local expansion_count = 0
 
   return function(parent)
+    populate_node(parent)
     parent.open = true
 
     Iterator.builder({ parent })
@@ -60,6 +60,7 @@ local function gen_iterator(should_expand_fn)
         should_expand_fn = should_expand_next_fn
         if should_expand then
           expansion_count = expansion_count + 1
+          populate_node(node)
           node = lib.get_last_group_node(node)
           node.open = true
         end

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -39,12 +39,14 @@ end
 ---@param node Node
 ---@param populate_node function
 ---@return boolean, function
+-- luacheck: push ignore populate_node
 local function expand_until_max_or_empty(expansion_count, node, populate_node)
   local should_halt = expansion_count >= M.MAX_FOLDER_DISCOVERY
   local should_exclude = M.EXCLUDE[node.name]
   local result = not should_halt and node.nodes and not node.open and not should_exclude
   return result, expand_until_max_or_empty
 end
+-- luacheck: pop
 
 local function gen_iterator(should_expand_fn)
   local expansion_count = 0

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -44,19 +44,24 @@ end
 
 local function gen_iterator(should_expand)
   local expansion_count = 0
+  local function expand(node)
+    populate_node(node)
+    node = lib.get_last_group_node(node)
+    node.open = true
+  end
 
   return function(parent)
-    populate_node(parent)
-    parent.open = true
+    if parent.parent and parent.nodes and not parent.open then
+      expansion_count = expansion_count + 1
+      expand(parent)
+    end
 
-    Iterator.builder({ parent })
+    Iterator.builder(parent.nodes)
       :hidden()
       :applier(function(node)
         if should_expand(expansion_count, node, populate_node) then
           expansion_count = expansion_count + 1
-          populate_node(node)
-          node = lib.get_last_group_node(node)
-          node.open = true
+          expand(node)
         end
       end)
       :recursor(function(node)

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -3,7 +3,6 @@ local renderer = require "nvim-tree.renderer"
 local Iterator = require "nvim-tree.iterators.node-iterator"
 local notify = require "nvim-tree.notify"
 local lib = require "nvim-tree.lib"
-local git = require "nvim-tree.git"
 
 local M = {}
 
@@ -30,23 +29,19 @@ local function populate_node(node)
     if not handle then
       return
     end
-    local status = git.load_project_status(cwd)
-    core.get_explorer():expand(node, status)
+    core.get_explorer():expand(node)
   end
 end
 
 ---@param expansion_count integer
 ---@param node Node
----@param populate_node function
 ---@return boolean
--- luacheck: push ignore populate_node
-local function expand_until_max_or_empty(expansion_count, node, populate_node)
+local function expand_until_max_or_empty(expansion_count, node)
   local should_halt = expansion_count >= M.MAX_FOLDER_DISCOVERY
   local should_exclude = M.EXCLUDE[node.name]
   local result = not should_halt and node.nodes and not node.open and not should_exclude
   return result
 end
--- luacheck: pop
 
 local function gen_iterator(should_expand_fn)
   local expansion_count = 0

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -66,7 +66,7 @@ local function gen_iterator(should_expand)
       end)
       :recursor(function(node)
         local should_recurse = should_expand(expansion_count - 1, node, populate_node)
-        return expansion_count < M.MAX_FOLDER_DISCOVERY and (should_recurse and node.open and node.nodes)
+        return expansion_count < M.MAX_FOLDER_DISCOVERY and should_recurse and node.nodes
       end)
       :iterate()
 

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -40,12 +40,13 @@ local function gen_iterator(should_expand_fn)
   local expansion_count = 0
 
   return function(parent)
-    if parent.parent and parent.nodes and not parent.open then
-      expansion_count = expansion_count + 1
-      expand(parent)
-    end
+    -- if parent.parent and parent.nodes and not parent.open then
+    --   expansion_count = expansion_count + 1
+    --   expand(parent)
+    -- end
+    expand(parent)
 
-    Iterator.builder(parent.nodes)
+    Iterator.builder({parent})
       :hidden()
       :applier(function(node)
         local should_expand, should_expand_next_fn = should_expand_fn(expansion_count, node)
@@ -54,8 +55,14 @@ local function gen_iterator(should_expand_fn)
           expansion_count = expansion_count + 1
           expand(node)
         end
+        -- print("iterator " .. node.name  .. " " .. vim.inspect(should_expand))
       end)
       :recursor(function(node)
+        -- print(vim.inspect(expansion_count < M.MAX_FOLDER_DISCOVERY))
+        -- print(vim.inspect(node.group_next and { node.group_next }))
+        -- print(vim.inspect((node.open and node.nodes)))
+
+        -- print("recursor " .. node.name .. " " .. vim.inspect(expansion_count < M.MAX_FOLDER_DISCOVERY and (node.group_next and { node.group_next } or (node.open and node.nodes))))
         return expansion_count < M.MAX_FOLDER_DISCOVERY and (node.group_next and { node.group_next } or (node.open and node.nodes))
       end)
       :iterate()

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -29,13 +29,13 @@ end
 ---@param expansion_count integer
 ---@param node Node
 ---@return boolean
-local function should_expand(expansion_count, node)
+local function expand_until_max_or_empty(expansion_count, node)
   local should_halt = expansion_count >= M.MAX_FOLDER_DISCOVERY
   local should_exclude = M.EXCLUDE[node.name]
   return not should_halt and node.nodes and not node.open and not should_exclude
 end
 
-local function gen_iterator()
+local function gen_iterator(should_expand)
   local expansion_count = 0
 
   return function(parent)
@@ -64,9 +64,10 @@ local function gen_iterator()
 end
 
 ---@param base_node table
-function M.fn(base_node)
+function M.fn(base_node, expand_until)
+  expand_until = expand_until or expand_until_max_or_empty
   local node = base_node.nodes and base_node or core.get_explorer()
-  if gen_iterator()(node) then
+  if gen_iterator(expand_until)(node) then
     notify.warn("expansion iteration was halted after " .. M.MAX_FOLDER_DISCOVERY .. " discovered folders")
   end
   renderer.draw()

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -42,7 +42,7 @@ local function expand_until_max_or_empty(expansion_count, node)
   return not should_halt and node.nodes and not node.open and not should_exclude
 end
 
-local function gen_iterator(should_expand_fn)
+local function gen_iterator(should_expand)
   local expansion_count = 0
 
   return function(parent)
@@ -52,8 +52,7 @@ local function gen_iterator(should_expand_fn)
     Iterator.builder({ parent })
       :hidden()
       :applier(function(node)
-        local should_expand = should_expand_fn(expansion_count, node, populate_node)
-        if should_expand then
+        if should_expand(expansion_count, node, populate_node) then
           expansion_count = expansion_count + 1
           populate_node(node)
           node = lib.get_last_group_node(node)
@@ -61,7 +60,7 @@ local function gen_iterator(should_expand_fn)
         end
       end)
       :recursor(function(node)
-        local should_recurse = should_expand_fn(expansion_count - 1, node, populate_node)
+        local should_recurse = should_expand(expansion_count - 1, node, populate_node)
         return expansion_count < M.MAX_FOLDER_DISCOVERY and (should_recurse and node.open and node.nodes)
       end)
       :iterate()

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -42,7 +42,8 @@ local function expand_until_max_or_empty(expansion_count, node)
   return not should_halt and node.nodes and not node.open and not should_exclude
 end
 
-local function gen_iterator(should_expand)
+---@param expand_until fun(expansion_count: integer, node: Node): boolean
+local function gen_iterator(expand_until)
   local expansion_count = 0
   local function expand(node)
     populate_node(node)
@@ -59,13 +60,13 @@ local function gen_iterator(should_expand)
     Iterator.builder(parent.nodes)
       :hidden()
       :applier(function(node)
-        if should_expand(expansion_count, node, populate_node) then
+        if expand_until(expansion_count, node, populate_node) then
           expansion_count = expansion_count + 1
           expand(node)
         end
       end)
       :recursor(function(node)
-        local should_recurse = should_expand(expansion_count - 1, node, populate_node)
+        local should_recurse = expand_until(expansion_count - 1, node, populate_node)
         return expansion_count < M.MAX_FOLDER_DISCOVERY and should_recurse and node.nodes
       end)
       :iterate()

--- a/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
+++ b/lua/nvim-tree/actions/tree/modifiers/expand-all.lua
@@ -28,14 +28,15 @@ end
 
 ---@param expansion_count integer
 ---@param node Node
----@return boolean
+---@return boolean, function
 local function expand_until_max_or_empty(expansion_count, node)
   local should_halt = expansion_count >= M.MAX_FOLDER_DISCOVERY
   local should_exclude = M.EXCLUDE[node.name]
-  return not should_halt and node.nodes and not node.open and not should_exclude
+  local result = not should_halt and node.nodes and not node.open and not should_exclude
+  return result, expand_until_max_or_empty
 end
 
-local function gen_iterator(should_expand)
+local function gen_iterator(should_expand_fn)
   local expansion_count = 0
 
   return function(parent)
@@ -47,7 +48,9 @@ local function gen_iterator(should_expand)
     Iterator.builder(parent.nodes)
       :hidden()
       :applier(function(node)
-        if should_expand(expansion_count, node) then
+        local should_expand, should_expand_next_fn = should_expand_fn(expansion_count, node)
+        should_expand_fn = should_expand_next_fn
+        if should_expand then
           expansion_count = expansion_count + 1
           expand(node)
         end

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -144,7 +144,12 @@ Api.tree.get_nodes = wrap(lib.get_nodes)
 Api.tree.find_file = wrap(actions.tree.find_file.fn)
 Api.tree.search_node = wrap(actions.finders.search_node.fn)
 Api.tree.collapse_all = wrap(actions.tree.modifiers.collapse_all.fn)
+
+---@class ApiTreeExpandAllOpts
+---@field expand_until function|nil
+
 Api.tree.expand_all = wrap_node(actions.tree.modifiers.expand_all.fn)
+
 Api.tree.toggle_enable_filters = wrap(actions.tree.modifiers.toggles.enable)
 Api.tree.toggle_gitignore_filter = wrap(actions.tree.modifiers.toggles.git_ignored)
 Api.tree.toggle_git_clean_filter = wrap(actions.tree.modifiers.toggles.git_clean)

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -146,7 +146,7 @@ Api.tree.search_node = wrap(actions.finders.search_node.fn)
 Api.tree.collapse_all = wrap(actions.tree.modifiers.collapse_all.fn)
 
 ---@class ApiTreeExpandAllOpts
----@field expand_until function|nil
+---@field expand_until (fun(expansion_count: integer, node: Node): boolean)|nil
 
 Api.tree.expand_all = wrap_node(actions.tree.modifiers.expand_all.fn)
 

--- a/lua/nvim-tree/explorer/node.lua
+++ b/lua/nvim-tree/explorer/node.lua
@@ -36,7 +36,7 @@ end
 ---@param node Node
 ---@return boolean
 function M.has_one_child_folder(node)
-  return #node.nodes == 1 and node.nodes[1].nodes and vim.loop.fs_access(node.nodes[1].absolute_path, "R") or false
+  return node.nodes ~= nil and #node.nodes == 1 and node.nodes[1].nodes and vim.loop.fs_access(node.nodes[1].absolute_path, "R") or false
 end
 
 ---@param node Node


### PR DESCRIPTION
This is my attempt to solve #2789 

With this change I can now define the following mapping:
```lua
local function stop_expansion(_, node)
    return false, stop_expansion
end
local function expand_until_non_single(count, node)
    local cwd = node.link_to or node.absolute_path
    local handle = vim.loop.fs_scandir(cwd)
    if not handle then
        return false, stop_expansion
    end
    local status = git.load_project_status(cwd)
    populate_children(handle, cwd, node, status)
    local child_folder_only = explorer_node.has_one_child_folder(node) and node.nodes[1]
    if count > 1 and not child_folder_only then
        return true, stop_expansion
    elseif child_folder_only then
        return true, expand_until_non_single
    else
        return false, stop_expansion
    end
end
map('n', 'E', function()
    api.tree.expand_all(nil, expand_until_non_single)
end, opts("Expand until not single"))
```

This works as expected however it has some downsides:
1. the api is very flexible but at the same time quite complex. I had to do it in this way because the `expand_all` function will not expand the last directory. It stops as soon as `should_expand` returns `false` but I wanted the last directory to be expanded.
2. ~I had to copy `populate_children` method which is not a part of public api~ replaced with `explorer.explore(node, status)`

Btw if this got accepted in some form I am going to replace the default expand behavior in my config with this, since I find it so useful.
