### PR TITLE
fix(#2954): more efficient LSP updates, increase diagnostics.debounce_delay from 50ms to 500ms

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -527,7 +527,7 @@ Following is the default configuration. See |nvim-tree-opts| for details. >lua
         enable = false,
         show_on_dirs = false,
         show_on_open_dirs = true,
-        debounce_delay = 50,
+        debounce_delay = 500,
         severity = {
           min = vim.diagnostic.severity.HINT,
           max = vim.diagnostic.severity.ERROR,
@@ -1272,7 +1272,7 @@ Enable/disable the feature.
 
 *nvim-tree.diagnostics.debounce_delay*
 Idle milliseconds between diagnostic event and update.
-  Type: `number`, Default: `50` (ms)
+  Type: `number`, Default: `500` (ms)
 
 *nvim-tree.diagnostics.show_on_dirs*
 Show diagnostic icons on parent directories.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -208,16 +208,16 @@ local function setup_autocommands(opts)
 
   if opts.diagnostics.enable then
     create_nvim_tree_autocmd("DiagnosticChanged", {
-      callback = function()
+      callback = function(ev)
         log.line("diagnostics", "DiagnosticChanged")
-        require("nvim-tree.diagnostics").update()
+        require("nvim-tree.diagnostics").update_lsp(ev)
       end,
     })
     create_nvim_tree_autocmd("User", {
       pattern = "CocDiagnosticChange",
       callback = function()
         log.line("diagnostics", "CocDiagnosticChange")
-        require("nvim-tree.diagnostics").update()
+        require("nvim-tree.diagnostics").update_coc()
       end,
     })
   end
@@ -386,7 +386,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     enable = false,
     show_on_dirs = false,
     show_on_open_dirs = true,
-    debounce_delay = 50,
+    debounce_delay = 500,
     severity = {
       min = vim.diagnostic.severity.HINT,
       max = vim.diagnostic.severity.ERROR,

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -117,7 +117,9 @@ local function from_cache(node)
   return { value = max_severity, cache_version = NODE_SEVERITIES_VERSION }
 end
 
----Fired on DiagnosticChanged for a single buffer
+---Fired on DiagnosticChanged for a single buffer.
+---This will be called on set and reset of diagnostics.
+---On disabling LSP, a reset event will be sent for all buffers.
 ---@param ev table standard event with data.diagnostics populated
 function M.update_lsp(ev)
   if not M.enable or not ev or not ev.data or not ev.data.diagnostics then
@@ -171,7 +173,7 @@ function M.update_coc()
     return
   end
   utils.debounce("CocDiagnosticChanged update", M.debounce_delay, function()
-    local profile = log.profile_start("diagnostics update")
+    local profile = log.profile_start("CocDiagnosticChanged update")
     NODE_SEVERITIES = from_coc()
     NODE_SEVERITIES_VERSION = NODE_SEVERITIES_VERSION + 1
     if log.enabled("diagnostics") then


### PR DESCRIPTION
fixes #2954 

@des-b I'd be most grateful for your review and thoughts.

This changes the approach to LSP:
* examine the `DiagnosticChanged` data on the event (sync) thread
* `NODE_SEVERITIES` and `NODE_SEVERITIES_VERSION` only updated on delta
* on delta a redraw is scheduled

The debounce delay was increased as there are a _lot_ of events as the user types.

It's not clear whether a full redraw `R` is needed; it could clear `NODE_SEVERITIES` and rebuild it. YAGNI?