### PR TITLE
revert(#3180, #3177): invalid group or tabpage

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -639,6 +639,7 @@ Following is the default configuration. See |nvim-tree-opts| for details. >lua
         },
       },
       experimental = {
+        multi_instance = false,
       },
       log = {
         enable = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -486,6 +486,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
   },
   experimental = {
+    multi_instance = false,
   },
   log = {
     enable = false,
@@ -668,7 +669,7 @@ function M.purge_all_state()
   local explorer = core.get_explorer()
   if explorer then
     explorer.view:close_all_tabs()
-    explorer.view:abandon_all_windows()
+    explorer.view:abandon_all_windows("purge_all_state")
     require("nvim-tree.git").purge_state()
     explorer:destroy()
     core.reset_explorer()
@@ -726,6 +727,7 @@ function M.setup(conf)
   require("nvim-tree.buffers").setup(opts)
   require("nvim-tree.help").setup(opts)
   require("nvim-tree.watcher").setup(opts)
+  require("nvim-tree.multi-instance-debug").setup(opts)
 
   setup_autocommands(opts)
 

--- a/lua/nvim-tree/actions/fs/remove-file.lua
+++ b/lua/nvim-tree/actions/fs/remove-file.lua
@@ -18,7 +18,7 @@ local function close_windows(windows)
   -- Prevent from closing when the win count equals 1 or 2,
   -- where the win to remove could be the last opened.
   -- For details see #2503.
-  if explorer and explorer.opts.view.float.enable and #vim.api.nvim_list_wins() < 3 then
+  if explorer and explorer.view.float.enable and #vim.api.nvim_list_wins() < 3 then
     return
   end
 
@@ -36,12 +36,12 @@ local function clear_buffer(absolute_path)
   for _, buf in pairs(bufs) do
     if buf.name == absolute_path then
       local tree_winnr = vim.api.nvim_get_current_win()
-      if buf.hidden == 0 and (#bufs > 1 or explorer and explorer.opts.view.float.enable) then
+      if buf.hidden == 0 and (#bufs > 1 or explorer and explorer.view.float.enable) then
         vim.api.nvim_set_current_win(buf.windows[1])
         vim.cmd(":bn")
       end
       vim.api.nvim_buf_delete(buf.bufnr, { force = true })
-      if explorer and not explorer.opts.view.float.quit_on_focus_loss then
+      if explorer and not explorer.view.float.quit_on_focus_loss then
         vim.api.nvim_set_current_win(tree_winnr)
       end
       if M.config.actions.remove_file.close_window then

--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -23,7 +23,7 @@ local function usable_win_ids()
   local explorer = core.get_explorer()
   local tabpage = vim.api.nvim_get_current_tabpage()
   local win_ids = vim.api.nvim_tabpage_list_wins(tabpage)
-  local tree_winid = explorer and explorer.view:get_winid(tabpage)
+  local tree_winid = explorer and explorer.view:get_winnr(tabpage, "open-file.usable_win_ids")
 
   return vim.tbl_filter(function(id)
     local bufid = vim.api.nvim_win_get_buf(id)
@@ -196,7 +196,7 @@ local function open_file_in_tab(filename)
   if M.quit_on_open then
     local explorer = core.get_explorer()
     if explorer then
-      explorer.view:close()
+      explorer.view:close(nil, "open-file.open_file_in_tab")
     end
   end
   if M.relative_path then
@@ -209,7 +209,7 @@ local function drop(filename)
   if M.quit_on_open then
     local explorer = core.get_explorer()
     if explorer then
-      explorer.view:close()
+      explorer.view:close(nil, "open-file.drop")
     end
   end
   if M.relative_path then
@@ -222,7 +222,7 @@ local function tab_drop(filename)
   if M.quit_on_open then
     local explorer = core.get_explorer()
     if explorer then
-      explorer.view:close()
+      explorer.view:close(nil, "open-file.tab_drop")
     end
   end
   if M.relative_path then
@@ -352,7 +352,7 @@ local function open_in_new_window(filename, mode)
     end
   end
 
-  if (mode == "preview" or mode == "preview_no_picker") and explorer and explorer.opts.view.float.enable then
+  if (mode == "preview" or mode == "preview_no_picker") and explorer and explorer.view.float.enable then
     -- ignore "WinLeave" autocmd on preview
     -- because the registered "WinLeave"
     -- will kill the floating window immediately
@@ -453,7 +453,7 @@ function M.fn(mode, filename)
   end
 
   if M.quit_on_open and explorer then
-    explorer.view:close()
+    explorer.view:close(nil, "open-file.fn")
   end
 end
 

--- a/lua/nvim-tree/actions/root/change-dir.lua
+++ b/lua/nvim-tree/actions/root/change-dir.lua
@@ -85,7 +85,7 @@ M.force_dirchange = add_profiling_to(function(foldername, should_open_view)
     if should_change_dir() then
       cd(M.options.global, foldername)
     end
-    core.init(foldername)
+    core.init(foldername, "change-dir")
   end
 
   if should_open_view then

--- a/lua/nvim-tree/actions/tree/toggle.lua
+++ b/lua/nvim-tree/actions/tree/toggle.lua
@@ -44,7 +44,7 @@ function M.fn(opts, no_focus, cwd, bang)
 
   if explorer and explorer.view:is_visible() then
     -- close
-    explorer.view:close()
+    explorer.view:close(nil, "toggle.fn")
   else
     -- open
     lib.open({

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -247,7 +247,7 @@ local function edit(mode, node, edit_opts)
   local mode_unsupported_quit_on_open = mode == "drop" or mode == "tab_drop" or mode == "edit_in_place"
   if not mode_unsupported_quit_on_open and edit_opts.quit_on_open then
     if explorer then
-      explorer.view:close(cur_tabpage)
+      explorer.view:close(cur_tabpage, "api.edit " .. mode)
     end
   end
 

--- a/lua/nvim-tree/core.lua
+++ b/lua/nvim-tree/core.lua
@@ -9,8 +9,11 @@ local TreeExplorer = nil
 local first_init_done = false
 
 ---@param foldername string
-function M.init(foldername)
+---@param callsite string
+function M.init(foldername, callsite)
   local profile = log.profile_start("core init %s", foldername)
+
+  log.line("dev", "core.init(%s, %s)", foldername, callsite)
 
   if TreeExplorer then
     TreeExplorer:destroy()

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -185,7 +185,7 @@ function M.update_coc()
 
     local bufnr
     if explorer then
-      bufnr = explorer.view:get_bufnr()
+      bufnr = explorer.view:get_bufnr("diagnostics.update_coc")
     end
 
     local should_draw = bufnr and vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr)

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -165,6 +165,22 @@ function Explorer:create_autocmds()
     end,
   })
 
+  -- prevent new opened file from opening in the same window as nvim-tree
+  vim.api.nvim_create_autocmd("BufWipeout", {
+    group = self.augroup_id,
+    pattern = "NvimTree_*",
+    callback = function()
+      if not utils.is_nvim_tree_buf(0) then
+        return
+      end
+      if self.opts.actions.open_file.eject then
+        self.view:prevent_buffer_override()
+      else
+        self.view:abandon_current_window()
+      end
+    end,
+  })
+
   vim.api.nvim_create_autocmd("BufEnter", {
     group = self.augroup_id,
     pattern = "NvimTree_*",

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -105,9 +105,12 @@ function Explorer:create_autocmds()
     vim.api.nvim_create_autocmd("WinLeave", {
       group = self.augroup_id,
       pattern = "NvimTree_*",
-      callback = function()
+      callback = function(data)
+        if self.opts.experimental.multi_instance then
+          log.line("dev", "WinLeave %s", vim.inspect(data, { newline = "" }))
+        end
         if utils.is_nvim_tree_buf(0) then
-          self.view:close()
+          self.view:close(nil, "WinLeave")
         end
       end,
     })
@@ -169,7 +172,10 @@ function Explorer:create_autocmds()
   vim.api.nvim_create_autocmd("BufWipeout", {
     group = self.augroup_id,
     pattern = "NvimTree_*",
-    callback = function()
+    callback = function(data)
+      if self.opts.experimental.multi_instance then
+        log.line("dev", "BufWipeout %s", vim.inspect(data, { newline = "" }))
+      end
       if not utils.is_nvim_tree_buf(0) then
         return
       end
@@ -548,7 +554,7 @@ end
 ---nil on no explorer or invalid view win
 ---@return integer[]|nil
 function Explorer:get_cursor_position()
-  local winnr = self.view:get_winid()
+  local winnr = self.view:get_winnr(nil, "Explorer:get_cursor_position")
   if not winnr or not vim.api.nvim_win_is_valid(winnr) then
     return
   end

--- a/lua/nvim-tree/explorer/live-filter.lua
+++ b/lua/nvim-tree/explorer/live-filter.lua
@@ -61,7 +61,7 @@ local overlay_bufnr = 0
 local overlay_winnr = 0
 
 local function remove_overlay(self)
-  if self.explorer.opts.view.float.enable and self.explorer.opts.view.float.quit_on_focus_loss then
+  if self.explorer.view.float.enable and self.explorer.view.float.quit_on_focus_loss then
     -- return to normal nvim-tree float behaviour when filter window is closed
     vim.api.nvim_create_autocmd("WinLeave", {
       pattern = "NvimTree_*",
@@ -171,7 +171,7 @@ local function calculate_overlay_win_width(self)
 end
 
 local function create_overlay(self)
-  if self.explorer.opts.view.float.enable then
+  if self.explorer.view.float.enable then
     -- don't close nvim-tree float when focus is changed to filter window
     vim.api.nvim_clear_autocmds({
       event   = "WinLeave",

--- a/lua/nvim-tree/explorer/view.lua
+++ b/lua/nvim-tree/explorer/view.lua
@@ -7,19 +7,31 @@ local globals = require("nvim-tree.globals")
 
 local Class = require("nvim-tree.classic")
 
----Window and buffer related settings and operations
+---@class OpenInWinOpts
+---@field hijack_current_buf boolean|nil default true
+---@field resize boolean|nil default true
+---@field winid number|nil 0 or nil for current
+
+local DEFAULT_MIN_WIDTH = 30
+local DEFAULT_MAX_WIDTH = -1
+local DEFAULT_PADDING = 1
+
 ---@class (exact) View: Class
 ---@field live_filter table
 ---@field side string
+---@field float table
 ---@field private explorer Explorer
 ---@field private adaptive_size boolean
+---@field private centralize_selection boolean
+---@field private hide_root_folder boolean
 ---@field private winopts table
+---@field private height integer
+---@field private preserve_window_proportions boolean
 ---@field private initial_width integer
 ---@field private width (fun():integer)|integer|string
 ---@field private max_width integer
 ---@field private padding integer
--- TODO multi-instance remove or replace with single member
----@field private bufnr_by_tabid table<integer, integer>
+---@field private bufnr_by_tab table<integer, integer> stored per tab until multi-instance is complete
 local View = Class:extend()
 
 ---@class View
@@ -33,13 +45,18 @@ local View = Class:extend()
 function View:new(args)
   args.explorer:log_new("View")
 
-  self.explorer         = args.explorer
-  self.adaptive_size    = false
-  self.side             = (self.explorer.opts.view.side == "right") and "right" or "left"
-  self.live_filter      = { prev_focused_node = nil, }
-  self.bufnr_by_tabid   = {}
+  self.explorer                    = args.explorer
+  self.adaptive_size               = false
+  self.centralize_selection        = self.explorer.opts.view.centralize_selection
+  self.float                       = self.explorer.opts.view.float
+  self.height                      = self.explorer.opts.view.height
+  self.hide_root_folder            = self.explorer.opts.renderer.root_folder_label == false
+  self.preserve_window_proportions = self.explorer.opts.view.preserve_window_proportions
+  self.side                        = (self.explorer.opts.view.side == "right") and "right" or "left"
+  self.live_filter                 = { prev_focused_node = nil, }
+  self.bufnr_by_tab                = {}
 
-  self.winopts          = {
+  self.winopts                     = {
     relativenumber = self.explorer.opts.view.relativenumber,
     number         = self.explorer.opts.view.number,
     list           = false,
@@ -60,15 +77,19 @@ function View:new(args)
 
   self:configure_width(self.explorer.opts.view.width)
   self.initial_width = self:get_width()
-
-  -- TODO multi-instance remove this; delete buffers rather than retaining them
-  local tabid = vim.api.nvim_get_current_tabpage()
-  self.bufnr_by_tabid[tabid] = globals.BUFNR_BY_TABID[tabid]
 end
 
 function View:destroy()
   self.explorer:log_destroy("View")
 end
+
+-- The initial state of a tab
+local tabinitial = {
+  -- The position of the cursor { line, column }
+  cursor = { 0, 0 },
+  -- The NvimTree window number
+  winnr = nil,
+}
 
 ---@type { name: string, value: any }[]
 local BUFFER_OPTIONS = {
@@ -80,12 +101,11 @@ local BUFFER_OPTIONS = {
   { name = "swapfile",   value = false },
 }
 
--- TODO multi-instance remove this; delete buffers rather than retaining them
 ---@private
 ---@param bufnr integer
 ---@return boolean
 function View:matches_bufnr(bufnr)
-  for _, b in pairs(globals.BUFNR_BY_TABID) do
+  for _, b in pairs(globals.BUFNR_PER_TAB) do
     if b == bufnr then
       return true
     end
@@ -93,7 +113,6 @@ function View:matches_bufnr(bufnr)
   return false
 end
 
--- TODO multi-instance remove this; delete buffers rather than retaining them
 ---@private
 function View:wipe_rogue_buffer()
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
@@ -108,23 +127,23 @@ end
 function View:create_buffer(bufnr)
   self:wipe_rogue_buffer()
 
-  local tabid = vim.api.nvim_get_current_tabpage()
+  local tab = vim.api.nvim_get_current_tabpage()
+  globals.BUFNR_PER_TAB[tab] = bufnr or vim.api.nvim_create_buf(false, false)
 
-  bufnr = bufnr or vim.api.nvim_create_buf(false, false)
+  if self.explorer.opts.experimental.multi_instance then
+    self.bufnr_by_tab[tab] = globals.BUFNR_PER_TAB[tab]
+  end
 
-  -- set both bufnr registries
-  globals.BUFNR_BY_TABID[tabid] = bufnr
-  self.bufnr_by_tabid[tabid] = bufnr
+  vim.api.nvim_buf_set_name(self:get_bufnr("View:create_buffer1"), "NvimTree_" .. tab)
 
-  vim.api.nvim_buf_set_name(bufnr, "NvimTree_" .. tabid)
-
+  bufnr = self:get_bufnr("View:create_buffer2")
   for _, option in ipairs(BUFFER_OPTIONS) do
     vim.api.nvim_set_option_value(option.name, option.value, { buf = bufnr })
   end
 
-  require("nvim-tree.keymap").on_attach(bufnr)
+  require("nvim-tree.keymap").on_attach(self:get_bufnr("View:create_buffer3"))
 
-  events._dispatch_tree_attached_post(bufnr)
+  events._dispatch_tree_attached_post(self:get_bufnr("View:create_buffer4"))
 end
 
 ---@private
@@ -156,9 +175,27 @@ local move_tbl = {
   right = "L",
 }
 
+-- setup_tabpage sets up the initial state of a tab
+---@private
+---@param tabpage integer
+---@param callsite string
+function View:setup_tabpage(tabpage, callsite)
+  local winnr = vim.api.nvim_get_current_win()
+
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:setup_tabpage(%3s, %-20.20s) w%d %s",
+      tabpage,
+      callsite,
+      winnr,
+      globals.TABPAGES[tabpage] and vim.inspect(globals.TABPAGES[tabpage], { newline = "" }) or "tabinitial")
+  end
+
+  globals.TABPAGES[tabpage] = vim.tbl_extend("force", globals.TABPAGES[tabpage] or tabinitial, { winnr = winnr })
+end
+
 ---@private
 function View:set_window_options_and_buffer()
-  pcall(vim.api.nvim_command, "buffer " .. self:get_bufnr())
+  pcall(vim.api.nvim_command, "buffer " .. self:get_bufnr("View:set_window_options_and_buffer"))
 
   if vim.fn.has("nvim-0.10") == 1 then
     local eventignore = vim.api.nvim_get_option_value("eventignore", {})
@@ -186,22 +223,22 @@ end
 ---@private
 ---@return table
 function View:open_win_config()
-  if type(self.explorer.opts.view.float.open_win_config) == "function" then
-    return self.explorer.opts.view.float.open_win_config()
+  if type(self.float.open_win_config) == "function" then
+    return self.float.open_win_config()
   else
-    return self.explorer.opts.view.float.open_win_config
+    return self.float.open_win_config
   end
 end
 
 ---@private
 function View:open_window()
-  if self.explorer.opts.view.float.enable then
+  if self.float.enable then
     vim.api.nvim_open_win(0, true, self:open_win_config())
   else
     vim.api.nvim_command("vsp")
     self:reposition_window()
   end
-  globals.WINID_BY_TABID[vim.api.nvim_get_current_tabpage()] = vim.api.nvim_get_current_win()
+  self:setup_tabpage(vim.api.nvim_get_current_tabpage(), "View:open_window")
   self:set_window_options_and_buffer()
 end
 
@@ -236,31 +273,37 @@ local function switch_buf_if_last_buf()
   end
 end
 
----save any state that should be preserved on reopening
+---save_tab_state saves any state that should be preserved across redraws.
 ---@private
----@param tabid integer
-function View:save_state(tabid)
-  tabid = tabid or vim.api.nvim_get_current_tabpage()
-  globals.CURSORS[tabid] = vim.api.nvim_win_get_cursor(self:get_winid(tabid) or 0)
+---@param tabnr integer
+function View:save_tab_state(tabnr)
+  local tabpage = tabnr or vim.api.nvim_get_current_tabpage()
+  globals.CURSORS[tabpage] = vim.api.nvim_win_get_cursor(self:get_winnr(tabpage, "View:save_tab_state") or 0)
 end
 
 ---@private
----@param tabid integer
-function View:close_internal(tabid)
-  if not self:is_visible({ tabpage = tabid }) then
+---@param tabpage integer
+function View:close_internal(tabpage)
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:close_internal(t%s)", tabpage)
+  end
+  if not self:is_visible({ tabpage = tabpage }) then
     return
   end
-  self:save_state(tabid)
+  self:save_tab_state(tabpage)
   switch_buf_if_last_buf()
-  local tree_win = self:get_winid(tabid)
+  local tree_win = self:get_winnr(tabpage, "View:close_internal")
   local current_win = vim.api.nvim_get_current_win()
-  for _, win in pairs(vim.api.nvim_tabpage_list_wins(tabid)) do
+  for _, win in pairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
     if vim.api.nvim_win_get_config(win).relative == "" then
       local prev_win = vim.fn.winnr("#") -- this tab only
       if tree_win == current_win and prev_win > 0 then
         vim.api.nvim_set_current_win(vim.fn.win_getid(prev_win))
       end
       if vim.api.nvim_win_is_valid(tree_win or 0) then
+        if self.explorer.opts.experimental.multi_instance then
+          log.line("dev", "View:close_internal(t%s) w%s", tabpage, tree_win)
+        end
         local success, error = pcall(vim.api.nvim_win_close, tree_win or 0, true)
         if not success then
           notify.debug("Failed to close window: " .. error)
@@ -276,19 +319,23 @@ function View:close_this_tab_only()
   self:close_internal(vim.api.nvim_get_current_tabpage())
 end
 
--- TODO this is broken at 1.13.0 - current tab does not close when tab.sync.close is set
 function View:close_all_tabs()
-  for tabid, _ in pairs(globals.WINID_BY_TABID) do
-    self:close_internal(tabid)
+  for tabpage, _ in pairs(globals.TABPAGES) do
+    self:close_internal(tabpage)
   end
 end
 
----@param tabid integer|nil
-function View:close(tabid)
+---@param tabpage integer|nil
+---@param callsite string
+function View:close(tabpage, callsite)
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:close(t%s, %s)", tabpage, callsite)
+  end
+
   if self.explorer.opts.tab.sync.close then
     self:close_all_tabs()
-  elseif tabid then
-    self:close_internal(tabid)
+  elseif tabpage then
+    self:close_internal(tabpage)
   else
     self:close_this_tab_only()
   end
@@ -319,12 +366,12 @@ end
 ---@private
 function View:grow()
   local starts_at = self:is_root_folder_visible(require("nvim-tree.core").get_cwd()) and 1 or 0
-  local lines = vim.api.nvim_buf_get_lines(self:get_bufnr(), starts_at, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(self:get_bufnr("View:grow1"), starts_at, -1, false)
   -- number of columns of right-padding to indicate end of path
   local padding = self:get_size(self.padding)
 
   -- account for sign/number columns etc.
-  local wininfo = vim.fn.getwininfo(self:get_winid())
+  local wininfo = vim.fn.getwininfo(self:get_winnr(nil, "View:grow"))
   if type(wininfo) == "table" and type(wininfo[1]) == "table" then
     padding = padding + wininfo[1].textoff
   end
@@ -343,7 +390,7 @@ function View:grow()
   for line_nr, l in pairs(lines) do
     local count = vim.fn.strchars(l)
     -- also add space for right-aligned icons
-    local extmarks = vim.api.nvim_buf_get_extmarks(self:get_bufnr(), ns_id, { line_nr, 0 }, { line_nr, -1 }, { details = true })
+    local extmarks = vim.api.nvim_buf_get_extmarks(self:get_bufnr("View:grow2"), ns_id, { line_nr, 0 }, { line_nr, -1 }, { details = true })
     count = count + utils.extmarks_length(extmarks)
     if resizing_width < count then
       resizing_width = count
@@ -364,9 +411,9 @@ end
 
 ---@param size string|number|nil
 function View:resize(size)
-  if self.explorer.opts.view.float.enable and not self.adaptive_size then
+  if self.float.enable and not self.adaptive_size then
     -- if the floating windows's adaptive size is not desired, then the
-    -- float size should be defined in self.explorer.opts.view.float.open_win_config
+    -- float size should be defined in view.float.open_win_config
     return
   end
 
@@ -386,19 +433,20 @@ function View:resize(size)
 
   if size then
     self.width = size
+    self.height = size
   end
 
   if not self:is_visible() then
     return
   end
 
-  local winid = self:get_winid() or 0
+  local winnr = self:get_winnr(nil, "View:resize") or 0
 
   local new_size = self:get_width()
 
-  if new_size ~= vim.api.nvim_win_get_width(winid) then
-    vim.api.nvim_win_set_width(winid, new_size)
-    if not self.explorer.opts.view.preserve_window_proportions then
+  if new_size ~= vim.api.nvim_win_get_width(winnr) then
+    vim.api.nvim_win_set_width(winnr, new_size)
+    if not self.preserve_window_proportions then
       vim.cmd(":wincmd =")
     end
   end
@@ -414,15 +462,23 @@ function View:reposition_window()
 end
 
 ---@private
-function View:set_current_win()
+---@param callsite string
+function View:set_current_win(callsite)
   local current_tab = vim.api.nvim_get_current_tabpage()
-  globals.WINID_BY_TABID[current_tab] = vim.api.nvim_get_current_win()
-end
+  local current_win = vim.api.nvim_get_current_win()
 
----@class OpenInWinOpts
----@field hijack_current_buf boolean|nil default true
----@field resize boolean|nil default true
----@field winid number|nil 0 or nil for current
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:set_current_win(%-20.20s) t%d w%3s->w%3s %s",
+      callsite,
+      current_tab,
+      globals.TABPAGES[current_tab].winnr,
+      current_win,
+      (globals.TABPAGES[current_tab].winnr == current_win) and "" or "MISMATCH"
+    )
+  end
+
+  globals.TABPAGES[current_tab].winnr = current_win
+end
 
 ---Open the tree in the a window
 ---@param opts OpenInWinOpts|nil
@@ -433,8 +489,8 @@ function View:open_in_win(opts)
     vim.api.nvim_set_current_win(opts.winid)
   end
   self:create_buffer(opts.hijack_current_buf and vim.api.nvim_get_current_buf())
-  globals.WINID_BY_TABID[vim.api.nvim_get_current_tabpage()] = vim.api.nvim_get_current_win()
-  self:set_current_win()
+  self:setup_tabpage(vim.api.nvim_get_current_tabpage(),                         "View:open_in_win")
+  self:set_current_win("View:open_in_win")
   self:set_window_options_and_buffer()
   if opts.resize then
     self:reposition_window()
@@ -446,17 +502,44 @@ end
 function View:abandon_current_window()
   local tab = vim.api.nvim_get_current_tabpage()
 
-  -- reset both bufnr registries
-  globals.BUFNR_BY_TABID[tab] = nil
-  self.bufnr_by_tabid[tab] = nil
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:abandon_current_window() t%d w%s b%s member b%s %s",
+      tab,
+      globals.TABPAGES[tab] and globals.TABPAGES[tab].winnr or nil,
+      globals.BUFNR_PER_TAB[tab],
+      self.bufnr_by_tab[tab],
+      (globals.BUFNR_PER_TAB[tab] == self.bufnr_by_tab[tab]) and "" or "MISMATCH")
 
-  globals.WINID_BY_TABID[tab] = nil
+    self.bufnr_by_tab[tab] = nil
+  end
+
+  -- TODO multi-instance kill the buffer instead of retaining
+
+  globals.BUFNR_PER_TAB[tab] = nil
+  if globals.TABPAGES[tab] then
+    globals.TABPAGES[tab].winnr = nil
+  end
 end
 
-function View:abandon_all_windows()
+---@param callsite string
+function View:abandon_all_windows(callsite)
   for tab, _ in pairs(vim.api.nvim_list_tabpages()) do
-    globals.BUFNR_BY_TABID[tab] = nil
-    globals.WINID_BY_TABID[tab] = nil
+    if self.explorer.opts.experimental.multi_instance then
+      log.line("dev", "View:abandon_all_windows(%-20.20s) t%d w%s b%s member b%s %s",
+        callsite,
+        tab,
+        globals.TABPAGES and globals.TABPAGES.winnr or nil,
+        globals.BUFNR_PER_TAB[tab],
+        self.bufnr_by_tab[tab],
+        (globals.BUFNR_PER_TAB[tab] == self.bufnr_by_tab[tab]) and "" or "MISMATCH")
+    end
+
+    -- TODO multi-instance kill the buffer instead of retaining
+
+    globals.BUFNR_PER_TAB[tab] = nil
+    if globals.TABPAGES[tab] then
+      globals.TABPAGES[tab].winnr = nil
+    end
   end
 end
 
@@ -464,104 +547,164 @@ end
 ---@return boolean
 function View:is_visible(opts)
   if opts and opts.tabpage then
-    local winid = self:winid(opts.tabpage)
-    return winid and vim.api.nvim_win_is_valid(winid) or false
+    if globals.TABPAGES[opts.tabpage] == nil then
+      return false
+    end
+    local winnr = globals.TABPAGES[opts.tabpage].winnr
+    return winnr and vim.api.nvim_win_is_valid(winnr)
   end
 
   if opts and opts.any_tabpage then
-    for tabid, _ in pairs(globals.WINID_BY_TABID) do
-      local winid = self:winid(tabid)
-
-      if winid and vim.api.nvim_win_is_valid(winid) then
+    for _, v in pairs(globals.TABPAGES) do
+      if v.winnr and vim.api.nvim_win_is_valid(v.winnr) then
         return true
       end
     end
     return false
   end
 
-  local winid = self:get_winid()
-  return winid ~= nil and vim.api.nvim_win_is_valid(winid or 0)
+  return self:get_winnr(nil, "View:is_visible1") ~= nil and vim.api.nvim_win_is_valid(self:get_winnr(nil, "View:is_visible2") or 0)
 end
 
 ---@param opts table|nil
 function View:set_cursor(opts)
   if self:is_visible() then
-    pcall(vim.api.nvim_win_set_cursor, self:get_winid(), opts)
+    pcall(vim.api.nvim_win_set_cursor, self:get_winnr(nil, "View:set_cursor"), opts)
   end
 end
 
----@param winid number|nil
+---@param winnr number|nil
 ---@param open_if_closed boolean|nil
-function View:focus(winid, open_if_closed)
-  local wid = winid or self:get_winid(nil)
+function View:focus(winnr, open_if_closed)
+  local wnr = winnr or self:get_winnr(nil, "View:focus1")
 
-  if vim.api.nvim_win_get_tabpage(wid or 0) ~= vim.api.nvim_win_get_tabpage(0) then
-    self:close()
+  if vim.api.nvim_win_get_tabpage(wnr or 0) ~= vim.api.nvim_win_get_tabpage(0) then
+    self:close(nil, "View:focus")
     self:open()
-    wid = self:get_winid(nil)
+    wnr = self:get_winnr(nil, "View:focus2")
   elseif open_if_closed and not self:is_visible() then
     self:open()
   end
 
-  if wid then
-    vim.api.nvim_set_current_win(wid)
+  if wnr then
+    vim.api.nvim_set_current_win(wnr)
   end
 end
 
 --- Retrieve the winid of the open tree.
 ---@param opts ApiTreeWinIdOpts|nil
----@return number|nil winid unlike get_winid(), this returns nil if the nvim-tree window is not visible
+---@return number|nil winid unlike get_winnr(), this returns nil if the nvim-tree window is not visible
 function View:api_winid(opts)
   local tabpage = opts and opts.tabpage
   if tabpage == 0 then
     tabpage = vim.api.nvim_get_current_tabpage()
   end
   if self:is_visible({ tabpage = tabpage }) then
-    return self:get_winid(tabpage)
+    return self:get_winnr(tabpage, "View:winid")
   else
     return nil
   end
 end
 
----restore any state from last close
-function View:restore_state()
-  self:set_cursor(globals.CURSORS[vim.api.nvim_get_current_tabpage()])
+--- Restores the state of a NvimTree window if it was initialized before.
+function View:restore_tab_state()
+  local tabpage = vim.api.nvim_get_current_tabpage()
+  self:set_cursor(globals.CURSORS[tabpage])
 end
 
 --- winid containing the buffer
----@param tabid number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@param tabpage number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@param callsite string
 ---@return integer? winid
-function View:winid(tabid)
-  local bufnr = self.bufnr_by_tabid[tabid]
+function View:winid(tabpage, callsite)
+  local bufnr = self.bufnr_by_tab[tabpage]
+
+  local msg = string.format("View:winid(%3s, %-20.20s)", tabpage, callsite)
 
   if bufnr then
-    for _, winid in pairs(vim.api.nvim_tabpage_list_wins(tabid or 0)) do
-      if vim.api.nvim_win_get_buf(winid) == bufnr then
-        return winid
+    for _, w in pairs(vim.api.nvim_tabpage_list_wins(tabpage or 0)) do
+      if vim.api.nvim_win_get_buf(w) == bufnr then
+        log.line("dev", "%s b%d : w%s", msg, bufnr, w)
+        return w
       end
     end
+  else
+    log.line("dev", "%s no bufnr", msg)
   end
 end
 
 --- Returns the window number for nvim-tree within the tabpage specified
----@param tabid number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@param tabpage number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@param callsite string
 ---@return number|nil
-function View:get_winid(tabid)
-  tabid = tabid or vim.api.nvim_get_current_tabpage()
-  return self:winid(tabid)
+function View:get_winnr(tabpage, callsite)
+  if self.explorer.opts.experimental.multi_instance then
+    local msg = string.format("View:get_winnr(%3s, %-20.20s)", tabpage, callsite)
+
+    tabpage = tabpage or vim.api.nvim_get_current_tabpage()
+    local tabinfo = globals.TABPAGES[tabpage]
+
+    local ret = nil
+
+    if not tabinfo then
+      msg = string.format("%s t%d no tabinfo", msg, tabpage)
+    elseif not tabinfo.winnr then
+      msg = string.format("%s t%d no tabinfo.winnr", msg, tabpage)
+    elseif not vim.api.nvim_win_is_valid(tabinfo.winnr) then
+      msg = string.format("%s t%d invalid tabinfo.winnr %d", msg, tabpage, tabinfo.winnr)
+    else
+      msg = string.format("%s t%d w%d", msg, tabpage, tabinfo.winnr)
+      ret = tabinfo.winnr
+    end
+
+    local winid = self:winid(tabpage, "View:get_winnr")
+    if ret ~= winid then
+      if ret then
+        msg = string.format("%s winid_from_bufnr w%s MISMATCH", msg, winid)
+      else
+        msg = string.format("%s winid_from_bufnr w%s STALE", msg, winid)
+      end
+      notify.error(string.format("View:get_winnr w%s View:winnr w%s MISMATCH", ret, winid))
+    end
+
+    log.line("dev", "%s", msg)
+
+    return ret
+  else
+    tabpage = tabpage or vim.api.nvim_get_current_tabpage()
+    local tabinfo = globals.TABPAGES[tabpage]
+    if tabinfo and tabinfo.winnr and vim.api.nvim_win_is_valid(tabinfo.winnr) then
+      return tabinfo.winnr
+    end
+  end
 end
 
 --- Returns the current nvim tree bufnr
+---@param callsite string
 ---@return number
-function View:get_bufnr()
+function View:get_bufnr(callsite)
   local tab = vim.api.nvim_get_current_tabpage()
+  if self.explorer.opts.experimental.multi_instance then
+    log.line("dev", "View:get_bufnr(%-20.20s) t%d global b%s member b%s %s",
+      callsite,
+      tab,
+      globals.BUFNR_PER_TAB[tab],
+      self.bufnr_by_tab[tab],
+      (globals.BUFNR_PER_TAB[tab] == self.bufnr_by_tab[tab]) and "" or "MISMATCH")
 
-  return self.bufnr_by_tabid[tab]
+    if globals.BUFNR_PER_TAB[tab] ~= self.bufnr_by_tab[tab] then
+      notify.error(string.format("View:get_bufnr globals.BUFNR_PER_TAB[%s] b%s view.bufnr_by_tab[%s] b%s MISMATCH",
+        tab, globals.BUFNR_PER_TAB[tab],
+        tab, self.bufnr_by_tab[tab]
+      ))
+    end
+  end
+  return globals.BUFNR_PER_TAB[tab]
 end
 
 function View:prevent_buffer_override()
-  local view_winid = self:get_winid()
-  local view_bufnr = self:get_bufnr()
+  local view_winnr = self:get_winnr(nil, "View:prevent_buffer_override")
+  local view_bufnr = self:get_bufnr("View:prevent_buffer_override")
 
   -- need to schedule to let the new buffer populate the window
   -- because this event needs to be run on bufWipeout.
@@ -573,14 +716,18 @@ function View:prevent_buffer_override()
     local bufname = vim.api.nvim_buf_get_name(curbuf)
 
     if not bufname:match("NvimTree") then
-      for i, winid in ipairs(globals.WINID_BY_TABID) do
-        if winid == view_winid then
-          globals.WINID_BY_TABID[i] = nil
+      for i, tabpage in ipairs(globals.TABPAGES) do
+        if tabpage.winnr == view_winnr then
+          if self.explorer.opts.experimental.multi_instance then
+            log.line("dev", "View:prevent_buffer_override() t%d w%d clearing", i, view_winnr)
+          end
+
+          globals.TABPAGES[i] = nil
           break
         end
       end
     end
-    if curwin ~= view_winid or bufname == "" or curbuf == view_bufnr then
+    if curwin ~= view_winnr or bufname == "" or curbuf == view_bufnr then
       return
     end
 
@@ -610,14 +757,14 @@ end
 ---@param cwd string|nil
 ---@return boolean
 function View:is_root_folder_visible(cwd)
-  return cwd ~= "/" and self.explorer.opts.renderer.root_folder_label ~= false
+  return cwd ~= "/" and not self.hide_root_folder
 end
 
 -- used on ColorScheme event
 function View:reset_winhl()
-  local winid = self:get_winid()
-  if winid and vim.api.nvim_win_is_valid(winid) then
-    vim.wo[winid].winhl = appearance.WIN_HL
+  local winnr = self:get_winnr(nil, "View:reset_winhl1")
+  if winnr and vim.api.nvim_win_is_valid(winnr) then
+    vim.wo[self:get_winnr(nil, "View:reset_winhl2")].winhl = appearance.WIN_HL
   end
 end
 
@@ -626,11 +773,6 @@ end
 function View:is_width_determined()
   return type(self.width) ~= "function"
 end
-
--- These are needed as they are populated only by the user, not configuration
-local DEFAULT_MIN_WIDTH = 30
-local DEFAULT_MAX_WIDTH = -1
-local DEFAULT_PADDING = 1
 
 ---Configure width-related config
 ---@param width string|function|number|table|nil

--- a/lua/nvim-tree/explorer/view.lua
+++ b/lua/nvim-tree/explorer/view.lua
@@ -20,6 +20,7 @@ local Class = require("nvim-tree.classic")
 ---@field private padding integer
 -- TODO multi-instance replace with single members
 ---@field private bufnr_by_tabid table<integer, integer>
+---@field private winid_by_tabid table<integer, integer>
 local View = Class:extend()
 
 ---@class View
@@ -38,6 +39,7 @@ function View:new(args)
   self.side           = (self.explorer.opts.view.side == "right") and "right" or "left"
   self.live_filter    = { prev_focused_node = nil, }
   self.bufnr_by_tabid = {}
+  self.winid_by_tabid = {}
 
   self.winopts        = {
     relativenumber = self.explorer.opts.view.relativenumber,
@@ -76,48 +78,35 @@ local BUFFER_OPTIONS = {
   { name = "swapfile",   value = false },
 }
 
----@private
----@param data table
----@param bufnr integer
-function View:log_event(data, bufnr)
-  log.line("dev", "View %s\
-  bufnr = %s\
-  vim.api.nvim_get_current_tabpage() = %s\
-  vim.api.nvim_get_current_win() = %s\
-  self.bufnr_by_tabid = %s\
-  globals.BUFNR_BY_TABID = %s\
-  globals.WINID_BY_TABID = %s\
-  vim.fn.win_findbuf(bufnr) = %s\
-  data = %s\
-  vim.v.event = %s",
-    data.event,
-    bufnr,
-    vim.api.nvim_get_current_tabpage(),
-    vim.api.nvim_get_current_win(),
-    vim.inspect(self.bufnr_by_tabid, { newline = "" }),
-    vim.inspect(globals.BUFNR_BY_TABID, { newline = "" }),
-    vim.inspect(globals.WINID_BY_TABID, { newline = "" }),
-    vim.inspect(vim.fn.win_findbuf(bufnr), { newline = "" }),
-    vim.inspect(data, { newline = "" }),
-    vim.inspect(vim.v.event, { newline = "" })
-  )
-end
-
 ---Buffer local autocommands to track state, deleted on buffer wipeout
 ---@private
 ---@param bufnr integer
 function View:create_autocmds(bufnr)
+  -- clear bufnr and winid
   -- eject buffer opened in the nvim-tree window and create a new buffer
   vim.api.nvim_create_autocmd("BufWipeout", {
     group = self.explorer.augroup_id,
     buffer = bufnr,
     callback = function(data)
-      self:log_event(data, bufnr)
+      log.line("dev",
+        "View BufWipeout\n  bufnr = %s\n  data.buf = %s\n  self.bufnr_by_tabid = %s\n  self.winid_by_tabid = %s",
+        bufnr,
+        data.buf,
+        vim.inspect(self.bufnr_by_tabid, { newline = "" }),
+        vim.inspect(self.winid_by_tabid, { newline = "" }),
+        vim.inspect(data, { newline = "" })
+      )
 
       -- clear the tab's buffer
       self.bufnr_by_tabid = vim.tbl_map(function(b)
         return b ~= bufnr and b or nil
       end, self.bufnr_by_tabid)
+
+      -- clear the tab's window(s)
+      local winids = vim.fn.win_findbuf(bufnr)
+      self.winid_by_tabid = vim.tbl_map(function(winid)
+        return not vim.tbl_contains(winids, winid) and winid or nil
+      end, self.winid_by_tabid)
 
       if self.explorer.opts.actions.open_file.eject then
         self:prevent_buffer_override()
@@ -127,57 +116,24 @@ function View:create_autocmds(bufnr)
     end,
   })
 
-  -- not fired when entering the first window, only subsequent event such as following a split
-  -- does fire on :tabnew for _any_ buffer
-  vim.api.nvim_create_autocmd("WinEnter", {
+  -- set winid
+  vim.api.nvim_create_autocmd("BufWinEnter", {
     group = self.explorer.augroup_id,
     buffer = bufnr,
     callback = function(data)
-      self:log_event(data, bufnr)
+      local tabid = vim.api.nvim_get_current_tabpage()
 
-      -- ignore other buffers
-      if data.buf ~= bufnr then
-        return
-      end
+      log.line("dev",
+        "View BufWinEnter\n  bufnr = %s\n  data.buf = %s\n  self.bufnr_by_tabid = %s\n  self.winid_by_tabid = %s",
+        bufnr,
+        data.buf,
+        vim.inspect(self.bufnr_by_tabid, { newline = "" }),
+        vim.inspect(self.winid_by_tabid, { newline = "" })
+      )
 
-      -- ignore other tabs
-      -- this event is fired on a a :tabnew window, even though the buffer isn't actually present
-      local tabid_cur = vim.api.nvim_get_current_tabpage()
-      if self.bufnr_by_tabid[tabid_cur] ~= bufnr then
-        return
-      end
-
-      -- close other windows in this tab
-      self:close_other_windows(bufnr)
+      self.winid_by_tabid[tabid] = vim.fn.bufwinid(data.buf) -- first on current tabpage
     end,
   })
-end
-
----Close any other windows containing this buffer and setup current window
----Feature gated behind experimental.close_other_windows_in_tab
----@param bufnr integer
-function View:close_other_windows(bufnr)
-  if not self.explorer.opts.experimental.close_other_windows_in_tab then
-    return
-  end
-
-  -- are there any other windows containing bufnr?
-  local winids_buf = vim.fn.win_findbuf(bufnr)
-  if #winids_buf <= 1 then
-    return
-  end
-
-  -- close all other windows
-  local winid_cur = vim.api.nvim_get_current_win()
-  for _, winid in ipairs(winids_buf) do
-    if winid ~= winid_cur then
-      pcall(vim.api.nvim_win_close, winid, false)
-    end
-  end
-
-  -- setup current window, it may be new e.g. split
-  self:set_window_options_and_buffer()
-  self:resize()
 end
 
 -- TODO multi-instance remove this; delete buffers rather than retaining them

--- a/lua/nvim-tree/explorer/view.lua
+++ b/lua/nvim-tree/explorer/view.lua
@@ -18,9 +18,8 @@ local Class = require("nvim-tree.classic")
 ---@field private width (fun():integer)|integer|string
 ---@field private max_width integer
 ---@field private padding integer
--- TODO multi-instance replace with single members
+-- TODO multi-instance remove or replace with single member
 ---@field private bufnr_by_tabid table<integer, integer>
----@field private winid_by_tabid table<integer, integer>
 local View = Class:extend()
 
 ---@class View
@@ -34,14 +33,13 @@ local View = Class:extend()
 function View:new(args)
   args.explorer:log_new("View")
 
-  self.explorer       = args.explorer
-  self.adaptive_size  = false
-  self.side           = (self.explorer.opts.view.side == "right") and "right" or "left"
-  self.live_filter    = { prev_focused_node = nil, }
-  self.bufnr_by_tabid = {}
-  self.winid_by_tabid = {}
+  self.explorer         = args.explorer
+  self.adaptive_size    = false
+  self.side             = (self.explorer.opts.view.side == "right") and "right" or "left"
+  self.live_filter      = { prev_focused_node = nil, }
+  self.bufnr_by_tabid   = {}
 
-  self.winopts        = {
+  self.winopts          = {
     relativenumber = self.explorer.opts.view.relativenumber,
     number         = self.explorer.opts.view.number,
     list           = false,
@@ -62,6 +60,10 @@ function View:new(args)
 
   self:configure_width(self.explorer.opts.view.width)
   self.initial_width = self:get_width()
+
+  -- TODO multi-instance remove this; delete buffers rather than retaining them
+  local tabid = vim.api.nvim_get_current_tabpage()
+  self.bufnr_by_tabid[tabid] = globals.BUFNR_BY_TABID[tabid]
 end
 
 function View:destroy()
@@ -77,64 +79,6 @@ local BUFFER_OPTIONS = {
   { name = "modifiable", value = false },
   { name = "swapfile",   value = false },
 }
-
----Buffer local autocommands to track state, deleted on buffer wipeout
----@private
----@param bufnr integer
-function View:create_autocmds(bufnr)
-  -- clear bufnr and winid
-  -- eject buffer opened in the nvim-tree window and create a new buffer
-  vim.api.nvim_create_autocmd("BufWipeout", {
-    group = self.explorer.augroup_id,
-    buffer = bufnr,
-    callback = function(data)
-      log.line("dev",
-        "View BufWipeout\n  bufnr = %s\n  data.buf = %s\n  self.bufnr_by_tabid = %s\n  self.winid_by_tabid = %s",
-        bufnr,
-        data.buf,
-        vim.inspect(self.bufnr_by_tabid, { newline = "" }),
-        vim.inspect(self.winid_by_tabid, { newline = "" }),
-        vim.inspect(data, { newline = "" })
-      )
-
-      -- clear the tab's buffer
-      self.bufnr_by_tabid = vim.tbl_map(function(b)
-        return b ~= bufnr and b or nil
-      end, self.bufnr_by_tabid)
-
-      -- clear the tab's window(s)
-      local winids = vim.fn.win_findbuf(bufnr)
-      self.winid_by_tabid = vim.tbl_map(function(winid)
-        return not vim.tbl_contains(winids, winid) and winid or nil
-      end, self.winid_by_tabid)
-
-      if self.explorer.opts.actions.open_file.eject then
-        self:prevent_buffer_override()
-      else
-        self:abandon_current_window()
-      end
-    end,
-  })
-
-  -- set winid
-  vim.api.nvim_create_autocmd("BufWinEnter", {
-    group = self.explorer.augroup_id,
-    buffer = bufnr,
-    callback = function(data)
-      local tabid = vim.api.nvim_get_current_tabpage()
-
-      log.line("dev",
-        "View BufWinEnter\n  bufnr = %s\n  data.buf = %s\n  self.bufnr_by_tabid = %s\n  self.winid_by_tabid = %s",
-        bufnr,
-        data.buf,
-        vim.inspect(self.bufnr_by_tabid, { newline = "" }),
-        vim.inspect(self.winid_by_tabid, { newline = "" })
-      )
-
-      self.winid_by_tabid[tabid] = vim.fn.bufwinid(data.buf) -- first on current tabpage
-    end,
-  })
-end
 
 -- TODO multi-instance remove this; delete buffers rather than retaining them
 ---@private
@@ -168,17 +112,15 @@ function View:create_buffer(bufnr)
 
   bufnr = bufnr or vim.api.nvim_create_buf(false, false)
 
-  self.bufnr_by_tabid[tabid] = bufnr
-
+  -- set both bufnr registries
   globals.BUFNR_BY_TABID[tabid] = bufnr
+  self.bufnr_by_tabid[tabid] = bufnr
 
   vim.api.nvim_buf_set_name(bufnr, "NvimTree_" .. tabid)
 
   for _, option in ipairs(BUFFER_OPTIONS) do
     vim.api.nvim_set_option_value(option.name, option.value, { buf = bufnr })
   end
-
-  self:create_autocmds(bufnr)
 
   require("nvim-tree.keymap").on_attach(bufnr)
 
@@ -216,9 +158,7 @@ local move_tbl = {
 
 ---@private
 function View:set_window_options_and_buffer()
-  if not pcall(vim.api.nvim_command, "buffer " .. self:get_bufnr()) then
-    return
-  end
+  pcall(vim.api.nvim_command, "buffer " .. self:get_bufnr())
 
   if vim.fn.has("nvim-0.10") == 1 then
     local eventignore = vim.api.nvim_get_option_value("eventignore", {})
@@ -506,7 +446,9 @@ end
 function View:abandon_current_window()
   local tab = vim.api.nvim_get_current_tabpage()
 
+  -- reset both bufnr registries
   globals.BUFNR_BY_TABID[tab] = nil
+  self.bufnr_by_tabid[tab] = nil
 
   globals.WINID_BY_TABID[tab] = nil
 end
@@ -590,7 +532,7 @@ end
 ---@param tabid number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
 ---@return integer? winid
 function View:winid(tabid)
-  local bufnr = globals.BUFNR_BY_TABID[tabid]
+  local bufnr = self.bufnr_by_tabid[tabid]
 
   if bufnr then
     for _, winid in pairs(vim.api.nvim_tabpage_list_wins(tabid or 0)) do
@@ -601,7 +543,6 @@ function View:winid(tabid)
   end
 end
 
---- TODO this needs to be refactored away; it's private now to contain it
 --- Returns the window number for nvim-tree within the tabpage specified
 ---@param tabid number|nil (optional) the number of the chosen tabpage. Defaults to current tabpage.
 ---@return number|nil
@@ -615,7 +556,7 @@ end
 function View:get_bufnr()
   local tab = vim.api.nvim_get_current_tabpage()
 
-  return globals.BUFNR_BY_TABID[tab]
+  return self.bufnr_by_tabid[tab]
 end
 
 function View:prevent_buffer_override()

--- a/lua/nvim-tree/globals.lua
+++ b/lua/nvim-tree/globals.lua
@@ -2,8 +2,8 @@
 
 local M = {
   -- from View
-  WINID_BY_TABID = {},
-  BUFNR_BY_TABID = {},
+  TABPAGES = {},
+  BUFNR_PER_TAB = {},
   CURSORS = {},
 }
 

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -15,7 +15,7 @@ function M.set_target_win()
 
   local id = vim.api.nvim_get_current_win()
 
-  if explorer and id == explorer.view:get_winid() then
+  if explorer and id == explorer.view:get_winnr(nil, "lib.set_target_win") then
     M.target_winid = 0
     return
   end
@@ -102,14 +102,14 @@ function M.open(opts)
   M.set_target_win()
   if not core.get_explorer() or opts.path then
     if opts.path then
-      core.init(opts.path)
+      core.init(opts.path, "lib.open - opts.path")
     else
       local cwd, err = vim.loop.cwd()
       if not cwd then
         notify.error(string.format("current working directory unavailable: %s", err))
         return
       end
-      core.init(cwd)
+      core.init(cwd, "lib.open - cwd")
     end
   end
 
@@ -136,7 +136,7 @@ function M.open(opts)
   end
 
   if explorer then
-    explorer.view:restore_state()
+    explorer.view:restore_tab_state()
   end
 end
 

--- a/lua/nvim-tree/multi-instance-debug.lua
+++ b/lua/nvim-tree/multi-instance-debug.lua
@@ -1,0 +1,112 @@
+local globals = require("nvim-tree.globals")
+
+local M = {}
+
+--- Debugging only.
+--- Tabs show TABPAGES winnr and BUFNR_PER_TAB bufnr for the tab.
+--- Orphans for inexistent tab_ids are shown at the right.
+--- lib.target_winid is always shown at the right next to a close button.
+--- Enable with:
+---   vim.opt.tabline = "%!v:lua.require('nvim-tree.explorer.view').tab_line()"
+---   vim.opt.showtabline = 2
+---@return string
+function M.tab_line()
+  local tab_ids = vim.api.nvim_list_tabpages()
+  local cur_tab_id = vim.api.nvim_get_current_tabpage()
+
+  local bufnr_per_tab = vim.deepcopy(globals.BUFNR_PER_TAB)
+  local tabpages = vim.deepcopy(globals.TABPAGES)
+
+  local tl = "%#TabLine#"
+
+  for i, tab_id in ipairs(tab_ids) do
+    -- click to select
+    tl = tl .. "%" .. i .. "T"
+
+    -- style
+    if tab_id == cur_tab_id then
+      tl = tl .. "%#StatusLine#|"
+    else
+      tl = tl .. "|%#TabLine#"
+    end
+
+    -- tab_id itself
+    tl = tl .. " t" .. tab_id
+
+    -- winnr, if present
+    local tp = globals.TABPAGES[tab_id]
+    if tp then
+      tl = tl .. " w" .. (tp.winnr or "nil")
+    else
+      tl = tl .. "      "
+    end
+
+    -- bufnr, if present
+    local bpt = globals.BUFNR_PER_TAB[tab_id]
+    if bpt then
+      tl = tl .. " b" .. bpt
+    else
+      tl = tl .. "   "
+    end
+
+    tl = tl .. " "
+
+    -- remove actively mapped
+    bufnr_per_tab[tab_id] = nil
+    tabpages[tab_id] = nil
+  end
+
+  -- close last and reset
+  tl = tl .. "|%#CursorLine#%T"
+
+  -- collect orphans
+  local orphans = {}
+  for tab_id, bufnr in pairs(bufnr_per_tab) do
+    orphans[tab_id] = orphans[tab_id] or {}
+    orphans[tab_id].bufnr = bufnr
+  end
+  for tab_id, tp in pairs(tabpages) do
+    orphans[tab_id] = orphans[tab_id] or {}
+    orphans[tab_id].winnr = tp.winnr
+  end
+
+  -- right-align
+  tl = tl .. "%=%#TabLine#"
+
+  -- print orphans
+  for tab_id, orphan in pairs(orphans) do
+    -- inexistent tab
+    tl = tl .. "%#error#| t" .. tab_id
+
+    -- maybe winnr
+    if orphan.winnr then
+      tl = tl .. " w" .. (orphan.winnr or "nil")
+    else
+      tl = tl .. "      "
+    end
+
+    -- maybe bufnr
+    if orphan.bufnr then
+      tl = tl .. " b" .. orphan.bufnr
+    else
+      tl = tl .. "   "
+    end
+    tl = tl .. " "
+  end
+
+  -- target win id and close button
+  tl = tl .. "|%#TabLine# twi" .. (require("nvim-tree.lib").target_winid or "?") .. " %999X| X |"
+
+  return tl
+end
+
+function M.setup(opts)
+  if not opts.experimental.multi_instance then
+    return
+  end
+
+  vim.opt.tabline = "%!v:lua.require('nvim-tree.multi-instance-debug').tab_line()"
+  vim.opt.showtabline = 2
+end
+
+return M

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -101,29 +101,28 @@ function Renderer:render_hl(bufnr, hl_range_args)
 end
 
 function Renderer:draw()
-  local bufnr = self.explorer.view:get_bufnr()
+  local bufnr = self.explorer.view:get_bufnr("Renderer:draw")
   if not bufnr or not vim.api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  local winid = self.explorer.view:get_winid()
 
   local profile = log.profile_start("draw")
 
-  local cursor = vim.api.nvim_win_get_cursor(winid or 0)
+  local cursor = vim.api.nvim_win_get_cursor(self.explorer.view:get_winnr(nil, "Renderer:draw1") or 0)
 
   local builder = Builder(self.explorer):build()
 
   self:_draw(bufnr, builder.lines, builder.hl_range_args, builder.signs, builder.extmarks, builder.virtual_lines)
 
   if cursor and #builder.lines >= cursor[1] then
-    vim.api.nvim_win_set_cursor(winid or 0, cursor)
+    vim.api.nvim_win_set_cursor(self.explorer.view:get_winnr(nil, "Renderer:draw2") or 0, cursor)
   end
 
   self.explorer.view:grow_from_content()
 
   log.profile_end(profile)
 
-  events._dispatch_on_tree_rendered(bufnr, winid)
+  events._dispatch_on_tree_rendered(bufnr, self.explorer.view:get_winnr(nil, "Renderer:draw3"))
 end
 
 return Renderer


### PR DESCRIPTION
fixes #3180 
fixes #3177 

Reverts recent view changes:
* buffer autocommands for wipeout
* experiment #3174 
* changing `globals.TABPAGES` to a simple map

Consistency check removal to follow, proof of concept was not successful.