### PR TITLE
docs: fix renderer.icons.bookmarks_placement parameter, misspelling

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1066,7 +1066,7 @@ Configuration options for icons.
 
     *nvim-tree.renderer.icons.bookmarks_placement*
     Bookmark icon placement.
-      Type: `string`, Default: `signcolumn`
+      Type: `string`, Default: `"signcolumn"`
 
     *nvim-tree.renderer.icons.padding.icon*
     Inserted between icon and filename.
@@ -1380,7 +1380,7 @@ delete/wipe. A reload or filesystem event will result in an update.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.filters.no_bookmark*
-Do not show files that are not bookarked.
+Do not show files that are not bookmarked.
 Toggle via |nvim-tree-api.tree.toggle_no_bookmark_filter()|, default `M`
 Enabling this is not useful as there is no means yet to persist bookmarks.
   Type: `boolean`, Default: `false`


### PR DESCRIPTION
👋🏻 hey folks,

I am refreshing my NeoVim config due to 0.11 upgrade and was reading through the `nvim-tree` docs and noticed a few issues, so decided to open a PR to fix them (least I can do to support such a great plugin 😅).

Add a missing double quotes around the default value for `nvim-tree.renderer.icons.bookmarks_placement` config value and fix spelling of `bookmarked`.

Cheers,
Garry