### PR TITLE
fix: window picker: hide fillchars: stl and stlnc

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -80,6 +80,14 @@ local function pick_win_id()
   local win_map = {}
   local laststatus = vim.o.laststatus
   vim.o.laststatus = 2
+  local fillchars = vim.opt.fillchars:get()
+  local stl = fillchars.stl
+  local stlnc = fillchars.stlnc
+  fillchars.stl = nil
+  fillchars.stlnc = nil
+  vim.opt.fillchars = fillchars
+  fillchars.stl = stl
+  fillchars.stlnc = stlnc
 
   local tabpage = vim.api.nvim_get_current_tabpage()
   local win_ids = vim.api.nvim_tabpage_list_wins(tabpage)
@@ -179,6 +187,7 @@ local function pick_win_id()
   end
 
   vim.o.laststatus = laststatus
+  vim.opt.fillchars = fillchars
 
   if not vim.tbl_contains(vim.split(M.window_picker.chars, ""), resp) then
     return


### PR DESCRIPTION
This addresses a minor issue that I have with the window picker — if `stl` and/or `stlnc` `fillchars` are set, they are not hidden when the picker is shown:

This example uses the replication from [here](https://github.com/nvim-tree/nvim-tree.lua/wiki/Troubleshooting#clean-room-replication) together with `:set fillchars+=stl:*,stlnc:*`:

<img width="672" alt="image" src="https://github.com/user-attachments/assets/8c1c3b86-aee5-43f7-bbc9-f555a023db7e" />

The selection characters are hard to spot and hidden. This PR addresses this problem by temporarily disabling these characters when the window picker is displayed.