### PR TITLE
fix: window picker ignore hidden window

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -39,7 +39,7 @@ local function usable_win_ids()
     end
 
     local win_config = vim.api.nvim_win_get_config(id)
-    return id ~= tree_winid and win_config.focusable and not win_config.external or false
+    return id ~= tree_winid and win_config.focusable and not win_config.hide and not win_config.external or false
   end, win_ids)
 end
 


### PR DESCRIPTION
Hidden win should never be used as target.

## repro
Use neovim nightly
```lua
for name, url in pairs {
  nvt = 'https://github.com/nvim-tree/nvim-tree.lua',
} do
  local install_path = vim.fn.fnamemodify('nvim_issue/' .. name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end
require('nvim-tree').setup {}
require('vim._extui').enable({})
```

```sh
nvim --clean -u nvim-tree-hide.lua +"%bd!" +NvimTreeOpen
```
