### PR TITLE
perf(#3284): re-draw instead of refreshing the tree when a buffer is modified

### DIFF
--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -187,7 +187,7 @@ function Explorer:create_autocmds()
       callback = function()
         utils.debounce("Buf:modified_" .. self.uid_explorer, self.opts.view.debounce_delay, function()
           buffers.reload_modified()
-          self:reload_explorer()
+          self.renderer:draw()
         end)
       end,
     })


### PR DESCRIPTION
fixes #3284 

The tree is just redrawn when a buffer is modified, instead of being reloaded.

The modified functionality was added in 2022 #1835

The highlight overhaul and addition of decorators was done in 2024 #2455 which changed the way modified state was handled, decoupling all rendering from reloading. Multi-instance explorer changes are likely also needed.

I seem to recall a conversation about the need to refresh, however I cannot find it.