### PR TITLE
fix: invalid explorer on open

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -263,8 +263,6 @@ end
 function M.open(opts)
   opts = opts or {}
 
-  local explorer = core.get_explorer()
-
   M.set_target_win()
   if not core.get_explorer() or opts.path then
     if opts.path then
@@ -278,6 +276,9 @@ function M.open(opts)
       core.init(cwd)
     end
   end
+  
+  local explorer = core.get_explorer()
+  
   if should_hijack_current_buf() then
     view.close_this_tab_only()
     view.open_in_win()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -276,9 +276,9 @@ function M.open(opts)
       core.init(cwd)
     end
   end
-  
+
   local explorer = core.get_explorer()
-  
+
   if should_hijack_current_buf() then
     view.close_this_tab_only()
     view.open_in_win()


### PR DESCRIPTION
The return value of `core.get_explorer()` could be changed by the `core.init(..)` between the binding (L266) and its later uses (L281 onwards): 
https://github.com/nvim-tree/nvim-tree.lua/blob/8405ecfbd6bb08a94ffc9c68fef211eea56e8a3b/lua/nvim-tree/lib.lua#L266-L284