### PR TITLE
ci: migrate to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/googleapis/release-please-action@github.com/.git"
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/googleapis/release-please-action.git"
           git tag -d       v${{ steps.release.outputs.major }}                                                                       || true
           git tag -d       v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}                                    || true
           git tag -d       v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} || true


### PR DESCRIPTION
As prompted by https://github.com/nvim-tree/nvim-tree.lua/actions/runs/23034490998

Node hasn't been updated to 24, however you need to manually opt-in to the update. This doesn't seem like a good idea.