### PR TITLE
fix: change dir with explorer nodes unchanged

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -568,6 +568,7 @@ Following is the default configuration. See |nvim-tree-opts| for details.
           enable = true,
           global = false,
           restrict_above_cwd = false,
+          explorer_node_unchanged = false,
         },
         expand_all = {
           max_folder_discovery = 300,
@@ -1398,6 +1399,9 @@ vim |current-directory| behaviour.
     *nvim-tree.actions.change_dir.restrict_above_cwd*
     Restrict changing to a directory above the global cwd.
       Type: `boolean`, Default: `false`
+
+    *nvim-tree.actions.change_dir.explorer_node_unchanged*
+    Change dir with explorer nodes unchanged.
 
 *nvim-tree.actions.expand_all*
 Configuration for expand_all behaviour.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -532,6 +532,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       enable = true,
       global = false,
       restrict_above_cwd = false,
+      explorer_node_unchanged = false,
     },
     expand_all = {
       max_folder_discovery = 300,

--- a/lua/nvim-tree/actions/root/change-dir.lua
+++ b/lua/nvim-tree/actions/root/change-dir.lua
@@ -85,7 +85,11 @@ M.force_dirchange = add_profiling_to(function(foldername, should_open_view)
     if should_change_dir() then
       cd(M.options.global, foldername)
     end
-    core.init(foldername)
+    if M.options.explorer_node_unchanged then
+      core.change_root(foldername)
+    else
+      core.init(foldername)
+    end
   end
 
   if should_open_view then


### PR DESCRIPTION
# Situation
Every time I change the path in the explorer, the expanded folders in a certain directory will be reset. It's annoyning.
Here are some demonstration GIF images.

api: `api.tree.change_root_to_parent`
From path `~/tmp/t` to `~/tmp`
![](https://raw.githubusercontent.com/linepi/asset/master/toparent.gif)

api: `api.tree.change_root_to_node`
Enter folder `~/tmp/t`
![](https://raw.githubusercontent.com/linepi/asset/master/tochild.gif)

# Object
Change dir with explorer nodes unchanged.



