### PR TITLE
fix(#2978): grouped folder not showing closed icon

### DIFF
--- a/lua/nvim-tree/node/directory.lua
+++ b/lua/nvim-tree/node/directory.lua
@@ -215,7 +215,7 @@ function DirectoryNode:expand_or_collapse(toggle_group)
     next_open = not open
   end
 
-  local node = self
+  local node = head_node
   while node do
     node.open = next_open
     node = node.group_next


### PR DESCRIPTION
fixes #2978 