### PR TITLE
fix: incorrect window width when right_align icons present

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -325,7 +325,8 @@ local function grow()
   end
 
   local ns_id = vim.api.nvim_get_namespaces()["NvimTreeExtmarks"]
-  for line_nr, l in pairs(lines) do
+  for i, l in pairs(lines) do
+    local line_nr = starts_at + i - 1
     local line_width = vim.fn.strchars(l)
     -- also add space for right-aligned icons
     local extmarks = vim.api.nvim_buf_get_extmarks(M.get_bufnr(), ns_id, { line_nr, 0 }, { line_nr, -1 }, { details = true })


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/nvim-tree/nvim-tree.lua/pull/3214

In `grow()` when `M.View.root_excluded` is `true` lines starts from the second line, but later in the for loop we index starting from 1 always.