### PR TITLE
fix(#3045): wipe scratch buffers for full name and show info popups

### DIFF
--- a/lua/nvim-tree/actions/node/file-popup.lua
+++ b/lua/nvim-tree/actions/node/file-popup.lua
@@ -50,6 +50,7 @@ local function setup_window(node)
     file_path = node.absolute_path,
   }
   local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].bufhidden = "wipe"
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_win_set_buf(winnr, bufnr)
 end

--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -81,7 +81,7 @@ local function show()
 
       vim.api.nvim_buf_add_highlight(0, ns_id, details.hl_group, 0, col, details.end_col)
     end
-    vim.cmd([[ setlocal nowrap cursorline noswapfile nobuflisted buftype=nofile bufhidden=hide ]])
+    vim.cmd([[ setlocal nowrap cursorline noswapfile nobuflisted buftype=nofile bufhidden=wipe ]])
   end)
 end
 


### PR DESCRIPTION
Fixes https://github.com/nvim-tree/nvim-tree.lua/issues/3045

This PR fixes the issue of the [Scratch]-Buffer remaining after closing `full-name.lua::show()` and `require("nvim-tree.api").node.show_info_popup()`. Since I’m not sure if it covers all cases, I will add any missing parts in a timely manner. Wishing you have a great day.

Best regards !