### PR TITLE
fix: hijack directory "BufEnter", "BufNewFile" events are nested

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -190,7 +190,7 @@ local function setup_autocommands(opts)
   end
 
   if opts.hijack_directories.enable then
-    create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
+    create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory, nested = true })
   end
 
   if opts.view.centralize_selection then


### PR DESCRIPTION
I have some autocmds on `DirChanged` to record my directory history.

Currently, with `hijack_directories` enabled, `gf` or `:e /some/dir` will jump to directory without triggering the `DirChanged` events.
