### PR TITLE
fix(#3324): deprecated BufModifiedSet event replaced by OptionSet event for Nvim 0.13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - run: make format-check
 
       - name: build Nvim from source
+        if: ${{ matrix.nvim_version == 'stable' }}
         run: |
           mkdir -p "${DIR_NVIM_SRC}"
           curl -L "https://github.com/neovim/neovim/archive/refs/tags/${{ matrix.nvim_version }}.tar.gz" | tar zx --directory "${DIR_NVIM_SRC}/.."
@@ -94,3 +95,4 @@ jobs:
           make doc
 
       - run: make help-check
+        if: ${{ matrix.nvim_version == 'stable' }}

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -181,15 +181,30 @@ function Explorer:create_autocmds()
   end
 
   if self.opts.modified.enable then
-    vim.api.nvim_create_autocmd({ "BufModifiedSet", "BufWritePost" }, {
-      group = self.augroup_id,
-      callback = function()
-        utils.debounce("Buf:modified_" .. self.uid_explorer, self.opts.view.debounce_delay, function()
-          buffers.reload_modified()
-          self.renderer:draw()
-        end)
-      end,
-    })
+    local function on_modified_or_buf_write()
+      utils.debounce("Buf:modified_" .. self.uid_explorer, self.opts.view.debounce_delay, function()
+        buffers.reload_modified()
+        self.renderer:draw()
+      end)
+    end
+
+    if vim.fn.has("nvim-0.13") == 1 then
+      vim.api.nvim_create_autocmd({ "OptionSet", }, {
+        group = self.augroup_id,
+        pattern = "modified",
+        callback = on_modified_or_buf_write,
+      })
+      vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+        group = self.augroup_id,
+        callback = on_modified_or_buf_write,
+      })
+    else
+      -- BufModifiedSet event was removed in 0.13: it was a specific case of OptionSet
+      vim.api.nvim_create_autocmd({ "BufModifiedSet", "BufWritePost" }, {
+        group = self.augroup_id,
+        callback = on_modified_or_buf_write,
+      })
+    end
   end
 end
 

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -200,7 +200,7 @@ function Explorer:create_autocmds()
       })
     else
       -- BufModifiedSet event was removed in 0.13: it was a specific case of OptionSet
-      vim.api.nvim_create_autocmd({ "BufModifiedSet", "BufWritePost" }, {
+      vim.api.nvim_create_autocmd({ "BufModifiedSet", "BufWritePost" }, { ---@diagnostic disable-line: assign-type-mismatch
         group = self.augroup_id,
         callback = on_modified_or_buf_write,
       })


### PR DESCRIPTION
fixes #3324 

I played it safe and went with the shim.

It is odd: it's in `deprecated-0.13` however it's actually been removed.