### PR TITLE
chore: use builtin EmmyLuaCodeStyle for style checking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ end_of_line = lf
 [nvim-tree-lua.txt]
 max_line_length = 78
 
+# keep these in sync with .luarc.json so that lua-language-server may check/apply standalone
 [*.lua]
 indent_style = space
 max_line_length = 140

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,9 @@ end_of_line = lf
 [nvim-tree-lua.txt]
 max_line_length = 78
 
-# keep these in sync with .luarc.json so that lua-language-server may check/apply standalone
+# keep these in sync with .luarc.json
+#   .editorconfig is used within nvim, overriding .luarc.json
+#   .luarc.json is used by style check
 [*.lua]
 indent_style = space
 max_line_length = 140

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   style:
     runs-on: ubuntu-latest
     env:
+      GITHUB_PATH: luals/bin
       VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     concurrency:
@@ -60,8 +61,6 @@ jobs:
         run: |
           mkdir -p luals
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
-
-      - run: echo "luals/bin" >> "$GITHUB_PATH"
 
       - name: make style
         run: make style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,30 +34,30 @@ jobs:
 
       - run: make lint
 
-  style:
-    runs-on: ubuntu-latest
+  # style:
+  #   runs-on: ubuntu-latest
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
+  #   concurrency:
+  #     group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
+  #     cancel-in-progress: true
 
-    strategy:
-      matrix:
-        luals_version: [ 3.13.9 ]
+  #   strategy:
+  #     matrix:
+  #       luals_version: [ 3.13.9 ]
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: install luals
-        run: |
-          mkdir -p luals
-          curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
+  #     - name: install luals
+  #       run: |
+  #         mkdir -p luals
+  #         curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
 
-      - run: echo "luals/bin" >> "$GITHUB_PATH"
+  #     - run: echo "luals/bin" >> "$GITHUB_PATH"
 
-      - run: make style
+  #     - run: make style
 
-      - run: make style-doc
+  #     - run: make style-doc
 
   check:
     runs-on: ubuntu-latest
@@ -92,3 +92,11 @@ jobs:
         run: make check
 
       - run: make help-check
+
+      - name: make style
+        env:
+          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
+        run: make style
+
+      - run: make style-doc
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: leafo/gh-actions-luarocks@v5
 
       - name: install luacheck ${{ matrix.luacheck_version }}
-        run: luarocks install ${{ matrix.luacheck_version }}
+        run: luarocks install luacheck ${{ matrix.luacheck_version }}
 
       - run: make lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         nvim_version: [ stable, nightly ]
-        luals_version: [ 3.11.0 ]
+        luals_version: [ 3.13.9 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
   style:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PATH: luals/bin
       VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     concurrency:
@@ -61,6 +60,7 @@ jobs:
         run: |
           mkdir -p luals
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
+          echo "luals/bin" >> "$GITHUB_PATH"
 
       - name: make style
         run: make style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,20 @@ jobs:
 
       - run: make lint
 
-  style:
+  check:
     runs-on: ubuntu-latest
-    env:
-      VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
+      group: ${{ github.workflow }}-${{ matrix.nvim_version }}-${{ matrix.luals_version }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
 
     strategy:
       matrix:
+        nvim_version: [ stable, nightly ]
         luals_version: [ 3.13.9 ]
-        nvim_version: [ stable ]
+
+    env:
+      VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     steps:
       - uses: actions/checkout@v4
@@ -62,41 +63,10 @@ jobs:
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
           echo "luals/bin" >> "$GITHUB_PATH"
 
-      - name: make style
-        run: make style
-
-      - run: make style-doc
-
-  check:
-    runs-on: ubuntu-latest
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ matrix.nvim_version }}-${{ matrix.luals_version }}-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
-
-    strategy:
-      matrix:
-        nvim_version: [ stable, nightly ]
-        luals_version: [ 3.13.9 ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
-          version: ${{ matrix.nvim_version }}
-
-      - name: install luals
-        run: |
-          mkdir -p luals
-          curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
-
-      - run: echo "luals/bin" >> "$GITHUB_PATH"
-
-      - name: make check
-        env:
-          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
-        run: make check
+      - run: make check
 
       - run: make help-check
+
+      - run: make style
+
+      - run: make style-doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,22 @@ jobs:
     strategy:
       matrix:
         lua_version: [ 5.1 ]
+        luacheck_version: [ 1.2.0 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
 
-      - uses: leafo/gh-actions-lua@v11
+      - name: install lua
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: ${{ matrix.lua_version }}
 
-      - uses: leafo/gh-actions-luarocks@v4
+      - name: install luarocks
+        uses: leafo/gh-actions-luarocks@v5
 
-      - run: luarocks install luacheck 1.1.1
+      - name: install luacheck
+        run: luarocks install ${{ matrix.luacheck_version }}
 
       - run: make lint
 
@@ -50,14 +55,16 @@ jobs:
       VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
 
-      - uses: rhysd/action-setup-vim@v1
+      - name: install nvim ${{ matrix.nvim_version }}
+        uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.nvim_version }}
 
-      - name: install luals
+      - name: install lua-language-server
         run: |
           mkdir -p luals
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,15 @@ jobs:
     strategy:
       matrix:
         luals_version: [ 3.13.9 ]
+        nvim_version: [ stable ]
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.nvim_version }}
 
       - name: install luals
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install lua
+      - name: install lua ${{ matrix.lua_version }}
         uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: ${{ matrix.lua_version }}
@@ -34,7 +34,7 @@ jobs:
       - name: install luarocks
         uses: leafo/gh-actions-luarocks@v5
 
-      - name: install luacheck
+      - name: install luacheck ${{ matrix.luacheck_version }}
         run: luarocks install ${{ matrix.luacheck_version }}
 
       - run: make lint
@@ -64,7 +64,7 @@ jobs:
           neovim: true
           version: ${{ matrix.nvim_version }}
 
-      - name: install lua-language-server
+      - name: install lua-language-server ${{ matrix.luals_version }}
         run: |
           mkdir -p luals
           curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,17 @@ jobs:
 
     strategy:
       matrix:
-        emmy_lua_code_style_version: [ 1.5.6 ]
+        luals_version: [ 3.13.9 ]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: install emmy_lua_code_style
+      - name: install luals
         run: |
-          mkdir -p CodeFormat
-          curl -L "https://github.com/CppCXY/EmmyLuaCodeStyle/releases/download/${{ matrix.emmy_lua_code_style_version }}/linux-x64.tar.gz" | tar zx --directory CodeFormat
+          mkdir -p luals
+          curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
 
-      - run: echo "CodeFormat/linux-x64/bin" >> "$GITHUB_PATH"
+      - run: echo "luals/bin" >> "$GITHUB_PATH"
 
       - run: make style
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
   style:
     runs-on: ubuntu-latest
+    env:
+      VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
@@ -62,8 +64,6 @@ jobs:
       - run: echo "luals/bin" >> "$GITHUB_PATH"
 
       - name: make style
-        env:
-          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
         run: make style
 
       - run: make style-doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
 
       - run: echo "luals/bin" >> "$GITHUB_PATH"
 
-      - run: make style
+      - name: make style
+        env:
+          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
+        run: make style
 
       - run: make style-doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,30 +34,30 @@ jobs:
 
       - run: make lint
 
-  # style:
-  #   runs-on: ubuntu-latest
+  style:
+    runs-on: ubuntu-latest
 
-  #   concurrency:
-  #     group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
-  #     cancel-in-progress: true
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.emmy_lua_code_style_version }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
 
-  #   strategy:
-  #     matrix:
-  #       luals_version: [ 3.13.9 ]
+    strategy:
+      matrix:
+        luals_version: [ 3.13.9 ]
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: install luals
-  #       run: |
-  #         mkdir -p luals
-  #         curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
+      - name: install luals
+        run: |
+          mkdir -p luals
+          curl -L "https://github.com/LuaLS/lua-language-server/releases/download/${{ matrix.luals_version }}/lua-language-server-${{ matrix.luals_version }}-linux-x64.tar.gz" | tar zx --directory luals
 
-  #     - run: echo "luals/bin" >> "$GITHUB_PATH"
+      - run: echo "luals/bin" >> "$GITHUB_PATH"
 
-  #     - run: make style
+      - run: make style
 
-  #     - run: make style-doc
+      - run: make style-doc
 
   check:
     runs-on: ubuntu-latest
@@ -92,11 +92,3 @@ jobs:
         run: make check
 
       - run: make help-check
-
-      - name: make style
-        env:
-          VIMRUNTIME: /home/runner/nvim-${{ matrix.nvim_version }}/share/nvim/runtime
-        run: make style
-
-      - run: make style-doc
-

--- a/.luarc.json
+++ b/.luarc.json
@@ -7,6 +7,18 @@
       "${3rd}/luv/library"
     ]
   },
+  "format": {
+    "defaultConfig": {
+      "indent_style": "space",
+      "max_line_length": "140",
+      "indent_size": "2",
+      "continuation_indent": "2",
+      "quote_style": "double",
+      "call_arg_parentheses": "always",
+      "space_before_closure_open_parenthesis": "false",
+      "align_continuous_similar_call_args": "true"
+    }
+  },
   "diagnostics": {
     "libraryFiles": "Disable",
     "globals": [],

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "runtime.version.luals-check-only": "Lua 5.1",
   "workspace": {
     "library": [
       "$VIMRUNTIME/lua/vim",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Lint: [luacheck](https://github.com/lunarmodules/luacheck/)
 
 Style Fixing: [EmmyLuaCodeStyle](https://github.com/CppCXY/EmmyLuaCodeStyle): `CodeCheck`
 
-nvim-tree.lua migrated from stylua to EmmyLuaCodeStyle ~2024/10. `vim.lsp.buf.format()` may be used as it is the default formatter for luals
+nvim-tree.lua migrated from stylua to EmmyLuaCodeStyle ~2024/10. `vim.lsp.buf.format()` may be used as it is the default formatter for luals, using an embedded [EmmyLuaCodeStyle](https://github.com/CppCXY/EmmyLuaCodeStyle)
 
 You can install them via you OS package manager e.g. `pacman`, `brew` or other via other package managers such as `cargo` or `luarocks`
 
@@ -43,7 +43,7 @@ make lint
 make style
 ```
 
-You can automatically fix `CodeCheck` issues via:
+You can automatically fix style issues using `CodeCheck`:
 
 ```sh
 make style-fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Language server: [luals](https://luals.github.io)
 
 Lint: [luacheck](https://github.com/lunarmodules/luacheck/)
 
-Style: [EmmyLuaCodeStyle](https://github.com/CppCXY/EmmyLuaCodeStyle): `CodeCheck`
+Style Fixing: [EmmyLuaCodeStyle](https://github.com/CppCXY/EmmyLuaCodeStyle): `CodeCheck`
 
 nvim-tree.lua migrated from stylua to EmmyLuaCodeStyle ~2024/10. `vim.lsp.buf.format()` may be used as it is the default formatter for luals
 
@@ -36,7 +36,7 @@ make lint
 
 ## style
 
-1. Runs CodeCheck using `.editorconfig` settings
+1. Runs lua language server `codestyle-check` only, using `.luarc.json` settings
 1. Runs `scripts/doc-comments.sh` to validate annotated documentation
 
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ luacheck:
 
 # --diagnosis-as-error does not function for workspace, hence we post-process the output
 style-check:
-	CodeFormat check --config .editorconfig --diagnosis-as-error --workspace lua
+	@scripts/luals-check.sh codestyle-check
 
 style-doc:
 	scripts/doc-comments.sh

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -214,8 +214,9 @@ function Explorer:reload(node, project)
     end
 
     local abs = utils.path_join({ cwd, name })
-    ---@type uv.fs_stat.result|nil
-    local stat = vim.loop.fs_lstat(abs)
+
+    -- path incorrectly specified as an integer
+    local stat = vim.loop.fs_lstat(abs) ---@diagnostic disable-line param-type-mismatch
 
     local filter_reason = self.filters:should_filter_as_reason(abs, stat, filter_status)
     if filter_reason == FILTER_REASON.none then
@@ -373,8 +374,9 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
     if Watcher.is_fs_event_capable(abs) then
       local profile = log.profile_start("populate_children %s", abs)
 
-      ---@type uv.fs_stat.result|nil
-      local stat = vim.loop.fs_lstat(abs)
+      -- path incorrectly specified as an integer
+      local stat = vim.loop.fs_lstat(abs) ---@diagnostic disable-line param-type-mismatch
+
       local filter_reason = parent.filters:should_filter_as_reason(abs, stat, filter_status)
       if filter_reason == FILTER_REASON.none and not nodes_by_path[abs] then
         local child = node_factory.create({

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -388,7 +388,7 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
         })
         if child then
           table.insert(node.nodes, child)
-            nodes_by_path[child.absolute_path] = true
+          nodes_by_path[child.absolute_path] = true
           child:update_git_status(node_ignored, project)
         end
       elseif node.hidden_stats then

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -389,7 +389,7 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
         if child then
           table.insert(node.nodes, child)
             nodes_by_path[child.absolute_path] = true
-          child:update_git_status(node_ignored, 1)
+          child:update_git_status(node_ignored, project)
         end
       elseif node.hidden_stats then
         for reason, value in pairs(FILTER_REASON) do

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -388,8 +388,8 @@ function Explorer:populate_children(handle, cwd, node, project, parent)
         })
         if child then
           table.insert(node.nodes, child)
-          nodes_by_path[child.absolute_path] = true
-          child:update_git_status(node_ignored, project)
+            nodes_by_path[child.absolute_path] = true
+          child:update_git_status(node_ignored, 1)
         end
       elseif node.hidden_stats then
         for reason, value in pairs(FILTER_REASON) do

--- a/scripts/luals-check.sh
+++ b/scripts/luals-check.sh
@@ -4,6 +4,8 @@
 # luals-out/check.json will be produced on any issues, returning 1.
 # Outputs only check.json to stdout, all other messages to stderr, to allow jq etc.
 # $VIMRUNTIME specifies neovim runtime path, defaults to "/usr/share/nvim/runtime" if unset.
+#
+# Call with codestyle-check param to enable only codestyle-check
 
 if [ -z "${VIMRUNTIME}" ]; then
 	export VIMRUNTIME="/usr/share/nvim/runtime"
@@ -17,11 +19,24 @@ FILE_LUARC="${DIR_OUT}/luarc.json"
 rm -rf "${DIR_OUT}"
 mkdir "${DIR_OUT}"
 
-# Uncomment runtime.version for strict neovim baseline 5.1
-# It is not set normally, to prevent luals loading 5.1 and 5.x, resulting in both versions being chosen on vim.lsp.buf.definition()  
-cat "${PWD}/.luarc.json" | sed -E 's/.luals-check-only//g' > "${FILE_LUARC}"
+case "${1}" in
+	"codestyle-check")
+		jq \
+			'.diagnostics.neededFileStatus[] = "None" | ''.diagnostics.neededFileStatus."codestyle-check" = "Any"' \
+			"${PWD}/.luarc.json" > "${FILE_LUARC}"
 
-# execute inside lua to prevent luals itself from being checked
+		;;
+	*)
+		# Add runtime.version for strict neovim baseline 5.1
+		# It is not set normally, to prevent luals loading 5.1 and 5.x, resulting in both versions being chosen on vim.lsp.buf.definition
+		jq \
+			'."runtime.version" = "Lua 5.1"' \
+			"${PWD}/.luarc.json" > "${FILE_LUARC}"
+
+		;;
+esac
+
+# execute inside lua directory to prevent luals itself from being checked
 OUT=$(lua-language-server --check="${DIR_SRC}" --configpath="${FILE_LUARC}" --checklevel=Information --logpath="${DIR_OUT}" --loglevel=error)
 RC=$?
 

--- a/scripts/luals-check.sh
+++ b/scripts/luals-check.sh
@@ -22,7 +22,7 @@ mkdir "${DIR_OUT}"
 case "${1}" in
 	"codestyle-check")
 		jq \
-			'.diagnostics.neededFileStatus[] = "None" | ''.diagnostics.neededFileStatus."codestyle-check" = "Any"' \
+			'.diagnostics.neededFileStatus[] = "None" | .diagnostics.neededFileStatus."codestyle-check" = "Any"' \
 			"${PWD}/.luarc.json" > "${FILE_LUARC}"
 
 		;;


### PR DESCRIPTION
update versions:
* luacheck 1.1.1 -> 1.2.0
* luarocks v4 -> v5
* lua-language-server 3.11.0 -> 3.13.9

Small ci.yml tweaks.

Use the embedded EmmyLuaCodeStyle `CodeFormat` when checking style. This makes it easier for those who don't have it installed, as well as simlifying CI.

`CodeFormat` binary is still required for fixing style; doc updated.

Contentious change: style job collapsed into check, as they have all prerequisites in common.

TODO: update required checks following merge