### PR TITLE
feat(#2430): use vim.ui.open as default system_open, for neovim 0.10+

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1198,11 +1198,18 @@ Takes the `BufEnter` event as an argument. see |autocmd-events|
 
 Open a file or directory in your preferred application.
 
+|vim.ui.open| was introduced in neovim 0.10 and is the default.
+
+Once nvim-tree minimum neovim version is updated to 0.10, these options will
+no longer be necessary and will be removed.
+
 *nvim-tree.system_open.cmd*
 The open command itself.
   Type: `string`, Default: `""`
 
-Leave empty for OS specific default:
+neovim >= 0.10 defaults to |vim.ui.open|
+
+neovim <  0.10 defaults to:
   UNIX:    `"xdg-open"`
   macOS:   `"open"`
   Windows: `"cmd"`

--- a/lua/nvim-tree/actions/node/system-open.lua
+++ b/lua/nvim-tree/actions/node/system-open.lua
@@ -51,11 +51,9 @@ end
 
 ---@param node Node
 local function native(node)
-  local path = node.link_to or node.absolute_path
+  local _, err = vim.ui.open(node.link_to or node.absolute_path)
 
-  local _, err = vim.ui.open(path)
-
-  -- err only provided on opener executable not found; path not useful in that case
+  -- err only provided on opener executable not found hence logging path is not useful
   if err then
     notify.warn(err)
   end


### PR DESCRIPTION
fixes #2430 