### PR TITLE
fix(#2813): enable file renaming in `nvim-tree` with changed capitalization

### DIFF
--- a/lua/nvim-tree/actions/fs/rename-file.lua
+++ b/lua/nvim-tree/actions/fs/rename-file.lua
@@ -30,13 +30,21 @@ local function err_fmt(from, to, reason)
   return string.format("Cannot rename %s -> %s: %s", from, to, reason)
 end
 
+local function rename_file_exists(node, to)
+  if string.lower(node) == string.lower(to) then
+    return false
+  end
+
+  return utils.file_exists(to)
+end
+
 ---@param node Node
 ---@param to string
 function M.rename(node, to)
   local notify_from = notify.render_path(node.absolute_path)
   local notify_to = notify.render_path(to)
 
-  if utils.file_exists(to) then
+  if rename_file_exists(notify_from, notify_to) then
     notify.warn(err_fmt(notify_from, notify_to, "file already exists"))
     return
   end
@@ -65,7 +73,7 @@ function M.rename(node, to)
         notify.warn(err_fmt(notify_from, notify_to, err))
         return
       end
-    elseif not utils.file_exists(path_to_create) then
+    elseif not rename_file_exists(notify_from, path_to_create) then
       local success = vim.loop.fs_mkdir(path_to_create, 493)
       if not success then
         notify.error("Could not create folder " .. notify.render_path(path_to_create))


### PR DESCRIPTION
This PR fixes an issue in `nvim-tree` on macOS that prevented file renaming when only the capitalization of letters was changed. Now, `nvim-tree` allows renaming files regardless of changes in letter capitalization in the existing file name.