### PR TITLE
Abort iteration when fs-event-incapable

### DIFF
--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -40,22 +40,24 @@ local function populate_children(handle, cwd, node, git_status, parent)
     ---@type uv.fs_stat.result|nil
     local stat = vim.loop.fs_stat(abs)
     local filter_reason = parent.filters:should_filter_as_reason(abs, stat, filter_status)
-    if filter_reason == FILTER_REASON.none and not nodes_by_path[abs] and Watcher.is_fs_event_capable(abs) then
-      local child = nil
-      if t == "directory" and vim.loop.fs_access(abs, "R") then
-        child = builders.folder(node, abs, name, stat)
-      elseif t == "file" then
-        child = builders.file(node, abs, name, stat)
-      elseif t == "link" then
-        local link = builders.link(node, abs, name, stat)
-        if link.link_to ~= nil then
-          child = link
+    if filter_reason == FILTER_REASON.none and not nodes_by_path[abs] then
+      if Watcher.is_fs_event_capable(abs) then
+        local child = nil
+        if t == "directory" and vim.loop.fs_access(abs, "R") then
+          child = builders.folder(node, abs, name, stat)
+        elseif t == "file" then
+          child = builders.file(node, abs, name, stat)
+        elseif t == "link" then
+          local link = builders.link(node, abs, name, stat)
+          if link.link_to ~= nil then
+            child = link
+          end
         end
-      end
-      if child then
-        table.insert(node.nodes, child)
-        nodes_by_path[child.absolute_path] = true
-        explorer_node.update_git_status(child, node_ignored, git_status)
+        if child then
+          table.insert(node.nodes, child)
+          nodes_by_path[child.absolute_path] = true
+          explorer_node.update_git_status(child, node_ignored, git_status)
+        end
       end
     else
       for reason, value in pairs(FILTER_REASON) do


### PR DESCRIPTION
Fixes #2866. The original code, while detecting whether Windows NT allows the dir to be iterated through, will go to the other branch of the if...else... statement, which is intended for cases when filter_reason is not none. Simply moving `is_fs_event_capable` into the first branch should solve the problem.