### PR TITLE
feat(show_file_size): optionally show Size Information on right column

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -442,6 +442,13 @@ Following is the default configuration. See |nvim-tree-opts| for details.
             none = " ",
           },
         },
+        size = {
+          enable = false,
+          column_width = 12,
+          show_folder_size = false,
+          format_unit = "double",
+          noshow_folder_size_glyph = "•",
+        },
         icons = {
           web_devicons = {
             file = {
@@ -513,12 +520,6 @@ Following is the default configuration. See |nvim-tree-opts| for details.
       system_open = {
         cmd = "",
         args = {},
-      },
-      size = {
-        enable = true,
-        column_width = 12,
-        show_folder_size = false,
-        format_unit = "double",
       },
       git = {
         enable = true,
@@ -847,7 +848,7 @@ Use nvim-tree in a floating window.
  5.3 OPTS: RENDERER                                  *nvim-tree-opts-renderer*
 
 Highlight precedence, additive:
-  git < opened < modified < bookmarked < diagnostics < copied < cut
+  git < opened < modified < bookmarked < diagnostics < copied < cut < size
 
 *nvim-tree.renderer.add_trailing*
 Appends a trailing slash to folder names.
@@ -955,6 +956,37 @@ Configuration options for tree indent markers.
           none = " ",
         }
 <
+*nvim-tree.renderer.size*
+Configuration for file size display column
+
+    *nvim-tree.renderer.size.enable*
+    Determine if we should render file size information.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.renderer.size.column_width*
+    Determines the amount of space (in characters) the
+    file size information will take.
+      Type: `integer`, Default: `12`
+
+    *nvim-tree.renderer.size.show_folder_size*
+    Whether to show the size for folder as well.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.renderer.size.format_unit*
+    Determines how format unit is displayed.
+    If a string is passed we have the options:
+    - `"single"` : Show only 1 character for unit. Ex: for 10.4 Megabytes we render "10.4M"
+    - `"double"` : Show only 2 character for unit and add a space in between. Ex: "10.4 MB"
+
+    If more controle we needed, such as lowercase unit, a function can be
+    passed by the user that takes one of the possible units as string.
+    units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" }
+      Type: `string | fun(unit: string): string`, Default: `"double"`
+
+    *nvim-tree.renderer.size.noshow_folder_size_glyph*
+    Glyph to be shown when `nvim-tree.renderer.size.show_folder_size` is disabled.
+      Type: `string`, Default: `"•"`
+
 *nvim-tree.renderer.icons*
 Configuration options for icons.
 
@@ -2922,6 +2954,12 @@ highlight group is not, hard linking as follows: >
 |nvim-tree.renderer.indent_markers.inline_arrows|
 |nvim-tree.renderer.indent_width|
 |nvim-tree.renderer.root_folder_label|
+|nvim-tree.renderer.size|
+|nvim-tree.renderer.size.column_width|
+|nvim-tree.renderer.size.enable|
+|nvim-tree.renderer.size.format_unit|
+|nvim-tree.renderer.size.noshow_folder_size_glyph|
+|nvim-tree.renderer.size.show_folder_size|
 |nvim-tree.renderer.special_files|
 |nvim-tree.renderer.symlink_destination|
 |nvim-tree.respect_buf_cwd|

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -444,7 +444,8 @@ Following is the default configuration. See |nvim-tree-opts| for details.
         },
         size = {
           enable = false,
-          column_width = 12,
+          width_cutoff = 18,
+          column_width = 10,
           show_folder_size = false,
           format_unit = "double",
           noshow_folder_size_glyph = "•",
@@ -963,10 +964,16 @@ Configuration for file size display column
     Determine if we should render file size information.
       Type: `boolean`, Default: `false`
 
+    *nvim-tree.renderer.size.width_cutoff*
+    Whenever nvim-tree window has less width than this cutoff the
+    size information is hidden. If it goes back to having bigger width
+    then the cutoff, the information is shown again.
+      Type: `integer`, Default: `18`
+
     *nvim-tree.renderer.size.column_width*
     Determines the amount of space (in characters) the
     file size information will take.
-      Type: `integer`, Default: `12`
+      Type: `integer`, Default: `10`
 
     *nvim-tree.renderer.size.show_folder_size*
     Whether to show the size for folder as well.
@@ -2960,6 +2967,7 @@ highlight group is not, hard linking as follows: >
 |nvim-tree.renderer.size.format_unit|
 |nvim-tree.renderer.size.noshow_folder_size_glyph|
 |nvim-tree.renderer.size.show_folder_size|
+|nvim-tree.renderer.size.width_cutoff|
 |nvim-tree.renderer.special_files|
 |nvim-tree.renderer.symlink_destination|
 |nvim-tree.respect_buf_cwd|

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -514,6 +514,12 @@ Following is the default configuration. See |nvim-tree-opts| for details.
         cmd = "",
         args = {},
       },
+      size = {
+        enable = true,
+        column_width = 12,
+        show_folder_size = false,
+        format_unit = "double",
+      },
       git = {
         enable = true,
         show_on_dirs = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -338,6 +338,19 @@ local function setup_autocommands(opts)
     })
   end
 
+  if opts.renderer.size.enable then
+    create_nvim_tree_autocmd({ "WinResized", "VimResized" }, {
+      -- NOTE: for some reason WinResized doesn't work with pattern
+      -- I don't really know why
+      -- pattern = "NvimTree_*",
+      callback = function(event)
+        if view.is_visible() and utils.is_nvim_tree_buf(event.buf) then
+          renderer.on_resize()
+        end
+      end,
+    })
+  end
+
   if opts.modified.enable then
     create_nvim_tree_autocmd({ "BufModifiedSet", "BufWritePost" }, {
       callback = function()
@@ -419,7 +432,8 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
     size = {
       enable = false,
-      column_width = 12,
+      width_cutoff = 18,
+      column_width = 10,
       show_folder_size = false,
       format_unit = "double",
       noshow_folder_size_glyph = "•",
@@ -656,6 +670,7 @@ local ACCEPTED_TYPES = {
   renderer = {
     size = {
       enable = { "boolean" },
+      width_cutoff = { "integer" },
       column_width = { "integer" },
       show_folder_size = { "boolean" },
       format_unit = { "function", "string" },
@@ -845,7 +860,7 @@ function M.setup(conf)
   end
 
   if M.config.renderer.size.column_width < 6 then
-    notify.warn "`size.right_padding` is a small number, problably won't show any size numbers, try using 12."
+    notify.warn "`size.right_padding` is a small number, problably won't show any size numbers, try using 10."
   end
 
   if M.config.renderer.size.format_unit == "single" then

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -489,6 +489,12 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     cmd = "",
     args = {},
   },
+  size = {
+    enable = true,
+    column_width = 12,
+    show_folder_size = false,
+    format_unit = "double",
+  },
   git = {
     enable = true,
     show_on_dirs = true,
@@ -653,6 +659,12 @@ local ACCEPTED_TYPES = {
   update_focused_file = {
     exclude = { "function" },
   },
+  size = {
+    enable = { "boolean" },
+    column_width = { "integer" },
+    show_folder_size = { "boolean" },
+    format_unit = { "function", "string" },
+  },
   git = {
     disable_for_dirs = { "function" },
   },
@@ -697,6 +709,9 @@ local ACCEPTED_STRINGS = {
   },
   help = {
     sort_by = { "key", "desc" },
+  },
+  size = {
+    format_unit = { "single", "double" },
   },
 }
 
@@ -825,6 +840,22 @@ function M.setup(conf)
   if log.enabled "config" then
     log.line("config", "default config + user")
     log.raw("config", "%s\n", vim.inspect(opts))
+  end
+
+  if M.config.size.column_width < 6 then
+    notify.warn "`size.right_padding` is a small number, problably won't show any size numbers, try using 12."
+  end
+
+  if M.config.size.format_unit == "single" then
+    -- The unit. Ex: 10.12M
+    M.config.size.format_unit = function(unit)
+      return string.format("%1s", unit:sub(1, 1))
+    end
+  elseif M.config.size.format_unit == "double" then
+    -- The unit. Ex: 10.12 MB
+    M.config.size.format_unit = function(unit)
+      return string.format(" %2s", unit)
+    end
   end
 
   require("nvim-tree.actions").setup(opts)

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -417,6 +417,13 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
         none = " ",
       },
     },
+    size = {
+      enable = false,
+      column_width = 12,
+      show_folder_size = false,
+      format_unit = "double",
+      noshow_folder_size_glyph = "•",
+    },
     icons = {
       web_devicons = {
         file = {
@@ -488,12 +495,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   system_open = {
     cmd = "",
     args = {},
-  },
-  size = {
-    enable = true,
-    column_width = 12,
-    show_folder_size = false,
-    format_unit = "double",
   },
   git = {
     enable = true,
@@ -653,17 +654,18 @@ local ACCEPTED_TYPES = {
     },
   },
   renderer = {
+    size = {
+      enable = { "boolean" },
+      column_width = { "integer" },
+      show_folder_size = { "boolean" },
+      format_unit = { "function", "string" },
+      noshow_folder_size_glyph = { "string" },
+    },
     group_empty = { "boolean", "function" },
     root_folder_label = { "function", "string", "boolean" },
   },
   update_focused_file = {
     exclude = { "function" },
-  },
-  size = {
-    enable = { "boolean" },
-    column_width = { "integer" },
-    show_folder_size = { "boolean" },
-    format_unit = { "function", "string" },
   },
   git = {
     disable_for_dirs = { "function" },
@@ -699,6 +701,9 @@ local ACCEPTED_STRINGS = {
     highlight_bookmarks = { "none", "icon", "name", "all" },
     highlight_diagnostics = { "none", "icon", "name", "all" },
     highlight_clipboard = { "none", "icon", "name", "all" },
+    size = {
+      format_unit = { "single", "double" },
+    },
     icons = {
       git_placement = { "before", "after", "signcolumn", "right_align" },
       modified_placement = { "before", "after", "signcolumn", "right_align" },
@@ -709,9 +714,6 @@ local ACCEPTED_STRINGS = {
   },
   help = {
     sort_by = { "key", "desc" },
-  },
-  size = {
-    format_unit = { "single", "double" },
   },
 }
 
@@ -842,18 +844,18 @@ function M.setup(conf)
     log.raw("config", "%s\n", vim.inspect(opts))
   end
 
-  if M.config.size.column_width < 6 then
+  if M.config.renderer.size.column_width < 6 then
     notify.warn "`size.right_padding` is a small number, problably won't show any size numbers, try using 12."
   end
 
-  if M.config.size.format_unit == "single" then
+  if M.config.renderer.size.format_unit == "single" then
     -- The unit. Ex: 10.12M
-    M.config.size.format_unit = function(unit)
+    M.config.renderer.size.format_unit = function(unit)
       return string.format("%1s", unit:sub(1, 1))
     end
-  elseif M.config.size.format_unit == "double" then
+  elseif M.config.renderer.size.format_unit == "double" then
     -- The unit. Ex: 10.12 MB
-    M.config.size.format_unit = function(unit)
+    M.config.renderer.size.format_unit = function(unit)
       return string.format(" %2s", unit)
     end
   end

--- a/lua/nvim-tree/appearance/init.lua
+++ b/lua/nvim-tree/appearance/init.lua
@@ -59,6 +59,9 @@ M.HIGHLIGHT_GROUPS = {
   -- Picker
   { group = "NvimTreeWindowPicker", def = "guifg=#ededed guibg=#4493c8 gui=bold ctermfg=White ctermbg=DarkBlue" },
 
+  -- File Size
+  { group = "NvimTreeFileSize", link = "Conceal" },
+
   -- LiveFilter
   { group = "NvimTreeLiveFilterPrefix", link = "PreProc" },
   { group = "NvimTreeLiveFilterValue", link = "ModeMsg" },

--- a/lua/nvim-tree/commands.lua
+++ b/lua/nvim-tree/commands.lua
@@ -1,6 +1,5 @@
 local api = require "nvim-tree.api"
 local view = require "nvim-tree.view"
-local renderer = require "nvim-tree.renderer"
 
 local M = {}
 

--- a/lua/nvim-tree/commands.lua
+++ b/lua/nvim-tree/commands.lua
@@ -1,5 +1,6 @@
 local api = require "nvim-tree.api"
 local view = require "nvim-tree.view"
+local renderer = require "nvim-tree.renderer"
 
 local M = {}
 

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -455,8 +455,8 @@ end
 function Builder.setup(opts)
   M.opts = opts
 
+  -- Still follows this priorty order
   M.decorator_size = DecoratorSize:new(opts)
-
   M.decorators = {
     DecoratorCut:new(opts),
     DecoratorCopied:new(opts),

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -12,6 +12,7 @@ local DecoratorGit = require "nvim-tree.renderer.decorator.git"
 local DecoratorModified = require "nvim-tree.renderer.decorator.modified"
 local DecoratorHidden = require "nvim-tree.renderer.decorator.hidden"
 local DecoratorOpened = require "nvim-tree.renderer.decorator.opened"
+local DecoratorSize = require "nvim-tree.renderer.decorator.size"
 
 local pad = require "nvim-tree.renderer.components.padding"
 local icons = require "nvim-tree.renderer.components.icons"
@@ -447,6 +448,7 @@ function Builder.setup(opts)
 
   -- priority order
   M.decorators = {
+    DecoratorSize:new(opts),
     DecoratorCut:new(opts),
     DecoratorCopied:new(opts),
     DecoratorDiagnostics:new(opts),

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -235,17 +235,17 @@ function Builder:format_line(indent_markers, arrows, icon, name, node)
     add_to_end(line, M.decorators[i]:icons_after(node))
   end
 
+  local size_extmarks = add_to_end({}, M.decorator_size:icons_right_align(node))
+  if #size_extmarks > 0 then
+    self.size_extmarks[self.index] = size_extmarks
+  end
+
   local rights = {}
   for i = #M.decorators, 1, -1 do
     add_to_end(rights, M.decorators[i]:icons_right_align(node))
   end
   if #rights > 0 then
     self.extmarks[self.index] = rights
-  end
-
-  local size_extmarks = add_to_end({}, M.decorator_size:icons_right_align(node))
-  if #size_extmarks > 0 then
-    self.size_extmarks[self.index] = size_extmarks
   end
 
   return line

--- a/lua/nvim-tree/renderer/decorator/size.lua
+++ b/lua/nvim-tree/renderer/decorator/size.lua
@@ -123,7 +123,7 @@ function DecoratorSize:calculate_icons(node)
   end
 
   local size = node and node.fs_stat and node.fs_stat.size or 0
-  local folder_size_str = self.column_width > 0 and string.rep(" ", self.column_width - 1) .. self.noshow_folder_size_glyph or ""
+  local folder_size_str = self.column_width > 0 and (string.rep(" ", self.column_width - 1) .. self.noshow_folder_size_glyph) or ""
   local icon = {
     str = (self.show_folder_size or node.nodes == nil) and self:human_readable_size(size) or folder_size_str,
     hl = { "NvimTreeFileSize" },

--- a/lua/nvim-tree/renderer/decorator/size.lua
+++ b/lua/nvim-tree/renderer/decorator/size.lua
@@ -1,0 +1,117 @@
+local HL_POSITION = require("nvim-tree.enum").HL_POSITION
+local ICON_PLACEMENT = require("nvim-tree.enum").ICON_PLACEMENT
+local Decorator = require "nvim-tree.renderer.decorator"
+
+---@class DecoratorSize: Decorator
+---@field icon HighlightedString|nil
+local DecoratorSize = Decorator:new()
+
+---@param opts table
+---@return DecoratorSize
+function DecoratorSize:new(opts)
+  local o = Decorator.new(self, {
+    enabled = opts.size.enable,
+    column_width = opts.size.column_width,
+    show_folder_size = opts.size.show_folder_size,
+    format_unit = opts.size.format_unit, -- Assumed to be a function
+    units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" },
+    icon_placement = ICON_PLACEMENT.right_align,
+  })
+
+  o.format_size = function(size)
+    local formatted = string
+      .format("%.2f", size)
+      -- Remove trailing zeros after the decimal point
+      :gsub("(%..-)0+$", "%1")
+      -- Remove the trailing decimal point if it's a whole number
+      :gsub("%.$", "")
+    return formatted
+  end
+
+  return o
+end
+
+---@param node Node
+---@return string|nil group
+function DecoratorSize:calculate_highlight(_)
+  return nil
+end
+
+--- Convert a size to a human-readable format (e.g., KB, MB, GB) with fixed width
+---@private
+---@param size number size in bytes
+---@return string
+---NOTE: This function tries it's best to minified the string
+--- generated, but this implies that we have more than 3 branchs
+--- to determined how much bytes can we shave from the string to
+--- comply to self.max_lengh. Since we know self.max_length doesn't
+--- change, a better way would be decide a version of human_readable_size based
+--- on self.max_lenght once at this object's construction.
+--- Basically, instead of this method, we would baking all ifs first to decide which function to bind to possible field `self.human_readable_size`
+--- I don't actually know if it would be faster without test, but most likely it would be faster.
+function DecoratorSize:human_readable_size(size)
+  -- Check for nan, negative, etc.
+  if type(size) ~= "number" or size ~= size or size < 0 then
+    return ""
+  end
+  local index = 1
+
+  -- We check for index here because for exaple, let's say
+  -- on a given iteration you have :
+  -- 1024 YB, then index is equal to #units, normally we would devide again,
+  -- but we don't have more units, so keep as is.
+  while size >= 1024 and index < #self.units do
+    size = size / 1024
+    index = index + 1
+  end
+
+  local unit_str = self.format_unit(self.units[index])
+
+  -- Apparently string.format already rounds then number
+  local size_str = self.format_size(size)
+  local result = size_str .. unit_str
+
+  -- We Need a max length to align size redering properly
+  -- So the result must at at most this column width
+  local max_length = self.column_width
+
+  if #result > max_length then
+    if (index + 1) < #self.units then
+      vim.fn.confirm(result)
+      size = size / 1024
+      index = index + 1
+      size_str = self.format_size(size)
+      unit_str = self.format_unit(self.units[index])
+      result = size_str .. unit_str
+      -- Now that we divided one more time to make it even smaller
+      -- we are garanteed the size string to have lenght of <= 4 (from 0.xx size)
+      assert(#size_str <= 4)
+    end
+  end
+
+  -- After we're sure we divided as much as we can when we
+  -- actually need it, only then we add the padding of max_length
+  result = string.format("%" .. max_length .. "s", result)
+
+  -- If still too big after all that,
+  -- then we just set to empty string
+  if #result > max_length then
+    result = ""
+  end
+
+  return result
+end
+
+---@param node Node
+---@return HighlightedString[]|nil icons
+function DecoratorSize:calculate_icons(node)
+  local size = node and node.fs_stat and node.fs_stat.size or 0
+  local folder_size_str = self.column_width > 0 and string.rep(" ", self.column_width - 1) .. "-" or ""
+  local icon = {
+    str = (self.show_folder_size or node.nodes == nil) and self:human_readable_size(size) or folder_size_str,
+    hl = { "NvimTreeFileSize" },
+  }
+  return { icon }
+end
+
+return DecoratorSize

--- a/lua/nvim-tree/renderer/decorator/size.lua
+++ b/lua/nvim-tree/renderer/decorator/size.lua
@@ -33,7 +33,9 @@ function DecoratorSize:new(opts)
   o.column_width = opts.renderer.size.column_width
   o.show_folder_size = opts.renderer.size.show_folder_size
   o.units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" }
-  o.format_unit = opts.renderer.size.format_unit -- guaranteed to be a function
+
+  -- Guaranteed to be a function from previous setup
+  o.format_unit = opts.renderer.size.format_unit
   o.format_size = function(size)
     local formatted = string
       .format("%.2f", size)
@@ -51,15 +53,16 @@ end
 ---@private
 ---@param size number size in bytes
 ---@return string
---- edit: Since then I've moved a lot of ifs around getting down to only three, but I'll keep the comment just in case.
+--- edit: Since then I've moved a lot of ifs around getting down to only three, but I'll keep the comment bellow just in case.
 ---NOTE: This function still try it's best to minified the string
---- generated, but this implies that we have more than 3 branchs
+--- generated, but this implies that we have some branches
 --- to determined how much bytes can we shave from the string to
---- comply to self.column_width. Since we know self.column_width doesn't
---- change, a better way could be to decide a version of 'human_readable_size' based
---- on self.column_width once at this object's construction.
---- Basically, instead of this method, we would baking all ifs first to decide which function to bind to possible field `self.human_readable_size`
---- I don't actually know if it would be faster without test.
+--- comply to `self.column_width`.
+--- Since we know `self.column_width` doesn't change, a better way could be
+--- decide a version of 'human_readable_size' a priori, based
+--- on `self.column_width` *once* at this object's construction.
+--- Basically, instead of this method, we would "baking" all ifs first
+--- to decide which function to bind to possible field `self.human_readable_size`.
 function DecoratorSize:human_readable_size(size)
   -- Check for nan, negative, etc.
   if type(size) ~= "number" or size ~= size or size < 0 then

--- a/lua/nvim-tree/renderer/decorator/size.lua
+++ b/lua/nvim-tree/renderer/decorator/size.lua
@@ -1,9 +1,17 @@
 local HL_POSITION = require("nvim-tree.enum").HL_POSITION
 local ICON_PLACEMENT = require("nvim-tree.enum").ICON_PLACEMENT
+local view = require "nvim-tree.view"
+
 local Decorator = require "nvim-tree.renderer.decorator"
 
 ---@class DecoratorSize: Decorator
----@field icon HighlightedString|nil
+---@field width_cutoff integer
+---@field noshow_folder_size_glyph string
+---@field column_width integer
+---@field show_folder_size boolean
+---@field units string[]
+---@field format_unit function
+---@field format_size function
 local DecoratorSize = Decorator:new()
 
 ---@param opts table
@@ -11,14 +19,21 @@ local DecoratorSize = Decorator:new()
 function DecoratorSize:new(opts)
   local o = Decorator.new(self, {
     enabled = opts.renderer.size.enable,
-    noshow_folder_size_glyph = opts.renderer.size.noshow_folder_size_glyph or "",
-    column_width = opts.renderer.size.column_width,
-    show_folder_size = opts.renderer.size.show_folder_size,
-    format_unit = opts.renderer.size.format_unit, -- Assumed to be a function
-    units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" },
+    hl_pos = HL_POSITION.none,
     icon_placement = ICON_PLACEMENT.right_align,
   })
+  ---@cast o DecoratorSize
 
+  if not o.enabled then
+    return o
+  end
+
+  o.width_cutoff = opts.renderer.size.width_cutoff
+  o.noshow_folder_size_glyph = opts.renderer.size.noshow_folder_size_glyph or ""
+  o.column_width = opts.renderer.size.column_width
+  o.show_folder_size = opts.renderer.size.show_folder_size
+  o.units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" }
+  o.format_unit = opts.renderer.size.format_unit -- guaranteed to be a function
   o.format_size = function(size)
     local formatted = string
       .format("%.2f", size)
@@ -32,16 +47,11 @@ function DecoratorSize:new(opts)
   return o
 end
 
----@param node Node
----@return nil
-function DecoratorSize:calculate_highlight(_)
-  return nil
-end
-
 --- Convert a size to a human-readable format (e.g., KB, MB, GB) with fixed width
 ---@private
 ---@param size number size in bytes
 ---@return string
+--- edit: Since then I've moved a lot of ifs around getting down to only three, but I'll keep the comment just in case.
 ---NOTE: This function still try it's best to minified the string
 --- generated, but this implies that we have more than 3 branchs
 --- to determined how much bytes can we shave from the string to
@@ -50,7 +60,6 @@ end
 --- on self.column_width once at this object's construction.
 --- Basically, instead of this method, we would baking all ifs first to decide which function to bind to possible field `self.human_readable_size`
 --- I don't actually know if it would be faster without test.
---- edit: Since then I've moved a lot of ifs around getting down to only three, but I'll keep the comment just in case.
 function DecoratorSize:human_readable_size(size)
   -- Check for nan, negative, etc.
   if type(size) ~= "number" or size ~= size or size < 0 then
@@ -74,11 +83,11 @@ function DecoratorSize:human_readable_size(size)
   local result = size_str .. unit_str
 
   -- We Need a max length to align size redering properly
-  -- So the result must at at most this column width
+  -- So the result must have at most this column width
   local max_length = self.column_width
 
   if #result > max_length then
-    if (index + 1) < #self.units then
+    if index <= #self.units then
       size = size / 1024
       index = index + 1
       size_str = self.format_size(size)
@@ -97,7 +106,7 @@ function DecoratorSize:human_readable_size(size)
   -- If still too big after all that,
   -- then we just set to empty string
   if #result > max_length then
-    result = ""
+    result = string.format("%" .. max_length .. "s", "")
   end
 
   return result
@@ -106,6 +115,10 @@ end
 ---@param node Node
 ---@return HighlightedString[]|nil icons
 function DecoratorSize:calculate_icons(node)
+  if not self.enabled or view.get_current_width() < self.width_cutoff then
+    return nil
+  end
+
   local size = node and node.fs_stat and node.fs_stat.size or 0
   local folder_size_str = self.column_width > 0 and string.rep(" ", self.column_width - 1) .. self.noshow_folder_size_glyph or ""
   local icon = {

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -14,12 +14,15 @@ local SIGN_GROUP = "NvimTreeRendererSigns"
 
 local namespace_highlights_id = vim.api.nvim_create_namespace "NvimTreeHighlights"
 local namespace_extmarks_id = vim.api.nvim_create_namespace "NvimTreeExtmarks"
+local namespace_size_extmarks_id = vim.api.nvim_create_namespace "NvimTreeSizeExtmarks"
 
 ---@param bufnr number
 ---@param lines string[]
 ---@param hl_args AddHighlightArgs[]
 ---@param signs string[]
-local function _draw(bufnr, lines, hl_args, signs, extmarks)
+---@param extmarks table<integer, HighlightedString[]>
+---@param size_extmarks table<integer, HighlightedString[]>
+local function _draw(bufnr, lines, hl_args, signs, extmarks, size_extmarks)
   if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
   else
@@ -40,16 +43,8 @@ local function _draw(bufnr, lines, hl_args, signs, extmarks)
     vim.fn.sign_place(0, SIGN_GROUP, sign_name, bufnr, { lnum = i + 1 })
   end
 
-  vim.api.nvim_buf_clear_namespace(bufnr, namespace_extmarks_id, 0, -1)
-  for i, extname in pairs(extmarks) do
-    for _, mark in ipairs(extname) do
-      vim.api.nvim_buf_set_extmark(bufnr, namespace_extmarks_id, i, -1, {
-        virt_text = { { mark.str, mark.hl } },
-        virt_text_pos = "right_align",
-        hl_mode = "combine",
-      })
-    end
-  end
+  M.render_extmarks(bufnr, namespace_extmarks_id, extmarks)
+  M.render_extmarks(bufnr, namespace_size_extmarks_id, size_extmarks)
 end
 
 function M.render_hl(bufnr, hl)
@@ -66,6 +61,50 @@ function M.render_hl(bufnr, hl)
   end
 end
 
+function M.render_extmarks(bufnr, ns_id, extmarks)
+  if not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
+    return
+  end
+  vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+  for i, extname in pairs(extmarks) do
+    for _, mark in ipairs(extname) do
+      vim.api.nvim_buf_set_extmark(bufnr, ns_id, i, -1, {
+        virt_text = { { mark.str, mark.hl } },
+        virt_text_pos = "right_align",
+        hl_mode = "combine",
+      })
+    end
+  end
+end
+
+-- Here we do a partial redraw of only a subsection of extra marks.
+-- We could simply call reloaders.reload(), but that would be substantially slower.
+-- Calling `nvim_buf_clear_namespace` to hide size information
+-- and `render_extmarks` to show again is preferable in place of
+-- reloading all decorators, nodes and lines from scratch, since resize does not trigger a reload.
+local redraw_size_extmarks = false
+function M.on_resize()
+  if M.builder == nil then
+    return
+  end
+
+  local bufnr = view.get_bufnr()
+
+  if view.get_current_width() < M.config.size.width_cutoff then
+    redraw_size_extmarks = true
+    vim.api.nvim_buf_clear_namespace(bufnr, namespace_size_extmarks_id, 0, -1)
+    return
+  end
+
+  -- If we got here, we only need to know if we should redraw
+  -- We don't have to check if decorator_size is enbaled, because if it's
+  -- not, then size_extmarks would've been empty
+  if redraw_size_extmarks then
+    redraw_size_extmarks = false
+    M.render_extmarks(bufnr, namespace_size_extmarks_id, M.builder.size_extmarks)
+  end
+end
+
 function M.draw()
   local bufnr = view.get_bufnr()
   if not core.get_explorer() or not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
@@ -77,11 +116,11 @@ function M.draw()
   local cursor = vim.api.nvim_win_get_cursor(view.get_winnr() or 0)
   icon_component.reset_config()
 
-  local builder = Builder:new():build()
+  redraw_size_extmarks = false
+  M.builder = Builder:new():build()
+  _draw(bufnr, M.builder.lines, M.builder.hl_args, M.builder.signs, M.builder.extmarks, M.builder.size_extmarks)
 
-  _draw(bufnr, builder.lines, builder.hl_args, builder.signs, builder.extmarks)
-
-  if cursor and #builder.lines >= cursor[1] then
+  if cursor and #M.builder.lines >= cursor[1] then
     vim.api.nvim_win_set_cursor(view.get_winnr() or 0, cursor)
   end
 
@@ -94,11 +133,10 @@ end
 
 function M.setup(opts)
   M.config = opts.renderer
-
+  M.builder = nil
   _padding.setup(opts)
   full_name.setup(opts)
   icon_component.setup(opts)
-
   Builder.setup(opts)
 end
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -576,6 +576,13 @@ function M.configure_width(width)
   end
 end
 
+---Get effective width, works on float window
+---@return integer
+function M.get_current_width()
+  local view_winnr = M.get_winnr()
+  return view_winnr and vim.api.nvim_win_get_width(view_winnr or 0) or 0
+end
+
 function M.setup(opts)
   local options = opts.view or {}
   M.View.centralize_selection = options.centralize_selection


### PR DESCRIPTION
## Description

This PR make nvim-tree be able to display file size information as a decoration. It uses newly introduced ``right_align`` feature to create a column that shows size info. It allows to customization options to display file sizes in a human-readable format (e.g., MB, GB). It also exposes the highlight group ``NvimTreeFileSize``.

## Showcase
![image](https://github.com/user-attachments/assets/d04ee709-3288-48b6-a673-c0e833dc1c15)


## Setup: 
```lua
require'nvim-tree'.setup {
  renderer = {
    size = {
      enable = true,
      column_width = 12, -- max chars allowed to fill the column
      show_folder_size = false,
      format_unit = "double", -- or "single" or a custom function
    }
  }
}
```


## Improvements that could be made:
- Conditionally show file size information based on the current nvim-tree width in both floating and normal views.



EDIT: This improvement were made. We now support conditionally hiding size information based on current width  and width cutoff setting as shown below.

https://github.com/user-attachments/assets/b22469a0-c021-415d-8088-44dafd7b8948

The hiding is decently fast because it only does a partial redraw of extra marks as opposed to reloading the whole tree everytime the cutoff is triggered.

