### PR TITLE
fix(#2969): After a rename, the node loses selection

### DIFF
--- a/lua/nvim-tree/actions/fs/rename-file.lua
+++ b/lua/nvim-tree/actions/fs/rename-file.lua
@@ -161,12 +161,14 @@ function M.fn(default_modifier)
         return
       end
 
-      M.rename(node, prepend .. new_file_path .. append)
+      local full_new_path = prepend .. new_file_path .. append
+
+      M.rename(node, full_new_path)
       if not M.config.filesystem_watchers.enable then
         explorer:reload_explorer()
       end
 
-      find_file(utils.path_remove_trailing(new_file_path))
+      find_file(utils.path_remove_trailing(full_new_path))
     end)
   end
 end


### PR DESCRIPTION
Use the full path, as used in rename(), for the subsequent call to find_file(), in order to correctly re-select the renamed item.
Fix for 
https://github.com/nvim-tree/nvim-tree.lua/issues/2969