### PR TITLE
perf(#3171): cache toplevel for untracked

### DIFF
--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -193,9 +193,10 @@ function M.get_toplevel(path)
     end
   end
 
-  -- attempt to fetch toplevel
+  -- attempt to fetch toplevel, cache if untracked
   local toplevel, git_dir = git_utils.get_toplevel(path)
   if not toplevel or not git_dir then
+    M._toplevels_by_path[path] = false
     return nil
   end
   local toplevel_norm = vim.fn.fnamemodify(toplevel, ":p")


### PR DESCRIPTION
toplevel for untracked was not cached in the getter `git.get_toplevel`

Only cached by one caller `git.load_project`, however I'm hesitant to remove it from this complex module, and it does no harm.