### PR TITLE
fix: allow 0 (unlimited) filesystem_watchers.max_events which is the new default, except for windows at 1000

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1709,9 +1709,11 @@ Config: filesystem_watchers             *nvim-tree-config-filesystem-watchers*
                            between filesystem change and tree update.
       • {ignore_dirs}?     (`string[]|(fun(path: string): boolean)`, default: `{ "/.ccls-cache", "/build", "/node_modules", "/target", "/.zig-cache"}`)
                            Disable for specific directories.
-      • {max_events}?      (`integer`, default: `1000`) Disable for a single
-                           directory after {max_events} consecutive events
-                           with an interval < {debounce_delay}.
+      • {max_events}?      (`integer`, default: `0` or `1000` on windows)
+                           Disable for a single directory after {max_events}
+                           consecutive events with an interval <
+                           {debounce_delay}. Set to 0 to allow unlimited
+                           consecutive events.
 
 
 
@@ -2182,7 +2184,7 @@ Following is the default configuration, see |nvim_tree.config| for details. >lua
       filesystem_watchers = {
         enable = true,
         debounce_delay = 50,
-        max_events = 1000,
+        max_events = 0,
         ignore_dirs = {
           "/.ccls-cache",
           "/build",

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -463,7 +463,7 @@ local DEFAULT_OPTS = { -- default-config-start
   filesystem_watchers = {
     enable = true,
     debounce_delay = 50,
-    max_events = 1000,
+    max_events = 0,
     ignore_dirs = {
       "/.ccls-cache",
       "/build",
@@ -737,6 +737,9 @@ end
 local function localise_default_opts()
   if utils.is_macos or utils.is_windows then
     DEFAULT_OPTS.trash.cmd = "trash"
+  end
+  if utils.is_windows then
+    DEFAULT_OPTS.filesystem_watchers.max_events = 1000
   end
 end
 

--- a/lua/nvim-tree/_meta/config/filesystem_watchers.lua
+++ b/lua/nvim-tree/_meta/config/filesystem_watchers.lua
@@ -31,5 +31,6 @@ error("Cannot require a meta file")
 ---@field ignore_dirs? string[]|(fun(path: string): boolean)
 ---
 ---Disable for a single directory after {max_events} consecutive events with an interval < {debounce_delay}.
----(default: `1000`)
+---Set to 0 to allow unlimited consecutive events.
+---(default: `0` or `1000` on windows)
 ---@field max_events? integer

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -79,12 +79,12 @@ function M.create_watcher(node)
     watcher.data.outstanding_events = watcher.data.outstanding_events + 1
 
     -- disable watcher when outstanding exceeds max
-    if watcher.data.outstanding_events > M.config.filesystem_watchers.max_events then
+    if M.config.filesystem_watchers.max_events > 0 and watcher.data.outstanding_events > M.config.filesystem_watchers.max_events then
       notify.error(string.format(
         "Observed %d consecutive file system events with interval < %dms, exceeding filesystem_watchers.max_events=%s. Disabling watcher for directory '%s'. Consider adding this directory to filesystem_watchers.ignore_dirs",
         watcher.data.outstanding_events,
-        M.config.filesystem_watchers.max_events,
         M.config.filesystem_watchers.debounce_delay,
+        M.config.filesystem_watchers.max_events,
         node.absolute_path
       ))
       node:destroy_watcher()


### PR DESCRIPTION
There are many legitimate cases for thousands of filesystem events. Normally they should be allowed.

The guard was added only for windows which experiences runaway events, hence only applies to windows by default.