### PR TITLE
fix(api): correct argument types in `wrap_node` and `wrap_node_or_nil`

### DIFF
--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -69,7 +69,7 @@ end
 
 ---Inject the node as the first argument if present otherwise do nothing.
 ---@param fn fun(node: Node, ...): any
----@return fun(node: Node, ...): any
+---@return fun(node: Node?, ...): any
 local function wrap_node(fn)
   return function(node, ...)
     node = node or wrap_explorer("get_node_at_cursor")()
@@ -80,8 +80,8 @@ local function wrap_node(fn)
 end
 
 ---Inject the node or nil as the first argument if absent.
----@param fn fun(node: Node, ...): any
----@return fun(node: Node, ...): any
+---@param fn fun(node: Node?, ...): any
+---@return fun(node: Node?, ...): any
 local function wrap_node_or_nil(fn)
   return function(node, ...)
     node = node or wrap_explorer("get_node_at_cursor")()


### PR DESCRIPTION
The `wrap_node` and `wrap_node_or_nil` functions now correctly accept `Node?` to handle nil values, resolving a warning about incorrect argument counts in `api.tree.change_root_to_node()`.