### PR TITLE
feat: set filter input filetype to NvimTreeFilter

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -2339,6 +2339,7 @@ events.Event                                      *nvim-tree-api.events.Event*
 
 live_filter.start()                        *nvim-tree-api.live_filter.start()*
     Enter |nvim-tree.live_filter| mode.
+    Opens an input window with |filetype| `"NvimTreeFilter"`
 
 live_filter.clear()                        *nvim-tree-api.live_filter.clear()*
     Exit |nvim-tree.live_filter| mode.

--- a/lua/nvim-tree/explorer/live-filter.lua
+++ b/lua/nvim-tree/explorer/live-filter.lua
@@ -188,8 +188,10 @@ local function create_overlay(self)
 
   if vim.fn.has("nvim-0.10") == 1 then
     vim.api.nvim_set_option_value("modifiable", true, { buf = overlay_bufnr })
+    vim.api.nvim_set_option_value("filetype", "NvimTreeFilter", { buf = overlay_bufnr })
   else
     vim.api.nvim_buf_set_option(overlay_bufnr, "modifiable", true) ---@diagnostic disable-line: deprecated
+    vim.api.nvim_buf_set_option(overlay_bufnr, "filetype", "NvimTreeFilter") ---@diagnostic disable-line: deprecated
   end
 
   vim.api.nvim_buf_set_lines(overlay_bufnr, 0, -1, false, { self.filter })


### PR DESCRIPTION
can not disable nvim-cmp in nvimtree filter buffer, with this PR:

```
cmp.setup({
    enabled = function()
        if vim.bo.filetype == 'NvimTreeFilter'  then
            return false
        end
        return true
    end
    ----
}）
```