### PR TITLE
fix: invalid window id for popup info window

### DIFF
--- a/lua/nvim-tree/actions/node/file-popup.lua
+++ b/lua/nvim-tree/actions/node/file-popup.lua
@@ -57,7 +57,9 @@ end
 
 function M.close_popup()
   if current_popup ~= nil then
-    vim.api.nvim_win_close(current_popup.winnr, true)
+    if vim.api.nvim_win_is_valid(current_popup.winnr) then
+      vim.api.nvim_win_close(current_popup.winnr, true)
+    end
     vim.cmd("augroup NvimTreeRemoveFilePopup | au! CursorMoved | augroup END")
 
     current_popup = nil


### PR DESCRIPTION
Hi, this solves an error when the info window is closed via `fclose` - `vim.cmd("fclose")`. I have this in a keymap bind to `ESC` and get this error: 

```
x Error  12:13:38 msg_show.lua_error Error detected while processing CursorMoved Autocommands for "*":
Error executing lua callback: .../nvim-tree.lua/lua/nvim-tree/actions/node/file-popup.lua:60: Invalid window id: 1004
stack traceback:
[C]: in function 'nvim_win_close'
.../nvim-tree.lua/lua/nvim-tree/actions/node/file-popup.lua:60: in function <.../nvim-tree.lua/lua/nvim-tree/actions/node/file-popup.lua:58>
```

The fix is to check if window id is still valid.