### PR TITLE
fix(#2917): fix root copy paths: Y, ge, gy, y

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1960,6 +1960,13 @@ fs.copy.absolute_path({node})          *nvim-tree-api.fs.copy.absolute_path()*
     Parameters: ~
       • {node} (Node|nil) file or folder
 
+fs.copy.basename({node})                    *nvim-tree-api.fs.copy.basename()*
+    Copy the name of a file or folder with extension omitted to the system
+    clipboard.
+
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+
 fs.copy.filename({node})                    *nvim-tree-api.fs.copy.filename()*
     Copy the name of a file or folder to the system clipboard.
 
@@ -3027,6 +3034,7 @@ highlight group is not, hard linking as follows: >
 |nvim-tree-api.events.subscribe()|
 |nvim-tree-api.fs.clear_clipboard()|
 |nvim-tree-api.fs.copy.absolute_path()|
+|nvim-tree-api.fs.copy.basename()|
 |nvim-tree-api.fs.copy.filename()|
 |nvim-tree-api.fs.copy.node()|
 |nvim-tree-api.fs.copy.relative_path()|

--- a/lua/nvim-tree/actions/fs/clipboard.lua
+++ b/lua/nvim-tree/actions/fs/clipboard.lua
@@ -327,30 +327,62 @@ end
 
 ---@param node Node
 function Clipboard:copy_filename(node)
-  self:copy_to_reg(node.name)
+  local content
+
+  if node.name == ".." then
+    -- root
+    content = vim.fn.fnamemodify(self.explorer.absolute_path, ":t")
+  else
+    -- node
+    content = node.name
+  end
+
+  self:copy_to_reg(content)
 end
 
 ---@param node Node
 function Clipboard:copy_basename(node)
-  local basename = vim.fn.fnamemodify(node.name, ":r")
-  self:copy_to_reg(basename)
+  local content
+
+  if node.name == ".." then
+    -- root
+    content = vim.fn.fnamemodify(self.explorer.absolute_path, ":t:r")
+  else
+    -- node
+    content = vim.fn.fnamemodify(node.name, ":r")
+  end
+
+  self:copy_to_reg(content)
 end
 
 ---@param node Node
 function Clipboard:copy_path(node)
-  local absolute_path = node.absolute_path
-  local cwd = core.get_cwd()
-  if cwd == nil then
-    return
+  local content
+
+  if node.name == ".." then
+    -- root
+    content = utils.path_add_trailing ""
+  else
+    -- node
+    local absolute_path = node.absolute_path
+    local cwd = core.get_cwd()
+    if cwd == nil then
+      return
+    end
+
+    local relative_path = utils.path_relative(absolute_path, cwd)
+    content = node.nodes ~= nil and utils.path_add_trailing(relative_path) or relative_path
   end
 
-  local relative_path = utils.path_relative(absolute_path, cwd)
-  local content = node.nodes ~= nil and utils.path_add_trailing(relative_path) or relative_path
   self:copy_to_reg(content)
 end
 
 ---@param node Node
 function Clipboard:copy_absolute_path(node)
+  if node.name == ".." then
+    node = self.explorer
+  end
+
   local absolute_path = node.absolute_path
   local content = node.nodes ~= nil and utils.path_add_trailing(absolute_path) or absolute_path
   self:copy_to_reg(content)


### PR DESCRIPTION
fixes #2917 

Continued the `".."` testing pattern, #2886 should boil these conditions away.