### PR TITLE
fix: "Invalid buffer id" on closing nvim-tree window

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -242,6 +242,9 @@ local function setup_autocommands(opts)
     pattern = "*",
     ---@param ev vim.api.keyset.create_autocmd.callback_args
     callback = function(ev)
+      if not vim.api.nvim_buf_is_valid(ev.buf) then
+        return
+      end
       if vim.api.nvim_get_option_value("filetype", { buf = ev.buf }) == "NvimTree" then
         require("nvim-tree.events")._dispatch_on_tree_close()
       end


### PR DESCRIPTION
Hello there,

I got the following error if I try to close the [mcphub.nvim](https://github.com/ravitemer/mcphub.nvim) window with q. This fixes this error:

![image](https://github.com/user-attachments/assets/67be41e4-8adf-4a9e-99b9-7b24a31c5f89)