### PR TITLE
feat(#2349): add "right_align" option for renderer.icons.*_placement

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -974,25 +974,29 @@ Icon order and sign column precedence:
     *nvim-tree.renderer.icons.git_placement*
     Place where the git icons will be rendered.
     Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled).
+    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
+    `"right_align"` (requires |nvim_buf_set_extmark|).
       Type: `string`, Default: `"before"`
 
     *nvim-tree.renderer.icons.diagnostics_placement*
     Place where the diagnostics icon will be rendered.
     Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled).
+    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
+    `"right_align"` (requires |nvim_buf_set_extmark|).
       Type: `string`, Default: `"signcolumn"`
 
     *nvim-tree.renderer.icons.modified_placement*
     Place where the modified icon will be rendered.
     Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled).
+    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
+    `"right_align"` (requires |nvim_buf_set_extmark|).
       Type: `string`, Default: `"after"`
 
     *nvim-tree.renderer.icons.bookmarks_placement*
     Place where the bookmarks icon will be rendered.
     Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled).
+    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
+    `"right_align"` (requires |nvim_buf_set_extmark|).
       Type: `string`, Default: `signcolumn`
 
     *nvim-tree.renderer.icons.padding*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -944,6 +944,12 @@ Configuration options for icons.
 Icon order and sign column precedence:
   git < modified < bookmarked < diagnostics
 
+`renderer.icons.*_placement` options may be:
+- `"before"` : before file/folder, after the file/folders icons
+- `"after"` : after file/folder
+- `"signcolumn"` : far left, requires |nvim-tree.view.signcolumn| enabled
+- `"right_align"` : far right
+
     *nvim-tree.renderer.icons.web_devicons*
     Configure optional plugin `"nvim-tree/nvim-web-devicons"`
 
@@ -972,31 +978,19 @@ Icon order and sign column precedence:
               Type: `boolean`, Default: `true`
 
     *nvim-tree.renderer.icons.git_placement*
-    Place where the git icons will be rendered.
-    Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
-    `"right_align"` (requires |nvim_buf_set_extmark|).
+    Git icons placement.
       Type: `string`, Default: `"before"`
 
     *nvim-tree.renderer.icons.diagnostics_placement*
-    Place where the diagnostics icon will be rendered.
-    Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
-    `"right_align"` (requires |nvim_buf_set_extmark|).
+    Diganostic icon placement.
       Type: `string`, Default: `"signcolumn"`
 
     *nvim-tree.renderer.icons.modified_placement*
-    Place where the modified icon will be rendered.
-    Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
-    `"right_align"` (requires |nvim_buf_set_extmark|).
+    Modified icon placement.
       Type: `string`, Default: `"after"`
 
     *nvim-tree.renderer.icons.bookmarks_placement*
-    Place where the bookmarks icon will be rendered.
-    Can be `"after"` or `"before"` filename (after the file/folders icons)
-    or `"signcolumn"` (requires |nvim-tree.view.signcolumn| enabled) or
-    `"right_align"` (requires |nvim_buf_set_extmark|).
+    Bookmark icon placement.
       Type: `string`, Default: `signcolumn`
 
     *nvim-tree.renderer.icons.padding*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -672,10 +672,10 @@ local ACCEPTED_STRINGS = {
     highlight_diagnostics = { "none", "icon", "name", "all" },
     highlight_clipboard = { "none", "icon", "name", "all" },
     icons = {
-      git_placement = { "before", "after", "signcolumn" },
-      modified_placement = { "before", "after", "signcolumn" },
-      diagnostics_placement = { "before", "after", "signcolumn" },
-      bookmarks_placement = { "before", "after", "signcolumn" },
+      git_placement = { "before", "after", "signcolumn", "right_align" },
+      modified_placement = { "before", "after", "signcolumn", "right_align" },
+      diagnostics_placement = { "before", "after", "signcolumn", "right_align" },
+      bookmarks_placement = { "before", "after", "signcolumn", "right_align" },
     },
   },
   help = {

--- a/lua/nvim-tree/enum.lua
+++ b/lua/nvim-tree/enum.lua
@@ -16,6 +16,7 @@ M.ICON_PLACEMENT = {
   signcolumn = 1,
   before = 2,
   after = 3,
+  right_align = 4,
 }
 
 return M

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -60,6 +60,7 @@ function Builder:new()
     lines = {},
     markers = {},
     signs = {},
+    extmarks = {},
   }
   setmetatable(o, self)
   self.__index = self
@@ -226,6 +227,14 @@ function Builder:format_line(indent_markers, arrows, icon, name, node)
 
   for i = #M.decorators, 1, -1 do
     add_to_end(line, M.decorators[i]:icons_after(node))
+  end
+
+  local rights = {}
+  for i = #M.decorators, 1, -1 do
+    add_to_end(rights, M.decorators[i]:icons_right_align(node))
+  end
+  if #rights > 0 then
+    self.extmarks[self.index] = rights
   end
 
   return line

--- a/lua/nvim-tree/renderer/decorator/init.lua
+++ b/lua/nvim-tree/renderer/decorator/init.lua
@@ -74,6 +74,17 @@ function Decorator:icons_after(node)
   return self:calculate_icons(node)
 end
 
+---Icons when ICON_PLACEMENT.right_align
+---@param node Node
+---@return HighlightedString[]|nil icons
+function Decorator:icons_right_align(node)
+  if not self.enabled or self.icon_placement ~= ICON_PLACEMENT.right_align then
+    return
+  end
+
+  return self:calculate_icons(node)
+end
+
 ---Maybe icons, optionally implemented
 ---@protected
 ---@param _ Node

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -18,7 +18,7 @@ local namespace_id = vim.api.nvim_create_namespace "NvimTreeHighlights"
 ---@param lines string[]
 ---@param hl_args AddHighlightArgs[]
 ---@param signs string[]
-local function _draw(bufnr, lines, hl_args, signs)
+local function _draw(bufnr, lines, hl_args, signs, extmarks)
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
   else
@@ -37,6 +37,15 @@ local function _draw(bufnr, lines, hl_args, signs)
   vim.fn.sign_unplace(SIGN_GROUP)
   for i, sign_name in pairs(signs) do
     vim.fn.sign_place(0, SIGN_GROUP, sign_name, bufnr, { lnum = i + 1 })
+  end
+  for i, extname in pairs(extmarks) do
+    for _, mark in ipairs(extname) do
+      vim.api.nvim_buf_set_extmark(bufnr, namespace_id, i, -1, {
+        virt_text = { { mark.str, mark.hl } },
+        virt_text_pos = "right_align",
+        hl_mode = "combine",
+      })
+    end
   end
 end
 
@@ -67,7 +76,7 @@ function M.draw()
 
   local builder = Builder:new():build()
 
-  _draw(bufnr, builder.lines, builder.hl_args, builder.signs)
+  _draw(bufnr, builder.lines, builder.hl_args, builder.signs, builder.extmarks)
 
   if cursor and #builder.lines >= cursor[1] then
     vim.api.nvim_win_set_cursor(view.get_winnr() or 0, cursor)


### PR DESCRIPTION
Closes #2349

#### This PR augments options for icons placement allowing rendering of theses decorations on the far right using the ``right_align`` option from neovim ``ext_marks``

![image](https://github.com/user-attachments/assets/2b87fac3-4a4d-46ae-9f30-2c3ebf94dab5)

##  Setup for testing
```lua
require('nvim-tree').setup {
  renderer = {
    icons = {
      git_placement = 'right_align',
      modified_placement = 'right_align',
      diagnostics_placement = 'right_align',
      bookmarks_placement = 'right_align',
      padding = ' ',
      show = {
        file = true,
        folder = true,
        diagnostics = true,
        bookmarks = true,
        git = true,
        modified = true,
      },
    },
  },
}
```

If there's anything you'd like me to change about documentation or code, let me know, I'll do it.
