### PR TITLE
fix: renderer.add_trailing applies to symlink destination

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -855,7 +855,7 @@ Use nvim-tree in a floating window.
  5.3 OPTS: RENDERER                                  *nvim-tree-opts-renderer*
 
 *nvim-tree.renderer.add_trailing*
-Appends a trailing slash to folder names.
+Appends a trailing slash to folder and symlink folder destination names.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.renderer.group_empty*

--- a/lua/nvim-tree/node/directory-link.lua
+++ b/lua/nvim-tree/node/directory-link.lua
@@ -64,6 +64,9 @@ function DirectoryLinkNode:highlighted_name()
 
   if self.explorer.opts.renderer.symlink_destination then
     local link_to = utils.path_relative(self.link_to, self.explorer.absolute_path)
+    if self.explorer.opts.renderer.add_trailing then
+      link_to = utils.path_add_trailing(link_to)
+    end
 
     name.str      = string.format("%s%s%s", name.str, self.explorer.opts.renderer.icons.symlink_arrow, link_to)
     name.hl       = { "NvimTreeSymlinkFolderName" }


### PR DESCRIPTION
This uses `add_trailing` option also for destinations of symlinked folders