### PR TITLE
docs: fix default mappings function name in examples: api.map.on_attach.default

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -349,7 +349,7 @@ The `on_attach` function is passed the `bufnr` of nvim-tree. Use
     vim.keymap.set("n", "<C-e>", api.node.open.replace_tree_buffer,     opts("Open: In Place"))
     ---
     -- OR use all default mappings
-    api.map.on_attach.default.on_attach_default(bufnr)
+    api.map.on_attach.default(bufnr)
 
     -- remove a default
     vim.keymap.del("n", "<C-]>", { buffer = bufnr })
@@ -470,7 +470,7 @@ Alternatively, you may apply these default mappings from your
       return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
     end
 
-    api.map.on_attach.default.on_attach_default(bufnr)
+    api.map.on_attach.default(bufnr)
 
     -- your removals and mappings go here
   end


### PR DESCRIPTION
The function name mentioned in the docs for default mappings is incorrect. `api.map.on_attach.default` itself points to `keymap.on_attach_default` [here](https://github.com/nvim-tree/nvim-tree.lua/blob/1df1960d0e3a26643a4100f64fa03b991b9f4b85/lua/nvim-tree/api/impl/pre.lua#L46), and so the correct function call (which works as well) should just be `api.map.on_attach.default(bufnr)`.

Thanks!