### PR TITLE
fix: explicitly set `border` to `"none"` in full name float

### DIFF
--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -64,6 +64,7 @@ local function show()
     height    = 1,
     noautocmd = true,
     style     = "minimal",
+    border    = "none"
   })
 
   local ns_id = vim.api.nvim_get_namespaces()["NvimTreeHighlights"]


### PR DESCRIPTION
This fixes the following problem in `nvim` `v0.11.0` onwards, when `winborder` settings is used:

`nvt-min.lua`:
```lua
vim.g.loaded_netrw = 1
vim.g.loaded_netrwPlugin = 1

vim.cmd([[set runtimepath=$VIMRUNTIME]])
vim.cmd([[set packpath=/tmp/nvt-min/site]])
local package_root = "/tmp/nvt-min/site/pack"
local install_path = package_root .. "/packer/start/packer.nvim"
local function load_plugins()
  require("packer").startup({
    {
      "wbthomason/packer.nvim",
      "nvim-tree/nvim-tree.lua",
      "nvim-tree/nvim-web-devicons",
      -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
    },
    config = {
      package_root = package_root,
      compile_path = install_path .. "/plugin/packer_compiled.lua",
      display = { non_interactive = true },
    },
  })
end
if vim.fn.isdirectory(install_path) == 0 then
  print("Installing nvim-tree and dependencies.")
  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path })
end
load_plugins()
require("packer").sync()
vim.cmd([[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]])
vim.opt.termguicolors = true
vim.opt.cursorline = true

-- MODIFY NVIM-TREE SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
_G.setup = function()
  require("nvim-tree").setup {
    renderer = {
      full_name = true
    }
  }
end

vim.opt.winborder = "rounded"
```

When the dir is not in focus:
<img width="623" alt="Image" src="https://github.com/user-attachments/assets/15cf520f-e1cb-48c6-b492-73d21e5844be" />

When the dir is focused:
<img width="623" alt="Image" src="https://github.com/user-attachments/assets/c3ba53cb-1d7e-4ff3-99b2-600d4e1b327c" />