### PR TITLE
fix(#3041): use vim.diagnostic.get for updating diagnostics

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -128,7 +128,6 @@ function M.update_lsp(ev)
 
   local profile_event = log.profile_start("DiagnosticChanged event")
 
-  ---@type vim.Diagnostic[]
   local diagnostics = vim.diagnostic.get(ev.buf)
 
   -- use the buffer from the event, as ev.data.diagnostics will be empty on resolved diagnostics

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -129,7 +129,7 @@ function M.update_lsp(ev)
   local profile_event = log.profile_start("DiagnosticChanged event")
 
   ---@type vim.Diagnostic[]
-  local diagnostics = ev.data.diagnostics
+  local diagnostics = vim.diagnostic.get(ev.buf)
 
   -- use the buffer from the event, as ev.data.diagnostics will be empty on resolved diagnostics
   local bufname = uniformize_path(vim.api.nvim_buf_get_name(ev.buf))


### PR DESCRIPTION
Fixes #3041