### PR TITLE
fix(#2961): windows: escape brackets and parentheses when opening file

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -331,9 +331,9 @@ local function open_in_new_window(filename, mode)
 
   local fname
   if M.relative_path then
-    fname = vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd()))
+    fname = utils.escape_special_chars(vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd())))
   else
-    fname = vim.fn.fnameescape(filename)
+    fname = utils.escape_special_chars(vim.fn.fnameescape(filename))
   end
 
   local command
@@ -370,33 +370,27 @@ end
 ---@param mode string
 ---@param filename string
 function M.fn(mode, filename)
-  local fname
-  if utils.is_windows then
-    fname = filename
-  else
-    fname = utils.escape_special_chars(filename)
-  end
   if type(mode) ~= "string" then
     mode = ""
   end
 
   if mode == "tabnew" then
-    return open_file_in_tab(fname)
+    return open_file_in_tab(filename)
   end
 
   if mode == "drop" then
-    return drop(fname)
+    return drop(filename)
   end
 
   if mode == "tab_drop" then
-    return tab_drop(fname)
+    return tab_drop(filename)
   end
 
   if mode == "edit_in_place" then
-    return edit_in_current_buf(fname)
+    return edit_in_current_buf(filename)
   end
 
-  local buf_loaded = is_already_loaded(fname)
+  local buf_loaded = is_already_loaded(filename)
 
   local found_win = utils.get_win_buf_from_path(filename)
   if found_win and (mode == "preview" or mode == "preview_no_picker") then
@@ -404,7 +398,7 @@ function M.fn(mode, filename)
   end
 
   if not found_win then
-    open_in_new_window(fname, mode)
+    open_in_new_window(filename, mode)
   else
     vim.api.nvim_set_current_win(found_win)
     vim.bo.bufhidden = ""

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -329,14 +329,12 @@ local function open_in_new_window(filename, mode)
     set_current_win_no_autocmd(target_winid, { "BufEnter" })
   end
 
-  print("filename: " .. filename)
   local fname
   if M.relative_path then
     fname = utils.escape_special_chars(vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd())))
   else
     fname = utils.escape_special_chars(vim.fn.fnameescape(filename))
   end
-  print("fname: " .. fname)
 
   local command
   if create_new_window then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -331,9 +331,9 @@ local function open_in_new_window(filename, mode)
 
   local fname
   if M.relative_path then
-    fname = vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd()))
+    fname = utils.escape_special_chars(vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd())))
   else
-    fname = vim.fn.fnameescape(filename)
+    fname = utils.escape_special_chars(vim.fn.fnameescape(filename))
   end
 
   local command
@@ -370,28 +370,27 @@ end
 ---@param mode string
 ---@param filename string
 function M.fn(mode, filename)
-  local fname = utils.escape_special_chars(filename)
   if type(mode) ~= "string" then
     mode = ""
   end
 
   if mode == "tabnew" then
-    return open_file_in_tab(fname)
+    return open_file_in_tab(filename)
   end
 
   if mode == "drop" then
-    return drop(fname)
+    return drop(filename)
   end
 
   if mode == "tab_drop" then
-    return tab_drop(fname)
+    return tab_drop(filename)
   end
 
   if mode == "edit_in_place" then
-    return edit_in_current_buf(fname)
+    return edit_in_current_buf(filename)
   end
 
-  local buf_loaded = is_already_loaded(fname)
+  local buf_loaded = is_already_loaded(filename)
 
   local found_win = utils.get_win_buf_from_path(filename)
   if found_win and (mode == "preview" or mode == "preview_no_picker") then
@@ -399,7 +398,7 @@ function M.fn(mode, filename)
   end
 
   if not found_win then
-    open_in_new_window(fname, mode)
+    open_in_new_window(filename, mode)
   else
     vim.api.nvim_set_current_win(found_win)
     vim.bo.bufhidden = ""

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -329,12 +329,14 @@ local function open_in_new_window(filename, mode)
     set_current_win_no_autocmd(target_winid, { "BufEnter" })
   end
 
+  print("filename: " .. filename)
   local fname
   if M.relative_path then
     fname = utils.escape_special_chars(vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd())))
   else
     fname = utils.escape_special_chars(vim.fn.fnameescape(filename))
   end
+  print("fname: " .. fname)
 
   local command
   if create_new_window then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -331,9 +331,9 @@ local function open_in_new_window(filename, mode)
 
   local fname
   if M.relative_path then
-    fname = utils.escape_special_chars(vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd())))
+    fname = vim.fn.fnameescape(utils.path_relative(filename, vim.fn.getcwd()))
   else
-    fname = utils.escape_special_chars(vim.fn.fnameescape(filename))
+    fname = vim.fn.fnameescape(filename)
   end
 
   local command
@@ -370,27 +370,33 @@ end
 ---@param mode string
 ---@param filename string
 function M.fn(mode, filename)
+  local fname
+  if utils.is_windows then
+    fname = filename
+  else
+    fname = utils.escape_special_chars(filename)
+  end
   if type(mode) ~= "string" then
     mode = ""
   end
 
   if mode == "tabnew" then
-    return open_file_in_tab(filename)
+    return open_file_in_tab(fname)
   end
 
   if mode == "drop" then
-    return drop(filename)
+    return drop(fname)
   end
 
   if mode == "tab_drop" then
-    return tab_drop(filename)
+    return tab_drop(fname)
   end
 
   if mode == "edit_in_place" then
-    return edit_in_current_buf(filename)
+    return edit_in_current_buf(fname)
   end
 
-  local buf_loaded = is_already_loaded(filename)
+  local buf_loaded = is_already_loaded(fname)
 
   local found_win = utils.get_win_buf_from_path(filename)
   if found_win and (mode == "preview" or mode == "preview_no_picker") then
@@ -398,7 +404,7 @@ function M.fn(mode, filename)
   end
 
   if not found_win then
-    open_in_new_window(filename, mode)
+    open_in_new_window(fname, mode)
   else
     vim.api.nvim_set_current_win(found_win)
     vim.bo.bufhidden = ""

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -279,7 +279,7 @@ function M.escape_special_chars(path)
   if path == nil then
     return path
   end
-  return M.is_windows and path:gsub("\\", "/") or path
+  return M.is_windows and path:gsub("%(", "\\("):gsub("%)", "\\)") or path
 end
 
 --- Create empty sub-tables if not present

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -80,7 +80,7 @@ function M.path_relative(path, relative_to)
   end
 
   local norm_path = path
-  if has_parentheses_and_brackets(path) then
+  if M.is_windows and has_parentheses_and_brackets(path) then
     norm_path = path:gsub("/", "\\")
   end
 

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -59,6 +59,17 @@ function M.path_basename(path)
   return path:sub(i + 1, #path)
 end
 
+--- Check if there are parentheses before brackets, it causes problems for windows.
+--- Refer to issue #2862 and #2961 for more details.
+local function has_parentheses_and_brackets(path)
+  local _, i_parentheses = path:find("(", 1, true)
+  local _, i_brackets = path:find("[", 1, true)
+  if i_parentheses and i_brackets then
+    return true
+  end
+  return false
+end
+
 --- Get a path relative to another path.
 ---@param path string
 ---@param relative_to string|nil
@@ -68,13 +79,18 @@ function M.path_relative(path, relative_to)
     return path
   end
 
-  local _, r = path:find(M.path_add_trailing(relative_to), 1, true)
-  local p = path
+  local norm_path = path
+  if has_parentheses_and_brackets(path) then
+    norm_path = path:gsub("/", "\\")
+  end
+
+  local _, r = norm_path:find(M.path_add_trailing(relative_to), 1, true)
+  local p = norm_path
   if r then
     -- take the relative path starting after '/'
     -- if somehow given a completely matching path,
     -- returns ""
-    p = path:sub(r + 1)
+    p = norm_path:sub(r + 1)
   end
   return p
 end
@@ -272,6 +288,14 @@ function M.canonical_path(path)
   return path
 end
 
+--- Escapes special characters in string for windows, refer to issue #2862 and #2961 for more details.
+local function escape_special_char_for_windows(path)
+  if has_parentheses_and_brackets(path) then
+    return path:gsub("\\", "/"):gsub("/ ", "\\ ")
+  end
+  return path:gsub("%(", "\\("):gsub("%)", "\\)")
+end
+
 --- Escapes special characters in string if windows else returns unmodified string.
 ---@param path string
 ---@return string|nil
@@ -279,7 +303,8 @@ function M.escape_special_chars(path)
   if path == nil then
     return path
   end
-  return M.is_windows and path:gsub("%(", "\\("):gsub("%)", "\\)") or path
+  -- return M.is_windows and path:gsub("%(", "\\("):gsub("%)", "\\)") or path
+  return M.is_windows and escape_special_char_for_windows(path) or path
 end
 
 --- Create empty sub-tables if not present

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -303,7 +303,6 @@ function M.escape_special_chars(path)
   if path == nil then
     return path
   end
-  -- return M.is_windows and path:gsub("%(", "\\("):gsub("%)", "\\)") or path
   return M.is_windows and escape_special_char_for_windows(path) or path
 end
 


### PR DESCRIPTION
Description
With this change (https://github.com/nvim-tree/nvim-tree.lua/commit/45a93d99794fff3064141d5b3a50db98ce352697#diff-eeb21711fceb0abba1450bd1adcbecc4fd90cf8ce4d5d7a8233f886c1bebd41fR375), I found it doesn't work well on Windows for 2 cases:

1. When I open a file from nvim-tree, the root of nvim-tree window changed to the directory of that file
2. The buffer of this file can not be listed when I use telescope command `<cmd>lua require('telescope.builtin').buffers(require('telescope.themes').get_dropdown{previewer = false})<cr>
Neovim version`

This PR is to revert the change and fix the issue #2961 and #2862 