### PR TITLE
feat: add option to set last active window as target for file actions

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -570,6 +570,7 @@ Following is the default configuration. See |nvim-tree-opts| for details. >lua
       },
       actions = {
         use_system_clipboard = true,
+        set_last_win_as_target = true,
         change_dir = {
           enable = true,
           global = false,
@@ -1432,6 +1433,14 @@ Useful when path is not in `.gitignore` or git integration is disabled.
 A boolean value that toggle the use of system clipboard when copy/paste
 function are invoked. When enabled, copied text will be stored in registers
 '+' (system), otherwise, it will be stored in '1' and '"'.
+  Type: `boolean`, Default: `true`
+
+*nvim-tree.actions.set_last_win_as_target*
+A boolean value that toggles the behavior of setting the last active window as
+the target window for `nvim-tree`. When enabled, the last active window will be
+set as the target for file actions (like opening files), ensuring better window
+management. When disabled, the default behavior applies.
+
   Type: `boolean`, Default: `true`
 
 *nvim-tree.actions.change_dir*
@@ -2887,6 +2896,7 @@ highlight group is not, hard linking as follows: >
 |nvim-tree.actions.open_file.window_picker.picker|
 |nvim-tree.actions.remove_file.close_window|
 |nvim-tree.actions.use_system_clipboard|
+|nvim-tree.actions.set_last_win_as_target|
 |nvim-tree.auto_reload_on_write|
 |nvim-tree.diagnostics.debounce_delay|
 |nvim-tree.diagnostics.enable|

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -570,7 +570,7 @@ Following is the default configuration. See |nvim-tree-opts| for details. >lua
       },
       actions = {
         use_system_clipboard = true,
-        set_last_win_as_target = true,
+        set_last_win_as_target = false,
         change_dir = {
           enable = true,
           global = false,
@@ -1441,7 +1441,7 @@ the target window for `nvim-tree`. When enabled, the last active window will be
 set as the target for file actions (like opening files), ensuring better window
 management. When disabled, the default behavior applies.
 
-  Type: `boolean`, Default: `true`
+  Type: `boolean`, Default: `false`
 
 *nvim-tree.actions.change_dir*
 vim |current-directory| behaviour.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -232,17 +232,6 @@ local function setup_autocommands(opts)
       end,
     })
   end
-
-  if opts.actions.set_last_win_as_target then
-    create_nvim_tree_autocmd("BufLeave", {
-      callback = function()
-        local buf_name = vim.api.nvim_buf_get_name(0)
-        if not string.find(buf_name, "NvimTree_") then
-          require("nvim-tree.lib").set_target_win()
-        end
-      end,
-    })
-  end
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
@@ -440,7 +429,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   actions = {
     use_system_clipboard = true,
-    set_last_win_as_target = true,
+    set_last_win_as_target = false,
     change_dir = {
       enable = true,
       global = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -232,6 +232,17 @@ local function setup_autocommands(opts)
       end,
     })
   end
+
+  if opts.actions.set_last_win_as_target then
+    create_nvim_tree_autocmd("BufLeave", {
+      callback = function()
+        local buf_name = vim.api.nvim_buf_get_name(0)
+        if not string.find(buf_name, "NvimTree_") then
+          require("nvim-tree.lib").set_target_win()
+        end
+      end,
+    })
+  end
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
@@ -429,6 +440,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   actions = {
     use_system_clipboard = true,
+    set_last_win_as_target = true,
     change_dir = {
       enable = true,
       global = false,
@@ -490,8 +502,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       default_yes = false,
     },
   },
-  experimental = {
-  },
+  experimental = {},
   log = {
     enable = false,
     truncate = false,

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -426,6 +426,15 @@ function M.setup(opts)
     opts.actions.open_file.window_picker.chars = tostring(opts.actions.open_file.window_picker.chars):upper()
   end
   M.window_picker = opts.actions.open_file.window_picker
+  if opts.actions.set_last_win_as_target then
+    vim.api.nvim_create_autocmd("BufLeave", {
+      callback = function()
+        if utils.is_nvim_tree_buf then
+          lib.set_target_win()
+        end
+      end,
+    })
+  end
 end
 
 return M


### PR DESCRIPTION
- Add new option `set_last_win_as_target` to `opts.actions`
- Update documentation to reflect new option
- Set default value of `set_last_win_as_target` to `true`