### PR TITLE
refactor: use Node objects in Filters:bookmark for improved type safety

### DIFF
--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -127,7 +127,7 @@ function Filters:bookmark(path, path_type, bookmarks)
   if not self.state.no_bookmark then
     return false
   end
-
+  -- if bookmark is empty, we should see a empty filetree
   if next(bookmarks) == nil then
     return true
   end
@@ -141,6 +141,7 @@ function Filters:bookmark(path, path_type, bookmarks)
     end
 
     if path_type == "directory" then
+      -- check if path is mark's parent
       if vim.fn.stridx(bookmark_path, mark_parent) == 0 then
         return false
       end
@@ -149,6 +150,7 @@ function Filters:bookmark(path, path_type, bookmarks)
     ---@type DirectoryNode?
     local dir = bookmark_entry:as(DirectoryNode)
     if dir then
+      -- check if mark is path's parent
       local path_parent = utils.path_add_trailing(bookmark_path)
       if vim.fn.stridx(path, path_parent) == 0 then
         return false


### PR DESCRIPTION
This pull request updates the bookmark filtering logic in the `Filters:bookmark` function to work with a new data structure for bookmarks. Instead of mapping bookmark paths to a filetype or string, bookmarks now map to `Node` objects, allowing for more robust and type-safe operations.

**Refactor bookmark filtering to use Node objects:**

* The `bookmarks` parameter now expects a table mapping bookmark paths to `Node` objects instead of strings or filetypes, enabling more structured handling of bookmarks.
* The logic for checking bookmark types and parent-child relationships has been updated to use the `Node` interface, specifically using the `as(DirectoryNode)` method for type checking and path comparisons.