### PR TITLE
fix(#2990): Do not check if buffer is buflisted in diagnostics.update()

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -169,10 +169,7 @@ function M.update()
     log.profile_end(profile)
 
     local bufnr = view.get_bufnr()
-    local should_draw = bufnr
-      and vim.api.nvim_buf_is_valid(bufnr)
-      and vim.api.nvim_buf_is_loaded(bufnr)
-      and vim.api.nvim_get_option_value("buflisted", { buf = bufnr })
+    local should_draw = bufnr and vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr)
     if should_draw then
       local explorer = core.get_explorer()
       if explorer then


### PR DESCRIPTION
This ensures that LSP diagnostics of files which are not manually opened by users are rendered by nvim-tree diagnostic indicators.

However when users attach an LSP to nvim-tree this will bring back flashing as attempted to fix in #2980. Fixing this should probably done by checking data passed via diagnostic events (DiagnosticChanged and CocDiagnosticChanged).