### PR TITLE
fix(#3312): correct cursor when full name shown, requires nvim 0.12.2+

### DIFF
--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -76,6 +76,7 @@ function M.show()
     height    = 1,
     noautocmd = true,
     style     = "minimal",
+    zindex    = 40,
     border    = "none"
   })
   vim.wo[M.popup_win].winhl = view_state.Active.winopts.winhl


### PR DESCRIPTION
fixes #3312 

See https://github.com/neovim/neovim/pull/39054