### PR TITLE
docs: remove lintdoc from help-check, skip the name checker during help-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,5 @@ jobs:
           curl -L "https://github.com/neovim/neovim/archive/refs/tags/${{ matrix.nvim_version }}.tar.gz" | tar zx --directory "${DIR_NVIM_SRC}/.."
           cd "${DIR_NVIM_SRC}"
           make doc
-          make lintdoc
 
       - run: make help-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ make help-update
   - Generate config classes `*nvim-tree-config*`
   - Generate API `*nvim-tree-api*`
 
-## Checking And Linting
+## Checking
 
 This is run in CI. Commit or stage your changes and run:
 
@@ -194,7 +194,6 @@ make help-check
 
 - Re-runs `make help-update`
 - Checks that `git diff` is empty, to ensure that all content has been generated. This is why a stage or commit is necessary.
-- Lints `doc/nvim-tree-lua.txt` using `scripts/vimdoc.sh lintdoc` to check for no broken links etc.
 
 # Windows
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ help-update:
 # CI
 #
 help-check: help-update
-	scripts/vimdoc.sh lintdoc
 	git diff --exit-code doc/nvim-tree-lua.txt
 
 

--- a/lua/nvim-tree/_meta/api/appearance.lua
+++ b/lua/nvim-tree/_meta/api/appearance.lua
@@ -2,7 +2,7 @@
 local nvim_tree = { api = { appearance = {} } }
 
 ---
----FOO a new buffer displaying all nvim-tree highlight groups, their link chain and concrete definition.
+---Open a new buffer displaying all nvim-tree highlight groups, their link chain and concrete definition.
 ---
 ---Similar to `:so $VIMRUNTIME/syntax/hitest.vim` as per |:highlight|
 ---

--- a/lua/nvim-tree/_meta/api/appearance.lua
+++ b/lua/nvim-tree/_meta/api/appearance.lua
@@ -2,7 +2,7 @@
 local nvim_tree = { api = { appearance = {} } }
 
 ---
----Open a new buffer displaying all nvim-tree highlight groups, their link chain and concrete definition.
+---FOO a new buffer displaying all nvim-tree highlight groups, their link chain and concrete definition.
 ---
 ---Similar to `:so $VIMRUNTIME/syntax/hitest.vim` as per |:highlight|
 ---

--- a/scripts/vimdoc.sh
+++ b/scripts/vimdoc.sh
@@ -1,26 +1,17 @@
 #!/usr/bin/env sh
 
-# Wrapper around Nvim make targets:
+# Wrapper around Nvim make doc target:
 #
-# make doc - gen_vimdoc.lua
-#   Generates doc/nvim-tree-lua.txt 
-#   Uses nvim-tree sources defined in scripts/vimdoc_config.lua
-#   Shims above into src/gen/gen_vimdoc.lua, replacing Nvim's config.
-#
-# make lintdoc - lintdoc.lua
-#   Validates doc/nvim-tree-lua.txt 
-#   Desired:
-#   - tags valid
-#   - links valid
-#   Also:
-#   - brand spelling, notably Nvim and Lua
+# Generates doc/nvim-tree-lua.txt 
+# Uses nvim-tree sources defined in scripts/vimdoc_config.lua
+# Shims above into src/gen/gen_vimdoc.lua, replacing Nvim's config.
 #
 # There are some hardcoded expectations which we work around as commented.
 
 set -e
 
-if [ $# -ne 1 ] || [ "${1}" != "doc" ] && [ "${1}" != "lintdoc" ]; then
-	echo "usage: ${0} <doc|lintdoc>" 1>&2
+if [ $# -ne 1 ] || [ "${1}" != "doc" ]; then
+	echo "usage: ${0} <doc>" 1>&2
 	exit 1
 fi
 
@@ -38,7 +29,7 @@ fi
 if [ ! -d "${DIR_NVIM_SRC}" ]; then
 	cat << EOM
 
-Nvim source v0.11+ is required to run ${0}
+Nvim stable source is required to run ${0}
 
 Unavailable: ${DIR_NVIM_SRC_DEF} or \$DIR_NVIM_SRC=${DIR_NVIM_SRC}
 
@@ -84,7 +75,15 @@ if [ "${1}" = "doc" ]; then
 
 	# modify gen_vimdoc.lua to use our config, backing up original
 	cp "${DIR_NVIM_SRC}/src/gen/gen_vimdoc.lua" "${DIR_NVIM_SRC}/src/gen/gen_vimdoc.lua.org"
-	sed -i -E 's/spairs\(config\)/spairs\(require("gen.vimdoc_config")\)/g' "${DIR_NVIM_SRC}/src/gen/gen_vimdoc.lua"
+	sed -i -E '
+
+	# use our config
+	s/spairs\(config\)/spairs\(require("gen.vimdoc_config") --[[injected by nvim-tree]]\)/g ;
+
+	# remove the name linter
+	s/(^run\(\)$)/\n--injected by nvim-tree\nlint.lint_names = function\(\)\nend\n\n\1 --/g
+
+	' "${DIR_NVIM_SRC}/src/gen/gen_vimdoc.lua"
 
 	# leave a generic placeholder to bridge between nvim.gen_vimdoc.Config
 	echo "---@brief placeholder" > "${DIR_NVIM_SRC}/runtime/lua/placeholder.lua"


### PR DESCRIPTION
Our documentation fails the new doc name linting: https://github.com/neovim/neovim/pull/39117 and has been removed from `help-update`

`help-check` `lintdoc` is time consuming, adds little value and will likely break as more linting is added to it. It has been removed.