### PR TITLE
fix(#2746): background and right aligned icons in floating windows

### DIFF
--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -56,7 +56,7 @@ local function show(opts)
   -- windows width reduced by right aligned icons
   local icon_ns_id = vim.api.nvim_get_namespaces()["NvimTreeExtmarks"]
   local icon_extmarks = vim.api.nvim_buf_get_extmarks(0, icon_ns_id, { line_nr - 1, 0 }, { line_nr - 1, -1 }, { details = true })
-  text_width = text_width + view.extmarks_length(icon_extmarks)
+  text_width = text_width + utils.extmarks_length(icon_extmarks)
 
   if text_width < win_width then
     return

--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -56,7 +56,7 @@ local function show(opts)
   -- windows width reduced by right aligned icons
   local icon_ns_id = vim.api.nvim_get_namespaces()["NvimTreeExtmarks"]
   local icon_extmarks = vim.api.nvim_buf_get_extmarks(0, icon_ns_id, { line_nr - 1, 0 }, { line_nr - 1, -1 }, { details = true })
-  text_width = text_width + utils.extmarks_length(icon_extmarks)
+  win_width = win_width - utils.extmarks_length(icon_extmarks)
 
   if text_width < win_width then
     return

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -172,6 +172,21 @@ function M.find_node_line(node)
   return -1
 end
 
+---@param extmarks vim.api.keyset.get_extmark_item[] as per vim.api.nvim_buf_get_extmarks
+---@return number
+function M.extmarks_length(extmarks)
+  local length = 0
+  for _, extmark in ipairs(extmarks) do
+    local details = extmark[4]
+    if details and details.virt_text then
+      for _, text in ipairs(details.virt_text) do
+        length = length + vim.fn.strchars(text[1])
+      end
+    end
+  end
+  return length
+end
+
 -- get the node in the tree state depending on the absolute path of the node
 -- (grouped or hidden too)
 ---@param path string

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -302,21 +302,6 @@ function M.open(options)
   log.profile_end(profile)
 end
 
----@param extmarks table
----@return number
-function M.extmarks_length(extmarks)
-  local length = 0
-  for _, extmark in ipairs(extmarks) do
-    local details = extmark[4]
-    if details and details.virt_text then
-      for _, text in ipairs(details.virt_text) do
-        length = length + vim.fn.strchars(text[1])
-      end
-    end
-  end
-  return length
-end
-
 local function grow()
   local starts_at = M.is_root_folder_visible(require("nvim-tree.core").get_cwd()) and 1 or 0
   local lines = vim.api.nvim_buf_get_lines(M.get_bufnr(), starts_at, -1, false)
@@ -344,7 +329,7 @@ local function grow()
     local count = vim.fn.strchars(l)
     -- also add space for right-aligned icons
     local extmarks = vim.api.nvim_buf_get_extmarks(M.get_bufnr(), ns_id, { line_nr, 0 }, { line_nr, -1 }, { details = true })
-    count = count + M.extmarks_length(extmarks)
+    count = count + utils.extmarks_length(extmarks)
     if resizing_width < count then
       resizing_width = count
     end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -302,6 +302,21 @@ function M.open(options)
   log.profile_end(profile)
 end
 
+---@param extmarks table
+---@return number
+function M.extmarks_length(extmarks)
+  local length = 0
+  for _, extmark in ipairs(extmarks) do
+    local details = extmark[4]
+    if details and details.virt_text then
+      for _, text in ipairs(details.virt_text) do
+        length = length + vim.fn.strchars(text[1])
+      end
+    end
+  end
+  return length
+end
+
 local function grow()
   local starts_at = M.is_root_folder_visible(require("nvim-tree.core").get_cwd()) and 1 or 0
   local lines = vim.api.nvim_buf_get_lines(M.get_bufnr(), starts_at, -1, false)
@@ -329,14 +344,7 @@ local function grow()
     local count = vim.fn.strchars(l)
     -- also add space for right-aligned icons
     local extmarks = vim.api.nvim_buf_get_extmarks(M.get_bufnr(), ns_id, { line_nr, 0 }, { line_nr, -1 }, { details = true })
-    for _, extmark in ipairs(extmarks) do
-      local virt_texts = extmark[4].virt_text
-      if virt_texts then
-        for _, virt_text in ipairs(virt_texts) do
-          count = count + vim.fn.strchars(virt_text[1])
-        end
-      end
-    end
+    count = count + M.extmarks_length(extmarks)
     if resizing_width < count then
       resizing_width = count
     end


### PR DESCRIPTION
Closes https://github.com/nvim-tree/nvim-tree.lua/issues/2746

Also I added functionality for copying over right-aligned icons to the float.

Before:

<img width="471" alt="Screenshot 2025-05-16 at 8 48 57" src="https://github.com/user-attachments/assets/5174cb88-8c29-409e-92b9-d56fe69bbce5" />

After:

<img width="471" alt="Screenshot 2025-05-16 at 8 47 58" src="https://github.com/user-attachments/assets/9b6bef58-6a9b-4e16-a6a9-87f0cf8393c8" />

