### PR TITLE
fix(#3143): actions.open_file.window_picker.exclude applies when not using window picker

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1523,7 +1523,8 @@ Configuration options for opening a file from nvim-tree.
 
         *nvim-tree.actions.open_file.window_picker.enable*
         Enable the feature. If the feature is not enabled, files will open in
-        window from which you last opened the tree.
+        window from which you last opened the tree, obeying
+        |nvim-tree.actions.open_file.window_picker.exclude|
           Type: `boolean`, Default: `true`
 
         *nvim-tree.actions.open_file.window_picker.picker*
@@ -1542,9 +1543,10 @@ Configuration options for opening a file from nvim-tree.
           Type: `string`, Default: `"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"`
 
         *nvim-tree.actions.open_file.window_picker.exclude*
-        Table of buffer option names mapped to a list of option values that
-        indicates to the picker that the buffer's window should not be
-        selectable.
+        Table of buffer option names mapped to a list of option values.
+        Windows containing matching buffers will not be:
+        - available when using a window picker
+        - selected when not using a window picker
           Type: `table`, Default: >lua
             {
               filetype = {

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -43,17 +43,6 @@ local function usable_win_ids()
   end, win_ids)
 end
 
----Find the first window in the tab that is not NvimTree.
----@return integer -1 if none available
-local function first_win_id()
-  local selectable = usable_win_ids()
-  if #selectable > 0 then
-    return selectable[1]
-  else
-    return -1
-  end
-end
-
 ---Get user to pick a window in the tab that is not NvimTree.
 ---@return integer|nil -- If a valid window was picked, return its id. If an
 ---       invalid window was picked / user canceled, return nil. If there are
@@ -246,9 +235,14 @@ local function get_target_winid(mode)
   local target_winid
   if not M.window_picker.enable or string.find(mode, "no_picker") then
     target_winid = lib.target_winid
-    -- first available window
-    if not vim.tbl_contains(vim.api.nvim_tabpage_list_wins(0), target_winid) then
-      target_winid = first_win_id()
+    local usable_wins = usable_win_ids()
+    -- first available usable window
+    if not vim.tbl_contains(usable_wins, target_winid) then
+      if #usable_wins > 0 then
+        target_winid = usable_wins[1]
+      else
+        target_winid = -1
+      end
     end
   else
     -- pick a window


### PR DESCRIPTION
### Description

This PR ensures that when using `open.no_window_picker`, the fallback window selection respects the `window_picker.exclude` configuration.
Previously, if no window picker was used, nvim-tree would open the file in the last active window, even if that window matched an excluded type (e.g., a terminal).
Now it sets the fallback window as the first available usable window, not excluded in the configuration, which can prevent undesired behavior.

### Related Issue

Fixes #3143

### Additional Notes

I removed the `first_win_id` function to avoid redundant calls to `usable_win_ids`. Happy to adjust if you'd like to keep it.

Let me know if there’s any other adjustment or further cleanup you’d like.
Appreciate your time and review!