### PR TITLE
fix(#3124): fix icon padding for "right_align" placements, notably for dotfiles

### DIFF
--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -135,7 +135,7 @@ end
 function Builder:format_line(indent_markers, arrows, icon, name, node)
   local added_len = 0
   local function add_to_end(t1, t2)
-    if not t2 then
+    if not t2 or vim.tbl_isempty(t2) then
       return
     end
     for _, v in ipairs(t2) do


### PR DESCRIPTION
fixes #3124 

Bug is caused in `builder.lua`:
```lua
for _, d in ipairs(self.decorators) do
  add_to_end(rights, d:icons_right_align(not d:is(UserDecorator) and node or api_node))
end
```

In the case of tracked dotfiles, `d:icons_right_align(not d:is(UserDecorator) and node or api_node)` returns `{}` from the HiddenDecorator, but inside `add_to_end(t1, t2)` we only check `if not t2`. Not sure if this was intentional, I didn't notice any unexpected behaviour while testing but there may be edge cases I hadn't thought of.