### PR TITLE
feat(#1984): add quit_on_open and focus opts to various api.node.open functions

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2007,10 +2007,18 @@ fs.print_clipboard()                      *nvim-tree-api.fs.print_clipboard()*
 Parameters: ~
   • {node} (Node|nil) file or folder
 
-node.open.edit({node})                        *nvim-tree-api.node.open.edit()*
+node.open.edit({node}, {opts})                        *nvim-tree-api.node.open.edit()*
     File:   open as per |nvim-tree.actions.open_file|
     Folder: expand or collapse
     Root:   change directory up
+
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
 
                                *nvim-tree-api.node.open.replace_tree_buffer()*
 node.open.replace_tree_buffer({node})
@@ -2018,31 +2026,79 @@ node.open.replace_tree_buffer({node})
     nvim-tree window.
 
                                   *nvim-tree-api.node.open.no_window_picker()*
-node.open.no_window_picker({node})
+node.open.no_window_picker({node}, {opts})
     |nvim-tree-api.node.edit()|, window picker will never be used as per
     |nvim-tree.actions.open_file.window_picker.enable| `false`
 
-node.open.vertical({node})                *nvim-tree-api.node.open.vertical()*
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
+node.open.vertical({node}, {opts})                *nvim-tree-api.node.open.vertical()*
     |nvim-tree-api.node.edit()|, file will be opened in a new vertical split.
 
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
                                 *nvim-tree-api.node.open.vertical_no_picker()*
-node.open.vertical_no_picker({node})
+node.open.vertical_no_picker({node}, {opts})
     |nvim-tree-api.node.vertical()|, window picker will never be used as per
     |nvim-tree.actions.open_file.window_picker.enable| `false`
 
-node.open.horizontal({node})            *nvim-tree-api.node.open.horizontal()*
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
+node.open.horizontal({node}, {opts})            *nvim-tree-api.node.open.horizontal()*
     |nvim-tree-api.node.edit()|, file will be opened in a new horizontal split.
 
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
                               *nvim-tree-api.node.open.horizontal_no_picker()*
-node.open.horizontal_no_picker({node})
+node.open.horizontal_no_picker({node}, {opts})
     |nvim-tree-api.node.horizontal()|, window picker will never be used as per
     |nvim-tree.actions.open_file.window_picker.enable| `false`
 
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
                                 *nvim-tree-api.node.open.toggle_group_empty()*
-node.open.toggle_group_empty({node})
+node.open.toggle_group_empty({node}, {opts})
     Toggle |nvim-tree.renderer.group_empty| for a specific folder.
     Does nothing on files.
     Needs |nvim-tree.renderer.group_empty| set.
+
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
 
 node.open.drop({node})                        *nvim-tree-api.node.open.drop()*
     Switch to window with selected file if it exists.
@@ -2053,8 +2109,16 @@ node.open.drop({node})                        *nvim-tree-api.node.open.drop()*
     Folder: expand or collapse
     Root:   change directory up
 
-node.open.tab({node})                          *nvim-tree-api.node.open.tab()*
+node.open.tab({node}, {opts})                          *nvim-tree-api.node.open.tab()*
     |nvim-tree-api.node.edit()|, file will be opened in a new tab.
+
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
 
                                           *nvim-tree-api.node.open.tab_drop()*
 node.open.tab_drop({node})
@@ -2065,14 +2129,30 @@ node.open.tab_drop({node})
     Folder: expand or collapse
     Root:   change directory up
 
-node.open.preview({node})                  *nvim-tree-api.node.open.preview()*
+node.open.preview({node}, {opts})                  *nvim-tree-api.node.open.preview()*
     |nvim-tree-api.node.edit()|, file buffer will have |bufhidden| set to `delete`.
 
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
+
                                  *nvim-tree-api.node.open.preview_no_picker()*
-node.open.preview_no_picker({node})
+node.open.preview_no_picker({node}, {opts})
     |nvim-tree-api.node.edit()|, file buffer will have |bufhidden| set to `delete`.
     window picker will never be used as per
     |nvim-tree.actions.open_file.window_picker.enable| `false`
+
+    Parameters: ~
+      • {node} (Node|nil) file or folder
+      • {opts} (table) optional parameters
+
+    Options: ~
+      • {quit_on_open} (boolean) quits the tree when opening the file
+      • {focus} (boolean) keep focus in the tree when opening the file
 
 node.navigate.git.next({node})        *nvim-tree-api.node.navigate.git.next()*
     Navigate to the next item showing git status.

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -239,12 +239,14 @@ local function edit(mode, node, edit_opts)
 
   edit_opts = edit_opts or {}
 
-  if edit_opts.quit_on_open then
+  local mode_unsupported_quit_on_open = mode == "drop" or mode == "tab_drop" or mode == "edit_in_place"
+  if not mode_unsupported_quit_on_open and edit_opts.quit_on_open then
     view.close(cur_tabpage)
   end
 
+  local mode_unsupported_focus = mode == "drop" or mode == "tab_drop" or mode == "edit_in_place"
   local focus = edit_opts.focus == nil or edit_opts.focus == true
-  if not focus then
+  if not mode_unsupported_focus and not focus then
     -- if mode == "tabnew" a new tab will be opened and we need to focus back to the previous tab
     if mode == "tabnew" then
       vim.cmd(":tabprev")

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -233,12 +233,14 @@ Api.fs.copy.relative_path = wrap_node(wrap_explorer_member("clipboard", "copy_pa
 local function edit(mode, node, edit_opts)
   local file_link = node:as(FileLinkNode)
   local path = file_link and file_link.link_to or node.absolute_path
+  local cur_tabpage = vim.api.nvim_get_current_tabpage()
+
   actions.node.open_file.fn(mode, path)
 
   edit_opts = edit_opts or {}
 
   if edit_opts.quit_on_open then
-    view.close()
+    view.close(cur_tabpage)
   end
 
   local focus = edit_opts.focus == nil or edit_opts.focus == true

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -244,6 +244,7 @@ end
 ---@return fun(node: Node, edit_opts: NodeEditOpts?)
 local function open_or_expand_or_dir_up(mode, toggle_group)
   ---@param node Node
+  ---@param edit_opts NodeEditOpts?
   return function(node, edit_opts)
     local root = node:as(RootNode)
     local dir = node:as(DirectoryNode)

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -243,6 +243,10 @@ local function edit(mode, node, edit_opts)
 
   local focus = edit_opts.focus == nil or edit_opts.focus == true
   if not focus then
+    -- if mode == "tabnew" a new tab will be opened and we need to focus back to the previous tab
+    if mode == "tabnew" then
+      vim.cmd(":tabprev")
+    end
     view.focus()
   end
 end

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -225,6 +225,7 @@ Api.fs.copy.relative_path = wrap_node(wrap_explorer_member("clipboard", "copy_pa
 ---
 ---@class NodeEditOpts
 ---@field quit_on_open boolean|nil default false
+---@field focus boolean|nil default true
 
 ---@param mode string
 ---@param node Node
@@ -234,8 +235,15 @@ local function edit(mode, node, edit_opts)
   local path = file_link and file_link.link_to or node.absolute_path
   actions.node.open_file.fn(mode, path)
 
-  if edit_opts and edit_opts.quit_on_open then
+  edit_opts = edit_opts or {}
+
+  if edit_opts.quit_on_open then
     view.close()
+  end
+
+  local focus = edit_opts.focus == nil or edit_opts.focus == true
+  if not focus then
+    view.focus()
   end
 end
 

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -222,21 +222,29 @@ Api.fs.copy.absolute_path = wrap_node(wrap_explorer_member("clipboard", "copy_ab
 Api.fs.copy.filename = wrap_node(wrap_explorer_member("clipboard", "copy_filename"))
 Api.fs.copy.basename = wrap_node(wrap_explorer_member("clipboard", "copy_basename"))
 Api.fs.copy.relative_path = wrap_node(wrap_explorer_member("clipboard", "copy_path"))
+---
+---@class NodeEditOpts
+---@field quit_on_open boolean|nil default false
 
 ---@param mode string
 ---@param node Node
-local function edit(mode, node)
+---@param edit_opts NodeEditOpts?
+local function edit(mode, node, edit_opts)
   local file_link = node:as(FileLinkNode)
   local path = file_link and file_link.link_to or node.absolute_path
   actions.node.open_file.fn(mode, path)
+
+  if edit_opts and edit_opts.quit_on_open then
+    view.close()
+  end
 end
 
 ---@param mode string
 ---@param toggle_group boolean?
----@return fun(node: Node)
+---@return fun(node: Node, edit_opts: NodeEditOpts?)
 local function open_or_expand_or_dir_up(mode, toggle_group)
   ---@param node Node
-  return function(node)
+  return function(node, edit_opts)
     local root = node:as(RootNode)
     local dir = node:as(DirectoryNode)
 
@@ -245,7 +253,7 @@ local function open_or_expand_or_dir_up(mode, toggle_group)
     elseif dir then
       dir:expand_or_collapse(toggle_group)
     elseif not toggle_group then
-      edit(mode, node)
+      edit(mode, node, edit_opts)
     end
   end
 end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -270,9 +270,12 @@ function M.close_all_tabs()
   end
 end
 
-function M.close()
+---@param tabpage integer|nil
+function M.close(tabpage)
   if M.View.tab.sync.close then
     M.close_all_tabs()
+  elseif tabpage then
+    close(tabpage)
   else
     M.close_this_tab_only()
   end


### PR DESCRIPTION
fixes #1984

As discussed on #1984 , this should implement the ability of specifying the following two options in the `api.node.open.edit` method:

- `quit_on_open`: if set to true, it closes the tree when file related to the node is opened;
- `focus`: if set to ~~true~~ false, opens the file but keep the focus on the tree. Similar to what's done in the preview feature, but actually creating a new buffer for each file.

For now I've added a draft commit that supports the first option and then just checks it and closes the tree view in the edit API method.
Not sure if that's the best option, but at first I decided to not forward it to the action level to not mix it with the `quit_on_open` global option that can be passed in to the action, and also to keep the changes restricted to the API code only.

Thoughts?