### PR TITLE
feat(#2598): add api.tree.resize

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -3017,6 +3017,7 @@ highlight group is not, hard linking as follows: >
 |nvim-tree-api.tree.is_visible()|
 |nvim-tree-api.tree.open()|
 |nvim-tree-api.tree.reload()|
+|nvim-tree-api.tree.resize()|
 |nvim-tree-api.tree.search_node()|
 |nvim-tree-api.tree.toggle()|
 |nvim-tree-api.tree.toggle_custom_filter()|

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1658,6 +1658,22 @@ tree.focus()                                      *nvim-tree-api.tree.focus()*
 tree.reload()                                    *nvim-tree-api.tree.reload()*
     Refresh the tree. Does nothing if closed.
 
+tree.resize({opts})                              *nvim-tree-api.tree.resize()*
+    Resize the tree, persisting the new size.
+    Resets to |nvim-tree.view.width| when no {opts} provided.
+    See |:NvimTreeResize|
+
+    Parameters: ~
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {width}    (table)  new |nvim-tree.view.width| value
+      • {absolute} (number) set the width
+      • {relative} (number) increase or decrease the width
+
+    Only one option is supported, in the priority order above.
+    {absolute} and {relative} do nothing when {width} is a function.
+
 tree.change_root({path})                    *nvim-tree-api.tree.change_root()*
     Change the tree's root to a path.
 

--- a/lua/nvim-tree/actions/tree/init.lua
+++ b/lua/nvim-tree/actions/tree/init.lua
@@ -4,12 +4,14 @@ M.find_file = require "nvim-tree.actions.tree.find-file"
 M.modifiers = require "nvim-tree.actions.tree.modifiers"
 M.open = require "nvim-tree.actions.tree.open"
 M.toggle = require "nvim-tree.actions.tree.toggle"
+M.resize = require "nvim-tree.actions.tree.resize"
 
 function M.setup(opts)
   M.find_file.setup(opts)
   M.modifiers.setup(opts)
   M.open.setup(opts)
   M.toggle.setup(opts)
+  M.resize.setup(opts)
 end
 
 return M

--- a/lua/nvim-tree/actions/tree/resize.lua
+++ b/lua/nvim-tree/actions/tree/resize.lua
@@ -34,8 +34,12 @@ function M.fn(opts)
 
   local relative = options.relative
   if type(relative) == "number" then
-    local new_size = view.get_width() + relative
-    view.resize(new_size)
+    local relative_size = tostring(relative)
+    if relative > 0 then
+      relative_size = "+" .. relative_size
+    end
+
+    view.resize(relative_size)
     return
   end
 end

--- a/lua/nvim-tree/actions/tree/resize.lua
+++ b/lua/nvim-tree/actions/tree/resize.lua
@@ -1,0 +1,47 @@
+local view = require "nvim-tree.view"
+
+local M = {}
+
+---Resize the tree, persisting the new size.
+---@param opts ApiTreeResizeOpts|nil
+function M.fn(opts)
+  if opts == nil then
+    -- reset to config values
+    view.configure_width()
+    view.resize()
+    return
+  end
+
+  local options = opts or {}
+  local width_cfg = options.width
+
+  if width_cfg ~= nil then
+    view.configure_width(width_cfg)
+    view.resize()
+    return
+  end
+
+  if not view.is_width_determined() then
+    -- {absolute} and {relative} do nothing when {width} is a function.
+    return
+  end
+
+  local absolute = options.absolute
+  if type(absolute) == "number" then
+    view.resize(absolute)
+    return
+  end
+
+  local relative = options.relative
+  if type(relative) == "number" then
+    local new_size = view.get_width() + relative
+    view.resize(new_size)
+    return
+  end
+end
+
+function M.setup(opts)
+  M.config = opts or {}
+end
+
+return M

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -100,6 +100,13 @@ Api.tree.close_in_this_tab = wrap(view.close_this_tab_only)
 Api.tree.close_in_all_tabs = wrap(view.close_all_tabs)
 Api.tree.reload = wrap(actions.reloaders.reload_explorer)
 
+---@class ApiTreeResizeOpts
+---@field width string|function|number|table|nil
+---@field absolute number|nil
+---@field relative number|nil
+
+Api.tree.resize = wrap(actions.tree.resize.fn)
+
 Api.tree.change_root = wrap(function(...)
   require("nvim-tree").change_dir(...)
 end)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -548,6 +548,34 @@ function M.reset_winhl()
   end
 end
 
+---Check if width determined or calculated on-fly
+---@return boolean
+function M.is_width_determined()
+  return type(M.View.width) ~= "function"
+end
+
+---Configure width-related config
+---@param width string|function|number|table|nil
+function M.configure_width(width)
+  if type(width) == "table" then
+    M.View.adaptive_size = true
+    M.View.width = width.min or DEFAULT_MIN_WIDTH
+    M.View.max_width = width.max or DEFAULT_MAX_WIDTH
+    M.View.padding = width.padding or DEFAULT_PADDING
+  elseif width == nil then
+    if M.config.width ~= nil then
+      -- if we had input config - fallback to it
+      M.configure_width(M.config.width)
+    else
+      -- otherwise - restore initial width
+      M.View.width = M.View.initial_width
+    end
+  else
+    M.View.adaptive_size = false
+    M.View.width = width
+  end
+end
+
 function M.setup(opts)
   local options = opts.view or {}
   M.View.centralize_selection = options.centralize_selection
@@ -563,15 +591,8 @@ function M.setup(opts)
   M.View.float = options.float
   M.on_attach = opts.on_attach
 
-  if type(options.width) == "table" then
-    M.View.adaptive_size = true
-    M.View.width = options.width.min or DEFAULT_MIN_WIDTH
-    M.View.max_width = options.width.max or DEFAULT_MAX_WIDTH
-    M.View.padding = options.width.padding or DEFAULT_PADDING
-  else
-    M.View.adaptive_size = false
-    M.View.width = options.width
-  end
+  M.config = options
+  M.configure_width(options.width)
 
   M.View.initial_width = get_width()
 end


### PR DESCRIPTION
Resolved #2598 

## Testing environment

I slightly modified `useState` analogy to follow proposed API specification:
```lua
local resize = require("nvim-tree.api").tree.resize
local function use_nvim_tree_width(options)
	if type(options) ~= "table" then
		return
	end

	---@type number
	local offset = options.offset

	if type(offset) ~= "number" then
		offset = 10
	end

	---@type number|table
	local width = 30

	local function get_width()
		return width
	end

	local function increment_width()
		resize({ relative = offset }) -- <==== here
	end

	local function decrement_width()
		resize({ relative = -offset }) -- <==== here
	end

	local function dynamic_width()
		width = {}
		resize({ width = width }) -- <==== here
	end

	return get_width, increment_width, decrement_width, dynamic_width
end
```

Small showcase:
![ScreenRecording2024-06-24at13 13 30-ezgif com-video-to-gif-converter](https://github.com/nvim-tree/nvim-tree.lua/assets/34550675/179eb970-4706-413b-83ff-71787a5ddc27)

GIF explanation:
1. Increase
2. Increase
3. Increase
4. Decrease
5. Dynamic width
