### PR TITLE
fix(picker): exclude full_name window id from the choice

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -3,6 +3,7 @@ local lib = require("nvim-tree.lib")
 local notify = require("nvim-tree.notify")
 local utils = require("nvim-tree.utils")
 local core = require("nvim-tree.core")
+local full_name = require("nvim-tree.renderer.components.full-name")
 
 local M = {}
 
@@ -40,7 +41,12 @@ local function usable_win_ids()
     end
 
     local win_config = vim.api.nvim_win_get_config(id)
-    return id ~= tree_winid and win_config.focusable and not win_config.hide and not win_config.external or false
+    return id ~= tree_winid
+      and id ~= full_name.popup_win
+      and win_config.focusable
+      and not win_config.hide
+      and not win_config.external
+      or false
   end, win_ids)
 end
 


### PR DESCRIPTION
Problem: `full_name` window from is considered as usable by picker
Solution: exclude its ID (also true for nil values)