### PR TITLE
fix: arithmetic on nil value error on first git project open

### DIFF
--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -391,7 +391,7 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
         end
       else
         for reason, value in pairs(FILTER_REASON) do
-          if filter_reason == value then
+          if filter_reason == value and filter_reason ~= FILTER_REASON.none then
             node.hidden_stats[reason] = node.hidden_stats[reason] + 1
           end
         end

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -389,9 +389,9 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
           nodes_by_path[child.absolute_path] = true
           child:update_git_status(node_ignored, project)
         end
-      else
+      elseif node.hidden_stats then
         for reason, value in pairs(FILTER_REASON) do
-          if filter_reason == value and filter_reason ~= FILTER_REASON.none then
+          if filter_reason == value and type(node.hidden_stats[reason]) == "number" then
             node.hidden_stats[reason] = node.hidden_stats[reason] + 1
           end
         end


### PR DESCRIPTION
When opening neovim in a directory with a git repo for the first time after PC reboot, I always got this error message:

```
Fehler beim Ausführen von "BufEnter Autokommandos für "*"":
Error executing lua callback: ...-data/lazy/nvim-tree.lua/lua/nvim-tree/explorer/init.lua:395: attempt to perform arithmetic on a nil value
stack traceback:
...-data/lazy/nvim-tree.lua/lua/nvim-tree/explorer/init.lua:395: in function 'populate_children'
...-data/lazy/nvim-tree.lua/lua/nvim-tree/explorer/init.lua:419: in function 'explore'
...-data/lazy/nvim-tree.lua/lua/nvim-tree/explorer/init.lua:328: in function '_load'
...-data/lazy/nvim-tree.lua/lua/nvim-tree/explorer/init.lua:70: in function 'new'
...l/nvim-data/lazy/nvim-tree.lua/lua/nvim-tree/classic.lua:82: in function <...l/nvim-data/lazy/nvim-tree.lua/lua/nvim-tree/
classic.lua:80>
...ocal/nvim-data/lazy/nvim-tree.lua/lua/nvim-tree/core.lua:28: in function 'init'
.../nvim-tree.lua/lua/nvim-tree/actions/root/change-dir.lua:88: in function 'f' 
.../nvim-tree.lua/lua/nvim-tree/actions/root/change-dir.lua:77: in function 'force_dirchange'
...ata/Local/nvim-data/lazy/nvim-tree.lua/lua/nvim-tree.lua:113: in function <...ata/Local/nvim-data/lazy/nvim-tree.lua/lua/nvim-tree.lua:101>
```

This small change fixes it for me. I don't looked into the code all that deep, so maybe there is a better fix.
On a quick scim through the Issues I didn't find any matching Issue, maybe I overlooked it.