### PR TITLE
feat: load command definitions at nvim startup

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -759,10 +759,7 @@ function M.setup(conf)
 
   setup_autocommands(opts)
 
-  if vim.g.NvimTreeSetup ~= 1 then
-    -- first call to setup
-    require("nvim-tree.commands").setup()
-  else
+  if vim.g.NvimTreeSetup == 1 then
     -- subsequent calls to setup
     M.purge_all_state()
   end

--- a/plugin/nvim-tree.lua
+++ b/plugin/nvim-tree.lua
@@ -1,0 +1,1 @@
+require("nvim-tree.commands").setup()


### PR DESCRIPTION
This change ensures that commands are defined even if most modules are loaded as late as possible. 