### PR TITLE
fix: check tree_win exists before closing

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -226,8 +226,8 @@ local function close(tabpage)
       if tree_win == current_win and prev_win > 0 then
         vim.api.nvim_set_current_win(vim.fn.win_getid(prev_win))
       end
-      if vim.api.nvim_win_is_valid(tree_win or 0) then
-        vim.api.nvim_win_close(tree_win or 0, true)
+      if tree_win and vim.api.nvim_win_is_valid(tree_win) then
+        vim.api.nvim_win_close(tree_win, true)
       end
       events._dispatch_on_tree_close()
       return


### PR DESCRIPTION
## Description
Fixes `Vim:E444: Cannot close last window` error when after running `:NvimTreeClose`

## Minimal config
```
vim.g.loaded_netrw = 1
vim.g.loaded_netrwPlugin = 1

vim.cmd([[set runtimepath=$VIMRUNTIME]])
vim.cmd([[set packpath=/tmp/nvt-min/site]])
local package_root = '/tmp/nvt-min/site/pack'
local install_path = package_root .. '/packer/start/packer.nvim'
local function load_plugins()
    require('packer').startup({
        {
            'wbthomason/packer.nvim',
            'nvim-tree/nvim-tree.lua',
            'nvim-tree/nvim-web-devicons',
        },
        config = {
            package_root = package_root,
            compile_path = install_path .. '/plugin/packer_compiled.lua',
            display = { non_interactive = true },
        },
    })
end
if vim.fn.isdirectory(install_path) == 0 then
    print('Installing nvim-tree and dependencies.')
    vim.fn.system({ 'git', 'clone', '--depth=1', 'https://github.com/wbthomason/packer.nvim', install_path })
end
load_plugins()
require('packer').sync()
vim.cmd([[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]])
vim.opt.termguicolors = true
vim.opt.cursorline = true

-- MODIFY NVIM-TREE SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
_G.setup = function()
    require('nvim-tree').setup({
        view = {
            float = {
                enable = true,
            },
        },
    })
end
```
## Steps to reproduce
1. `nvim .`
2. `:NvimTreeOpen`
3. `:NvimTreeClose`

## Current behavior
nvim-tree closes with the following error:
```
Error executing Lua callback: ...e/pack/packer/start/nvim-tree.lua/lua/nvim-tree/view.lua:230: Vim:E444: Cannot close last window
stack traceback:
        [C]: in function 'nvim_win_close'
        ...e/pack/packer/start/nvim-tree.lua/lua/nvim-tree/view.lua:230: in function 'close'
        ...e/pack/packer/start/nvim-tree.lua/lua/nvim-tree/view.lua:239: in function 'close_this_tab_only'
        ...e/pack/packer/start/nvim-tree.lua/lua/nvim-tree/view.lua:252: in function 'close'
        ...ck/packer/start/nvim-tree.lua/lua/nvim-tree/commands.lua:25: in function <...ck/packer/start/nvim-tree.lua/lua/nvim-tree/commands.lua:24>
 ```