### PR TITLE
fix: reliably dispatch exactly one TreeOpen and TreeClose events

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -236,6 +236,17 @@ local function setup_autocommands(opts)
       end,
     })
   end
+
+  -- Handles event dispatch when tree is closed by `:q`
+  create_nvim_tree_autocmd("WinClosed", {
+    pattern = "*",
+    ---@param ev vim.api.keyset.create_autocmd.callback_args
+    callback = function(ev)
+      if vim.api.nvim_get_option_value("filetype", { buf = ev.buf }) == "NvimTree" then
+        require("nvim-tree.events")._dispatch_on_tree_close()
+      end
+    end,
+  })
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -130,7 +130,6 @@ function M.open(opts)
     open_view_and_draw()
   end
   view.restore_tab_state()
-  events._dispatch_on_tree_open()
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -1,6 +1,5 @@
 local view = require("nvim-tree.view")
 local core = require("nvim-tree.core")
-local events = require("nvim-tree.events")
 local notify = require("nvim-tree.notify")
 
 ---@class LibOpenOpts

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -254,7 +254,6 @@ local function close(tabpage)
           return
         end
       end
-      events._dispatch_on_tree_close()
       return
     end
   end
@@ -425,6 +424,7 @@ function M.open_in_win(opts)
     M.reposition_window()
     M.resize()
   end
+  events._dispatch_on_tree_open()
 end
 
 function M.abandon_current_window()


### PR DESCRIPTION
Fixes `TreeOpen` and `TreeClose` event dispatch, per this discussion: https://github.com/nvim-tree/nvim-tree.lua/pull/3105#issuecomment-2807238355. Post this, both these events should only be dispatched exactly once in every case.

Just to note, for `TreeClose`, I found out while implementing that autocmd on `WinClosed` does not match with the file name. Instead it matches with the window ID, which we would not know (I think?).
So instead, I had to write it as a condition in the callback to check the filetype of the underlying buffer to be `NvimTree`. Do let me know if anything can be improved here.

Any other thoughts on this ? @alex-courtis 

Thanks!