### PR TITLE
feat: allow lazy loading via vim.g.NvimTreeConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ require("nvim-tree").setup({
     dotfiles = true,
   },
 })
+
+-- OR use the following variable and nvim-tree will call setup lazily
+vim.g.NvimTreeConfig = {
+  on_attach = my_on_attach
+}
 ```
 
 ### Help

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -50,7 +50,11 @@ local Api = {
 ---@return fun(...): any
 local function wrap(fn)
   return function(...)
-    if vim.g.NvimTreeSetup == 1 then
+    if vim.g.NvimTreeSetup == 1 or vim.g.NvimTreeConfig then
+      if vim.g.NvimTreeSetup ~= 1 then
+        require("nvim-tree").setup(vim.g.NvimTreeConfig)
+      end
+
       return fn(...)
     else
       notify.error("nvim-tree setup not called")


### PR DESCRIPTION
I was trying to improve my neovim startup time by lazy loading dependencies [here](https://github.com/perrin4869/dotfiles/pull/5709), and `nvim-tree` was a good candidate to lazy load.
I noticed that it would be easy to implement this use case by adding the simple setup call in the `wrap` function.
It seems to work for my usecases but I did not do extensive testing