### PR TITLE
fix(#2906): resource leak on populate children

### DIFF
--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -46,22 +46,24 @@ local function populate_children(handle, cwd, node, git_status, parent)
       local type = stat and stat.type or nil
 
       local filter_reason = parent.filters:should_filter_as_reason(abs, stat, filter_status)
-      if filter_reason == FILTER_REASON.none and not nodes_by_path[abs] then
-        local child = nil
-        if type == "directory" and vim.loop.fs_access(abs, "R") then
-          child = builders.folder(node, abs, name, stat)
-        elseif type == "file" then
-          child = builders.file(node, abs, name, stat)
-        elseif type == "link" then
-          local link = builders.link(node, abs, name, stat)
-          if link.link_to ~= nil then
-            child = link
+      if filter_reason == FILTER_REASON.none then
+        if not nodes_by_path[abs] then
+          local child = nil
+          if type == "directory" and vim.loop.fs_access(abs, "R") then
+            child = builders.folder(node, abs, name, stat)
+          elseif type == "file" then
+            child = builders.file(node, abs, name, stat)
+          elseif type == "link" then
+            local link = builders.link(node, abs, name, stat)
+            if link.link_to ~= nil then
+              child = link
+            end
           end
-        end
-        if child then
-          table.insert(node.nodes, child)
-          nodes_by_path[child.absolute_path] = true
-          explorer_node.update_git_status(child, node_ignored, git_status)
+          if child then
+            table.insert(node.nodes, child)
+            nodes_by_path[child.absolute_path] = true
+            explorer_node.update_git_status(child, node_ignored, git_status)
+          end
         end
       else
         for reason, value in pairs(FILTER_REASON) do


### PR DESCRIPTION
FIx for https://github.com/nvim-tree/nvim-tree.lua/issues/2906

It looks like there are some situations where the explorer tries to populate a node when it is already populated. This leads to a situation in the code where the filter reason is none, however the node has already been loaded. This in turn leads to an attempt to record the hidden stats for the reason. Since the reason however is none and the `hidden_stats `object has understandably not been initialised to capture stats for reason none, the following exception is thrown

```txt
Error executing vim.schedule lua callback: ...r/start/nvim-tree.lua/lua/nvim-tree/explorer/explore.lua:69: attempt to perform
 arithmetic on a nil value
stack traceback:
        ...r/start/nvim-tree.lua/lua/nvim-tree/explorer/explore.lua:69: in function 'populate_children'
```

The fix changes the logic so that no attempt to record hidden stats are made and the node is not reloaded. I'm assuming here that the node has been loaded OK if the path is in the `nodes_by_path` object. I welcome any feedback on whether that is a good assumption.