### PR TITLE
feat: add TreePreOpen event

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2769,13 +2769,25 @@ e.g. handler for node renamed: >lua
 |nvim_tree_events_kind|
 
 - Event.Ready
-                When NvimTree has been initialized
+                When NvimTree has been initialized.
+                • Note: Handler takes no parameter.
+
+- Event.TreePreOpen
+                Invoked before the window and buffer for NvimTree are created
+                or opened. Before |Event.TreeOpen| event.
                 • Note: Handler takes no parameter.
 
 - Event.TreeOpen
+                Invoked after the NvimTree is opened.
+                • Note: Handler takes no parameter.
+
+- Event.TreePreClose
+                Invoked before the window and buffer for NvimTree are closed.
+                Before |Event.TreeClose| event.
                 • Note: Handler takes no parameter.
 
 - Event.TreeClose
+                Invoked after the NvimTree is closed.
                 • Note: Handler takes no parameter.
 
 - Event.Resize - When NvimTree is resized.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2781,13 +2781,9 @@ e.g. handler for node renamed: >lua
                 Invoked after the NvimTree is opened.
                 • Note: Handler takes no parameter.
 
-- Event.TreePreClose
-                Invoked before the window and buffer for NvimTree are closed.
-                Before |Event.TreeClose| event.
-                • Note: Handler takes no parameter.
-
 - Event.TreeClose
-                Invoked after the NvimTree is closed.
+                Invoked after the NvimTree is closed, but before the window is
+                closed. Dispatched on |WinClosed| event for NvimTree window.
                 • Note: Handler takes no parameter.
 
 - Event.Resize - When NvimTree is resized.

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -10,7 +10,6 @@ M.Event = {
   NodeRenamed = "NodeRenamed",
   TreePreOpen = "TreePreOpen",
   TreeOpen = "TreeOpen",
-  TreePreClose = "TreePreClose",
   TreeClose = "TreeClose",
   WillCreateFile = "WillCreateFile",
   FileCreated = "FileCreated",
@@ -101,11 +100,6 @@ end
 --@private
 function M._dispatch_on_tree_open()
   dispatch(M.Event.TreeOpen, nil)
-end
-
---@private
-function M._dispatch_on_tree_pre_close()
-  dispatch(M.Event.TreePreClose, nil)
 end
 
 --@private

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -8,7 +8,9 @@ M.Event = {
   Ready = "Ready",
   WillRenameNode = "WillRenameNode",
   NodeRenamed = "NodeRenamed",
+  TreePreOpen = "TreePreOpen",
   TreeOpen = "TreeOpen",
+  TreePreClose = "TreePreClose",
   TreeClose = "TreeClose",
   WillCreateFile = "WillCreateFile",
   FileCreated = "FileCreated",
@@ -92,8 +94,18 @@ function M._dispatch_folder_removed(folder_name)
 end
 
 --@private
+function M._dispatch_on_tree_pre_open()
+  dispatch(M.Event.TreePreOpen, nil)
+end
+
+--@private
 function M._dispatch_on_tree_open()
   dispatch(M.Event.TreeOpen, nil)
+end
+
+--@private
+function M._dispatch_on_tree_pre_close()
+  dispatch(M.Event.TreePreClose, nil)
 end
 
 --@private

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -110,6 +110,7 @@ function M.open(opts)
 
   local explorer = core.get_explorer()
 
+  events._dispatch_on_tree_pre_open()
   if should_hijack_current_buf() then
     view.close_this_tab_only()
     view.open_in_win()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -109,7 +109,6 @@ function M.open(opts)
 
   local explorer = core.get_explorer()
 
-  events._dispatch_on_tree_pre_open()
   if should_hijack_current_buf() then
     view.close_this_tab_only()
     view.open_in_win()

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -238,6 +238,7 @@ local function close(tabpage)
     return
   end
   save_tab_state(tabpage)
+  events._dispatch_on_tree_pre_close()
   switch_buf_if_last_buf()
   local tree_win = M.get_winnr(tabpage)
   local current_win = vim.api.nvim_get_current_win()
@@ -289,6 +290,7 @@ function M.open(options)
 
   local profile = log.profile_start("view open")
 
+  events._dispatch_on_tree_pre_open()
   create_buffer()
   open_window()
   M.resize()

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -238,7 +238,6 @@ local function close(tabpage)
     return
   end
   save_tab_state(tabpage)
-  events._dispatch_on_tree_pre_close()
   switch_buf_if_last_buf()
   local tree_win = M.get_winnr(tabpage)
   local current_win = vim.api.nvim_get_current_win()
@@ -415,6 +414,7 @@ end
 ---@param opts OpenInWinOpts|nil
 function M.open_in_win(opts)
   opts = opts or { hijack_current_buf = true, resize = true }
+  events._dispatch_on_tree_pre_open()
   if opts.winid and vim.api.nvim_win_is_valid(opts.winid) then
     vim.api.nvim_set_current_win(opts.winid)
   end


### PR DESCRIPTION
This adds 2 new events `TreePreOpen` and `TreePreClose`, which get triggered before `TreeOpen` and `TreeClose` events. They work similar to `TreeOpen` and `TreeClose`, in terms of the handler function.

This should help running logic **before** the NvimTree window is created or removed.

Let me know your thoughts.
Thanks!