### PR TITLE
fix(#3077): deleting a directory containing symlinked directory will delete the contents of the linked directory

### DIFF
--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -71,6 +71,8 @@ local function remove_dir(cwd)
 
     -- Type must come from fs_stat and not fs_scandir_next to maintain sshfs compatibility
     local stat = vim.loop.fs_stat(new_cwd)
+    -- TODO remove once 0.12 is the minimum neovim version
+    -- path incorrectly specified as an integer, fixed upstream for neovim 0.12 https://github.com/neovim/neovim/pull/33872
     ---@diagnostic disable-next-line: param-type-mismatch
     local lstat = vim.loop.fs_lstat(new_cwd)
 

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -71,9 +71,14 @@ local function remove_dir(cwd)
 
     -- Type must come from fs_stat and not fs_scandir_next to maintain sshfs compatibility
     local stat = vim.loop.fs_stat(new_cwd)
-    local type = stat and stat.type or nil
+    ---@diagnostic disable-next-line: param-type-mismatch
+    local lstat = vim.loop.fs_lstat(new_cwd)
 
-    if type == "directory" then
+    local type = stat and stat.type or nil
+    -- Checks if file is a link file to ensure deletion of the symlink instead of the file it points to
+    local ltype = lstat and lstat.type or nil
+
+    if type == "directory" and ltype ~= "link" then
       local success = remove_dir(new_cwd)
       if not success then
         return false


### PR DESCRIPTION
Fixed issue #3077 
The problem was that nvim-tree did not check if the file was a symlink, and the method `vim.loop.fs_stat(cwd)` returns the filetype of the file that the symlink points to, not the type of file the symlink is. I simply added a check `vim.loop.fs_lstat(new_cwd)`, which returns an object with type == "link" if the file is a symlink. 